### PR TITLE
HVACControl

### DIFF
--- a/measures/301EnergyRatingIndexRuleset/resources/301validator.rb
+++ b/measures/301EnergyRatingIndexRuleset/resources/301validator.rb
@@ -64,6 +64,7 @@ class EnergyRatingIndex301Validator
             '/HPXML/Building/BuildingDetails/Systems/HVAC/HVACPlant/HeatingSystem' => zero_or_one, # See [HeatingSystem]
             '/HPXML/Building/BuildingDetails/Systems/HVAC/HVACPlant/CoolingSystem' => zero_or_one, # See [CoolingSystem]
             '/HPXML/Building/BuildingDetails/Systems/HVAC/HVACPlant/HeatPump' => zero_or_one, # See [HeatPump]
+            '/HPXML/Building/BuildingDetails/Systems/HVAC/HVACPlant/HVACControl' => zero_or_one, # See [HVACControl]
             
             '/HPXML/Building/BuildingDetails/Systems/MechanicalVentilation/VentilationFans/VentilationFan[UsedForWholeBuildingVentilation="true"]' => zero_or_one, # See [MechanicalVentilation]
             '/HPXML/Building/BuildingDetails/Systems/WaterHeating' => zero_or_one, # See [WaterHeatingSystem]
@@ -328,6 +329,7 @@ class EnergyRatingIndex301Validator
         ## [CoolingSystem]
         '/HPXML/Building/BuildingDetails/Systems/HVAC/HVACPlant/CoolingSystem' => {
             'SystemIdentifier' => one, # Required by HPXML schema
+            '../../HVACControl' => one, # See [HVACControl]
             '[CoolingSystemType="central air conditioning" or CoolingSystemType="room air conditioner"]' => one, # See [CoolingType=CentralAC] or [CoolingType=RoomAC]
             '[CoolingSystemFuel="electricity"]' => one,
             'CoolingCapacity' => zero_or_one, # Uses Manual J auto-sizing if not provided
@@ -351,6 +353,7 @@ class EnergyRatingIndex301Validator
         ## [HeatPump]
         '/HPXML/Building/BuildingDetails/Systems/HVAC/HVACPlant/HeatPump' => {
             'SystemIdentifier' => one, # Required by HPXML schema
+            '../../HVACControl' => one, # See [HVACControl]
             '[HeatPumpType="air-to-air" or HeatPumpType="mini-split" or HeatPumpType="ground-to-air"]' => one, # See [HeatPumpType=ASHP] or [HeatPumpType=MSHP] or [HeatPumpType=GSHP]
             'FractionHeatLoadServed' => one,
             'FractionCoolLoadServed' => one,


### PR DESCRIPTION
Allow at most one HVACControl for the building. Required if there's a HeatingSystem, CoolingSystem, or HeatPump.