### PR TITLE
Remove DWHR from EP HPXML

### DIFF
--- a/measures/HPXMLTranslator/measure.rb
+++ b/measures/HPXMLTranslator/measure.rb
@@ -2036,23 +2036,13 @@ class OSModel
       dist_pump_annual_kwh = Float(XMLHelper.get_value(dist, "SystemType/Recirculation/extension/PumpAnnualkWh"))
     end
     dist_gpd = Float(XMLHelper.get_value(dist, "extension/MixedWaterGPD"))
-    
-    # Drain Water Heat Recovery
-    dwhr_avail = false
-    dwhr_eff = 0.0
-    dwhr_eff_adj = 0.0
-    dwhr_iFrac = 0.0
-    dwhr_plc = 0.0
-    dwhr_locF = 0.0
-    dwhr_fixF = 0.0
-    if XMLHelper.has_element(dist, "DrainWaterHeatRecovery")
-      dwhr_avail = true
-      dwhr_eff = Float(XMLHelper.get_value(dist, "DrainWaterHeatRecovery/Efficiency"))
-      dwhr_eff_adj = Float(XMLHelper.get_value(dist, "DrainWaterHeatRecovery/extension/EfficiencyAdjustment"))
-      dwhr_iFrac = Float(XMLHelper.get_value(dist, "DrainWaterHeatRecovery/extension/FracImpactedHotWater"))
-      dwhr_plc = Float(XMLHelper.get_value(dist, "DrainWaterHeatRecovery/extension/PipingLossCoefficient"))
-      dwhr_locF = Float(XMLHelper.get_value(dist, "DrainWaterHeatRecovery/extension/LocationFactor"))
-      dwhr_fixF = Float(XMLHelper.get_value(dist, "DrainWaterHeatRecovery/extension/FixtureFactor"))
+    daily_mw_fractions = XMLHelper.get_value(dist, "extension/MixedWaterDailyFractions").split(",").map(&:to_f)
+    if daily_mw_fractions.size != 365
+      fail "HotWaterDistribution/extension/MixedWaterDailyFractions must have 365 comma-separated values."
+    end
+    daily_wh_inlet_temperatures = XMLHelper.get_value(dist, "extension/WaterHeaterDailyInletTemperatures").split(",").map(&:to_f)
+    if daily_wh_inlet_temperatures.size != 365
+      fail "HotWaterDistribution/extension/WaterHeaterDailyInletTemperatures must have 365 comma-separated values."
     end
     
     success = Waterheater.apply_eri_hw_appl(model, unit, runner, weather,
@@ -2064,9 +2054,8 @@ class OSModel
                                             cook_annual_therm, cook_frac_sens, 
                                             cook_frac_lat, cook_fuel_type, fx_gpd,
                                             fx_sens_btu, fx_lat_btu, dist_type, 
-                                            dist_gpd, dist_pump_annual_kwh, dwhr_avail,
-                                            dwhr_eff, dwhr_eff_adj, dwhr_iFrac,
-                                            dwhr_plc, dwhr_locF, dwhr_fixF)
+                                            dist_gpd, dist_pump_annual_kwh, 
+                                            daily_wh_inlet_temperatures, daily_mw_fractions)
     return false if not success
     
     return true

--- a/measures/HPXMLTranslator/resources/ep_validator.rb
+++ b/measures/HPXMLTranslator/resources/ep_validator.rb
@@ -562,8 +562,9 @@ class EnergyPlusValidator
         '/HPXML/Building/BuildingDetails/Systems/WaterHeating/HotWaterDistribution' => {
             'SystemIdentifier' => one, # Required by HPXML schema
             '[SystemType/Standard | SystemType/Recirculation]' => one, # See [HWDistType=Standard] or [HWDistType=Recirculation]
-            'DrainWaterHeatRecovery' => zero_or_one, # See [DrainWaterHeatRecovery]
             'extension/MixedWaterGPD' => one,
+            'extension/MixedWaterDailyFractions' => one,
+            'extension/WaterHeaterDailyInletTemperatures' => one,
             'extension/EnergyConsumptionAdjustmentFactor' => one,
         },
         
@@ -574,16 +575,6 @@ class EnergyPlusValidator
             ## [HWDistType=Recirculation]
             '/HPXML/Building/BuildingDetails/Systems/WaterHeating/HotWaterDistribution/SystemType/Recirculation' => {
                 'extension/PumpAnnualkWh' => one,
-            },
-        
-            ## [DrainWaterHeatRecovery]
-            '/HPXML/Building/BuildingDetails/Systems/WaterHeating/HotWaterDistribution/DrainWaterHeatRecovery' => {
-                'Efficiency' => one,
-                'extension/EfficiencyAdjustment' => one,
-                'extension/FracImpactedHotWater' => one,
-                'extension/PipingLossCoefficient' => one,
-                'extension/LocationFactor' => one,
-                'extension/FixtureFactor' => one,
             },
         
         


### PR DESCRIPTION
Remove various DWHR fields from EP HPXML. Instead, use generic MixedWaterDailyFractions and WaterHeaterDailyInletTemperatures fields. This also allows us to move ERI hot water calculations to the 301 ruleset instead of living in the HPXML translator.