### PR TITLE
Simplify Lighting inputs

### DIFF
--- a/measures/301EnergyRatingIndexRuleset/resources/301.rb
+++ b/measures/301EnergyRatingIndexRuleset/resources/301.rb
@@ -2251,19 +2251,16 @@ class EnergyRatingIndex301Ruleset
     if orig_details.elements["Lighting/LightingFractions"]
 
       # Detailed
+      fFI_int = Float(XMLHelper.get_value(orig_details, "Lighting/LightingFractions/extension/FractionQualifyingTierIFixturesInterior"))
+      fFI_ext = Float(XMLHelper.get_value(orig_details, "Lighting/LightingFractions/extension/FractionQualifyingTierIFixturesExterior"))
+      fFI_grg = Float(XMLHelper.get_value(orig_details, "Lighting/LightingFractions/extension/FractionQualifyingTierIFixturesGarage"))
+      fFII_int = Float(XMLHelper.get_value(orig_details, "Lighting/LightingFractions/extension/FractionQualifyingTierIIFixturesInterior"))
+      fFII_ext = Float(XMLHelper.get_value(orig_details, "Lighting/LightingFractions/extension/FractionQualifyingTierIIFixturesExterior"))
+      fFII_grg = Float(XMLHelper.get_value(orig_details, "Lighting/LightingFractions/extension/FractionQualifyingTierIIFixturesGarage"))
       if @eri_version.include? "G"
-        fFI_int = Float(XMLHelper.get_value(orig_details, "Lighting/LightingFractions/extension/FractionQualifyingTierIFixturesInterior"))
-        fFI_ext = Float(XMLHelper.get_value(orig_details, "Lighting/LightingFractions/extension/FractionQualifyingTierIFixturesExterior"))
-        fFI_grg = Float(XMLHelper.get_value(orig_details, "Lighting/LightingFractions/extension/FractionQualifyingTierIFixturesGarage"))
-        fFII_int = Float(XMLHelper.get_value(orig_details, "Lighting/LightingFractions/extension/FractionQualifyingTierIIFixturesInterior"))
-        fFII_ext = Float(XMLHelper.get_value(orig_details, "Lighting/LightingFractions/extension/FractionQualifyingTierIIFixturesExterior"))
-        fFII_grg = Float(XMLHelper.get_value(orig_details, "Lighting/LightingFractions/extension/FractionQualifyingTierIIFixturesGarage"))
         int_kwh, ext_kwh, grg_kwh = calc_lighting_addendum_g(fFI_int, fFII_int, fFI_ext, fFII_ext, fFI_grg, fFII_grg)
       else
-        qFF_int = Float(XMLHelper.get_value(orig_details, "Lighting/LightingFractions/extension/FractionQualifyingFixturesInterior"))
-        qFF_ext = Float(XMLHelper.get_value(orig_details, "Lighting/LightingFractions/extension/FractionQualifyingFixturesExterior"))
-        qFF_grg = Float(XMLHelper.get_value(orig_details, "Lighting/LightingFractions/extension/FractionQualifyingFixturesGarage"))
-        int_kwh, ext_kwh, grg_kwh = calc_lighting(qFF_int, qFF_ext, qFF_grg)
+        int_kwh, ext_kwh, grg_kwh = calc_lighting(fFI_int+fFII_int, fFI_ext+fFII_ext, fFI_grg+fFII_grg)
       end
       
     else

--- a/measures/301EnergyRatingIndexRuleset/resources/301validator.rb
+++ b/measures/301EnergyRatingIndexRuleset/resources/301validator.rb
@@ -618,18 +618,11 @@ class EnergyRatingIndex301Validator
         
         # [Lighting]
         '/HPXML/Building/BuildingDetails/Lighting' => {
-            'LightingFractions' => zero_or_one, # Uses Reference Home if not provided; otherwise see [LtgType=UserSpecified] or [LtgType=UserSpecifiedAppendixG]
+            'LightingFractions' => zero_or_one, # Uses Reference Home if not provided; otherwise see [LtgType=UserSpecified]
         },
         
             ## [LtgType=UserSpecified]
-            '/HPXML/Building/BuildingDetails/Lighting/LightingFractions[/HPXML/SoftwareInfo/extension/ERICalculation[Version="2014" or Version="2014A" or Version="2014AE"]]' => {
-                'extension/FractionQualifyingFixturesInterior' => one,
-                'extension/FractionQualifyingFixturesExterior' => one,
-                'extension/FractionQualifyingFixturesGarage' => one,
-            },
-            
-            ## [LtgType=UserSpecified]
-            '/HPXML/Building/BuildingDetails/Lighting/LightingFractions[/HPXML/SoftwareInfo/extension/ERICalculation[Version="2014AEG"]]' => {
+            '/HPXML/Building/BuildingDetails/Lighting/LightingFractions[/HPXML/SoftwareInfo/extension/ERICalculation]' => {
                 'extension/FractionQualifyingTierIFixturesInterior' => one,
                 'extension/FractionQualifyingTierIFixturesExterior' => one,
                 'extension/FractionQualifyingTierIFixturesGarage' => one,

--- a/workflow/sample_files/valid-addenda-exclude-g-e-a.xml
+++ b/workflow/sample_files/valid-addenda-exclude-g-e-a.xml
@@ -369,9 +369,12 @@
       <Lighting>
         <LightingFractions>
           <extension>
-            <FractionQualifyingFixturesInterior>0.5</FractionQualifyingFixturesInterior>
-            <FractionQualifyingFixturesExterior>0.5</FractionQualifyingFixturesExterior>
-            <FractionQualifyingFixturesGarage>0.5</FractionQualifyingFixturesGarage>
+            <FractionQualifyingTierIFixturesInterior>0.5</FractionQualifyingTierIFixturesInterior>
+            <FractionQualifyingTierIFixturesExterior>0.5</FractionQualifyingTierIFixturesExterior>
+            <FractionQualifyingTierIFixturesGarage>0.5</FractionQualifyingTierIFixturesGarage>
+            <FractionQualifyingTierIIFixturesInterior>0.0</FractionQualifyingTierIIFixturesInterior>
+            <FractionQualifyingTierIIFixturesExterior>0.0</FractionQualifyingTierIIFixturesExterior>
+            <FractionQualifyingTierIIFixturesGarage>0.0</FractionQualifyingTierIIFixturesGarage>
           </extension>
         </LightingFractions>
       </Lighting>

--- a/workflow/sample_files/valid-addenda-exclude-g-e.xml
+++ b/workflow/sample_files/valid-addenda-exclude-g-e.xml
@@ -369,9 +369,12 @@
       <Lighting>
         <LightingFractions>
           <extension>
-            <FractionQualifyingFixturesInterior>0.5</FractionQualifyingFixturesInterior>
-            <FractionQualifyingFixturesExterior>0.5</FractionQualifyingFixturesExterior>
-            <FractionQualifyingFixturesGarage>0.5</FractionQualifyingFixturesGarage>
+            <FractionQualifyingTierIFixturesInterior>0.5</FractionQualifyingTierIFixturesInterior>
+            <FractionQualifyingTierIFixturesExterior>0.5</FractionQualifyingTierIFixturesExterior>
+            <FractionQualifyingTierIFixturesGarage>0.5</FractionQualifyingTierIFixturesGarage>
+            <FractionQualifyingTierIIFixturesInterior>0.0</FractionQualifyingTierIIFixturesInterior>
+            <FractionQualifyingTierIIFixturesExterior>0.0</FractionQualifyingTierIIFixturesExterior>
+            <FractionQualifyingTierIIFixturesGarage>0.0</FractionQualifyingTierIIFixturesGarage>
           </extension>
         </LightingFractions>
       </Lighting>

--- a/workflow/sample_files/valid-addenda-exclude-g.xml
+++ b/workflow/sample_files/valid-addenda-exclude-g.xml
@@ -369,9 +369,12 @@
       <Lighting>
         <LightingFractions>
           <extension>
-            <FractionQualifyingFixturesInterior>0.5</FractionQualifyingFixturesInterior>
-            <FractionQualifyingFixturesExterior>0.5</FractionQualifyingFixturesExterior>
-            <FractionQualifyingFixturesGarage>0.5</FractionQualifyingFixturesGarage>
+            <FractionQualifyingTierIFixturesInterior>0.5</FractionQualifyingTierIFixturesInterior>
+            <FractionQualifyingTierIFixturesExterior>0.5</FractionQualifyingTierIFixturesExterior>
+            <FractionQualifyingTierIFixturesGarage>0.5</FractionQualifyingTierIFixturesGarage>
+            <FractionQualifyingTierIIFixturesInterior>0.0</FractionQualifyingTierIIFixturesInterior>
+            <FractionQualifyingTierIIFixturesExterior>0.0</FractionQualifyingTierIIFixturesExterior>
+            <FractionQualifyingTierIIFixturesGarage>0.0</FractionQualifyingTierIIFixturesGarage>
           </extension>
         </LightingFractions>
       </Lighting>

--- a/workflow/tests/NASEO_Technical_Exercises/NASEO-05.xml
+++ b/workflow/tests/NASEO_Technical_Exercises/NASEO-05.xml
@@ -323,9 +323,12 @@
       <Lighting>
         <LightingFractions>
           <extension>
-            <FractionQualifyingFixturesInterior>0.75</FractionQualifyingFixturesInterior>
-            <FractionQualifyingFixturesExterior>0.75</FractionQualifyingFixturesExterior>
-            <FractionQualifyingFixturesGarage>0</FractionQualifyingFixturesGarage>
+            <FractionQualifyingTierIFixturesInterior>0.75</FractionQualifyingTierIFixturesInterior>
+            <FractionQualifyingTierIFixturesExterior>0.75</FractionQualifyingTierIFixturesExterior>
+            <FractionQualifyingTierIFixturesGarage>0.0</FractionQualifyingTierIFixturesGarage>
+            <FractionQualifyingTierIIFixturesInterior>0.0</FractionQualifyingTierIIFixturesInterior>
+            <FractionQualifyingTierIIFixturesExterior>0.0</FractionQualifyingTierIIFixturesExterior>
+            <FractionQualifyingTierIIFixturesGarage>0.0</FractionQualifyingTierIIFixturesGarage>
           </extension>
         </LightingFractions>
       </Lighting>


### PR DESCRIPTION
Remove `FractionQualifyingFixturesFoo` inputs in lieu of `FractionQualifyingTierIFixturesFoo` and `FractionQualifyingTierIFixturesFoo` inputs.