### PR TITLE
Output dir argument

### DIFF
--- a/workflow/design.rb
+++ b/workflow/design.rb
@@ -3,18 +3,18 @@
 
 require_relative "../measures/HPXMLtoOpenStudio/resources/meta_measure"
 
-def get_designdir(basedir, design)
-  return File.join(basedir, design.gsub(' ', ''))
+def get_designdir(output_dir, design)
+  return File.join(output_dir, design.gsub(' ', ''))
 end
 
 def get_output_hpxml_path(resultsdir, designdir)
   return File.join(resultsdir, File.basename(designdir) + ".xml")
 end
 
-def run_design(basedir, design, resultsdir, hpxml, debug, skip_validation)
+def run_design(basedir, output_dir, design, resultsdir, hpxml, debug, skip_validation)
   # Use print instead of puts in here (see https://stackoverflow.com/a/5044669)
   print "[#{design}] Creating input...\n"
-  output_hpxml_path, designdir = create_idf(design, basedir, resultsdir, hpxml, debug, skip_validation)
+  output_hpxml_path, designdir = create_idf(design, basedir, output_dir, resultsdir, hpxml, debug, skip_validation)
 
   if not designdir.nil?
     print "[#{design}] Running simulation...\n"
@@ -24,8 +24,8 @@ def run_design(basedir, design, resultsdir, hpxml, debug, skip_validation)
   return output_hpxml_path
 end
 
-def create_idf(design, basedir, resultsdir, hpxml, debug, skip_validation)
-  designdir = get_designdir(basedir, design)
+def create_idf(design, basedir, output_dir, resultsdir, hpxml, debug, skip_validation)
+  designdir = get_designdir(output_dir, design)
   Dir.mkdir(designdir)
 
   OpenStudio::Logger.instance.standardOutLogger.setLogLevel(OpenStudio::Fatal)
@@ -101,12 +101,13 @@ def run_energyplus(design, designdir)
   system(command, :err => File::NULL)
 end
 
-if ARGV.size == 6
+if ARGV.size == 7
   basedir = ARGV[0]
-  design = ARGV[1]
-  resultsdir = ARGV[2]
-  hpxml = ARGV[3]
-  debug = (ARGV[4].downcase.to_s == "true")
-  skip_validation = (ARGV[5].downcase.to_s == "true")
-  run_design(basedir, design, resultsdir, hpxml, debug, skip_validation)
+  output_dir = ARGV[1]
+  design = ARGV[2]
+  resultsdir = ARGV[3]
+  hpxml = ARGV[4]
+  debug = (ARGV[5].downcase.to_s == "true")
+  skip_validation = (ARGV[6].downcase.to_s == "true")
+  run_design(basedir, output_dir, design, resultsdir, hpxml, debug, skip_validation)
 end

--- a/workflow/energy_rating_index.rb
+++ b/workflow/energy_rating_index.rb
@@ -1018,6 +1018,7 @@ end
 if options[:output_dir].nil?
   options[:output_dir] = basedir # default
 end
+options[:output_dir] = File.expand_path(options[:output_dir])
 
 unless Dir.exists?(options[:output_dir])
   FileUtils.mkdir_p(options[:output_dir])

--- a/workflow/energy_rating_index.rb
+++ b/workflow/energy_rating_index.rb
@@ -27,31 +27,31 @@ def rm_path(path)
   end
 end
 
-def run_design_direct(basedir, design, resultsdir, hpxml, debug, skip_validation, run)
+def run_design_direct(basedir, output_dir, design, resultsdir, hpxml, debug, skip_validation, run)
   # Calls design.rb methods directly. Should only be called from a forked
   # process. This is the fastest approach.
-  designdir = get_designdir(basedir, design)
+  designdir = get_designdir(output_dir, design)
   rm_path(designdir)
 
   if run
-    output_hpxml_path = run_design(basedir, design, resultsdir, hpxml, debug, skip_validation)
+    output_hpxml_path = run_design(basedir, output_dir, design, resultsdir, hpxml, debug, skip_validation)
   end
 
   return output_hpxml_path, designdir
 end
 
-def run_design_spawn(basedir, design, resultsdir, hpxml, debug, skip_validation, run)
+def run_design_spawn(basedir, output_dir, design, resultsdir, hpxml, debug, skip_validation, run)
   # Calls design.rb in a new spawned process in order to utilize multiple
   # processes. Not as efficient as calling design.rb methods directly in
   # forked processes for a couple reasons:
   # 1. There is overhead to using the CLI
   # 2. There is overhead to spawning processes vs using forked processes
-  designdir = get_designdir(basedir, design)
+  designdir = get_designdir(output_dir, design)
   rm_path(designdir)
 
   if run
     cli_path = OpenStudio.getOpenStudioCLI
-    system("\"#{cli_path}\" --no-ssl \"#{File.join(File.dirname(__FILE__), "design.rb")}\" \"#{basedir}\" \"#{design}\" \"#{resultsdir}\" \"#{hpxml}\" #{debug} #{skip_validation}")
+    system("\"#{cli_path}\" --no-ssl \"#{File.join(File.dirname(__FILE__), "design.rb")}\" \"#{basedir}\" \"#{output_dir}\" \"#{design}\" \"#{resultsdir}\" \"#{hpxml}\" #{debug} #{skip_validation}")
   end
 
   output_hpxml_path = get_output_hpxml_path(resultsdir, designdir)
@@ -970,6 +970,10 @@ OptionParser.new do |opts|
     options[:hpxml] = t
   end
 
+  opts.on('-o', '--output-dir <DIR>', 'Output directory') do |t|
+    options[:output_dir] = t
+  end
+
   opts.on('-w', '--download-weather', 'Downloads all weather files') do |t|
     options[:epws] = t
   end
@@ -1011,8 +1015,16 @@ if OpenStudio.openStudioVersion != os_version
   fail "OpenStudio version #{os_version} is required."
 end
 
+if options[:output_dir].nil?
+  options[:output_dir] = basedir # default
+end
+
+unless Dir.exists?(options[:output_dir])
+  FileUtils.mkdir_p(options[:output_dir])
+end
+
 # Create results dir
-resultsdir = File.join(basedir, "results")
+resultsdir = File.join(options[:output_dir], "results")
 rm_path(resultsdir)
 Dir.mkdir(resultsdir)
 
@@ -1049,7 +1061,7 @@ if Process.respond_to?(:fork) # e.g., most Unix systems
   end
 
   Parallel.map(run_designs, in_processes: run_designs.size) do |design, run|
-    output_hpxml_path, designdir = run_design_direct(basedir, design, resultsdir, options[:hpxml], options[:debug], options[:skip_validation], run)
+    output_hpxml_path, designdir = run_design_direct(basedir, options[:output_dir], design, resultsdir, options[:hpxml], options[:debug], options[:skip_validation], run)
     next unless File.exists? File.join(designdir, "in.idf")
 
     design_output = process_design_output(design, designdir, resultsdir, output_hpxml_path)
@@ -1076,7 +1088,7 @@ else # e.g., Windows
   # multiple processors.
 
   Parallel.map(run_designs, in_threads: run_designs.size) do |design, run|
-    output_hpxml_path, designdir = run_design_spawn(basedir, design, resultsdir, options[:hpxml], options[:debug], options[:skip_validation], run)
+    output_hpxml_path, designdir = run_design_spawn(basedir, options[:output_dir], design, resultsdir, options[:hpxml], options[:debug], options[:skip_validation], run)
     next unless File.exists? File.join(designdir, "in.idf")
 
     design_output = process_design_output(design, designdir, resultsdir, output_hpxml_path)


### PR DESCRIPTION
 Adds an optional `-o` or `--output-dir` argument to specify where all the outputs end up. Closes #183.