### PR TITLE
Pass Reference Home Auto-Generation tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -648,16 +648,12 @@ def get_hpxml_file_air_infiltration_measurement_values(hpxml_file, air_infiltrat
          'RESNET_Tests/4.2_HERS_AutoGen_Reference_Home/04-L324.xml',
          'RESNET_Tests/4.3_HERS_Method/L100A-01.xml',
          'RESNET_Tests/Other_HERS_Method_Task_Group/L100A-CO-01.xml',
-         'RESNET_Tests/Other_HERS_Method_Task_Group/L100A-LV-01.xml'].include? hpxml_file
+         'RESNET_Tests/Other_HERS_Method_Task_Group/L100A-LV-01.xml',
+         'RESNET_Tests/4.6_Hot_Water/L100AD-HW-01.xml',
+         'RESNET_Tests/4.6_Hot_Water/L100AM-HW-01.xml'].include? hpxml_file
     air_infiltration_measurement_values = { :id => "InfiltrationMeasurement",
                                             :unit_of_measure => "ACHnatural",
-                                            :air_leakage => 0.67 } # TODO: Review this
-  elsif ['RESNET_Tests/4.6_Hot_Water/L100AD-HW-01.xml',
-         'RESNET_Tests/4.6_Hot_Water/L100AM-HW-01.xml'].include? hpxml_file
-    air_infiltration_measurement_values[:constant_ach_natural] = nil
-    air_infiltration_measurement_values[:house_pressure] = 50
-    air_infiltration_measurement_values[:unit_of_measure] = "ACH"
-    air_infiltration_measurement_values[:air_leakage] = 7.5 # TODO: Review this
+                                            :air_leakage => 0.67 }
   elsif ['RESNET_Tests/Other_HERS_Method_Proposed/L100-AC-06.xml',
          'RESNET_Tests/Other_HERS_Method_Proposed/L100-AL-06.xml'].include? hpxml_file
     # 3 ACH50

--- a/measures/301EnergyRatingIndexRuleset/resources/301.rb
+++ b/measures/301EnergyRatingIndexRuleset/resources/301.rb
@@ -1047,12 +1047,21 @@ class EnergyRatingIndex301Ruleset
   def self.set_systems_mechanical_ventilation_reference(orig_details, hpxml)
     # Table 4.2.2(1) - Whole-House Mechanical ventilation
 
-    vent_fan = orig_details.elements["Systems/MechanicalVentilation/VentilationFans/VentilationFan[UsedForWholeBuildingVentilation='true']"]
-    return if vent_fan.nil?
+    # Check for eRatio workaround first
+    eratio_fan = orig_details.elements["Systems/MechanicalVentilation/VentilationFans/VentilationFan[UsedForWholeBuildingVentilation='true']/extension"]
+    if not eratio_fan.nil?
+      vent_fan = eratio_fan.elements["OverrideVentilationFan"]
+    else
+      vent_fan = orig_details.elements["Systems/MechanicalVentilation/VentilationFans/VentilationFan[UsedForWholeBuildingVentilation='true']"]
+    end
 
-    vent_fan_values = HPXML.get_ventilation_fan_values(ventilation_fan: vent_fan)
-
-    fan_type = vent_fan_values[:fan_type]
+    fan_type = nil
+    sys_id = "MechanicalVentilation"
+    if not vent_fan.nil?
+      vent_fan_values = HPXML.get_ventilation_fan_values(ventilation_fan: vent_fan)
+      fan_type = vent_fan_values[:fan_type]
+      sys_id = HPXML.get_id(vent_fan)
+    end
 
     q_tot = Airflow.get_mech_vent_whole_house_cfm(1.0, @nbeds, @cfa, '2013')
 
@@ -1064,40 +1073,52 @@ class EnergyRatingIndex301Ruleset
 
     # Calculate fan cfm for fan power using Rated Home infiltration
     # http://www.resnet.us/standards/Interpretation_on_Reference_Home_mechVent_fanCFM_approved.pdf
-    orig_details.elements.each("Enclosure/AirInfiltration/AirInfiltrationMeasurement") do |air_infiltration_measurement|
-      air_infiltration_measurement_values = HPXML.get_air_infiltration_measurement_values(air_infiltration_measurement: air_infiltration_measurement)
+    if fan_type.nil?
+      fan_type = 'exhaust only'
+      fan_power_w = 0.0
+    else
+      air_infiltration_measurement_values = nil
+      # Check for eRatio workaround first
+      orig_details.elements.each("Enclosure/AirInfiltration/AirInfiltrationMeasurement/extension/OverrideAirInfiltrationMeasurement") do |air_infiltration_measurement|
+        air_infiltration_measurement_values = HPXML.get_air_infiltration_measurement_values(air_infiltration_measurement: air_infiltration_measurement)
+        break
+      end
+      if air_infiltration_measurement_values.nil?
+        orig_details.elements.each("Enclosure/AirInfiltration/AirInfiltrationMeasurement") do |air_infiltration_measurement|
+          air_infiltration_measurement_values = HPXML.get_air_infiltration_measurement_values(air_infiltration_measurement: air_infiltration_measurement)
+          break
+        end
+      end
       if air_infiltration_measurement_values[:unit_of_measure] == 'ACHnatural'
         nach = air_infiltration_measurement_values[:air_leakage]
         sla = Airflow.get_infiltration_SLA_from_ACH(nach, @ncfl, @weather)
-        break
       elsif air_infiltration_measurement_values[:unit_of_measure] == 'ACH' and air_infiltration_measurement_values[:house_pressure] == 50
         ach50 = air_infiltration_measurement_values[:air_leakage]
         sla = Airflow.get_infiltration_SLA_from_ACH50(ach50, 0.65, @cfa, @infilvolume)
-        break
       end
-    end
-    q_fan_power = calc_mech_vent_q_fan(q_tot, sla, vert_distance)
+      q_fan_power = calc_mech_vent_q_fan(q_tot, sla, vert_distance)
 
-    # Treat CFIS like supply ventilation. Is this correct?
-    if fan_type == 'central fan integrated supply'
-      fan_type = 'supply only'
-    end
+      # Treat CFIS like supply ventilation. Is this correct?
+      if fan_type == 'central fan integrated supply'
+        fan_type = 'supply only'
+      end
 
-    fan_power_w = nil
-    if fan_type == 'supply only' or fan_type == 'exhaust only'
-      w_cfm = 0.35
-      fan_power_w = w_cfm * q_fan_power
-    elsif fan_type == 'balanced'
-      w_cfm = 0.70
-      fan_power_w = w_cfm * q_fan_power
-    elsif fan_type == 'energy recovery ventilator' or fan_type == 'heat recovery ventilator'
-      w_cfm = 1.00
-      fan_power_w = w_cfm * q_fan_power
-      fan_type = 'balanced'
+      fan_power_w = nil
+      if fan_type == 'supply only' or fan_type == 'exhaust only'
+        w_cfm = 0.35
+        fan_power_w = w_cfm * q_fan_power
+      elsif fan_type == 'balanced'
+        w_cfm = 0.70
+        fan_power_w = w_cfm * q_fan_power
+      elsif fan_type == 'energy recovery ventilator' or fan_type == 'heat recovery ventilator'
+        w_cfm = 1.00
+        fan_power_w = w_cfm * q_fan_power
+        fan_type = 'balanced'
+      end
     end
 
     HPXML.add_ventilation_fan(hpxml: hpxml,
-                              id: HPXML.get_id(vent_fan),
+                              id: sys_id,
                               fan_type: fan_type,
                               rated_flow_rate: q_fan_airflow,
                               hours_in_operation: 24,
@@ -1524,7 +1545,7 @@ class EnergyRatingIndex301Ruleset
         re = 0.78
       end
     end
-    return ef, re
+    return ef.round(2), re
   end
 
   def self.has_fuel_access(orig_details)

--- a/measures/301EnergyRatingIndexRuleset/tests/test_mechanical_ventilation.rb
+++ b/measures/301EnergyRatingIndexRuleset/tests/test_mechanical_ventilation.rb
@@ -11,7 +11,7 @@ class MechVentTest < MiniTest::Test
 
     # Reference Home
     hpxml_doc = _test_measure(hpxml_name, Constants.CalcTypeERIReferenceHome)
-    _check_mech_vent(hpxml_doc)
+    _check_mech_vent(hpxml_doc, "exhaust only", 37.0, 24, 0.0) # Should have airflow but not fan energy
 
     # Rated Home
     hpxml_doc = _test_measure(hpxml_name, Constants.CalcTypeERIRatedHome)

--- a/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AD-HW-01.xml
+++ b/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AD-HW-01.xml
@@ -49,10 +49,9 @@
         <AirInfiltration>
           <AirInfiltrationMeasurement>
             <SystemIdentifier id='InfiltrationMeasurement'/>
-            <HousePressure>50.0</HousePressure>
             <BuildingAirLeakage>
-              <UnitofMeasure>ACH</UnitofMeasure>
-              <AirLeakage>7.5</AirLeakage>
+              <UnitofMeasure>ACHnatural</UnitofMeasure>
+              <AirLeakage>0.67</AirLeakage>
             </BuildingAirLeakage>
             <InfiltrationVolume>12312.0</InfiltrationVolume>
           </AirInfiltrationMeasurement>

--- a/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AD-HW-02.xml
+++ b/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AD-HW-02.xml
@@ -49,10 +49,9 @@
         <AirInfiltration>
           <AirInfiltrationMeasurement>
             <SystemIdentifier id='InfiltrationMeasurement'/>
-            <HousePressure>50.0</HousePressure>
             <BuildingAirLeakage>
-              <UnitofMeasure>ACH</UnitofMeasure>
-              <AirLeakage>7.5</AirLeakage>
+              <UnitofMeasure>ACHnatural</UnitofMeasure>
+              <AirLeakage>0.67</AirLeakage>
             </BuildingAirLeakage>
             <InfiltrationVolume>12312.0</InfiltrationVolume>
           </AirInfiltrationMeasurement>

--- a/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AD-HW-03.xml
+++ b/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AD-HW-03.xml
@@ -49,10 +49,9 @@
         <AirInfiltration>
           <AirInfiltrationMeasurement>
             <SystemIdentifier id='InfiltrationMeasurement'/>
-            <HousePressure>50.0</HousePressure>
             <BuildingAirLeakage>
-              <UnitofMeasure>ACH</UnitofMeasure>
-              <AirLeakage>7.5</AirLeakage>
+              <UnitofMeasure>ACHnatural</UnitofMeasure>
+              <AirLeakage>0.67</AirLeakage>
             </BuildingAirLeakage>
             <InfiltrationVolume>12312.0</InfiltrationVolume>
           </AirInfiltrationMeasurement>

--- a/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AD-HW-04.xml
+++ b/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AD-HW-04.xml
@@ -49,10 +49,9 @@
         <AirInfiltration>
           <AirInfiltrationMeasurement>
             <SystemIdentifier id='InfiltrationMeasurement'/>
-            <HousePressure>50.0</HousePressure>
             <BuildingAirLeakage>
-              <UnitofMeasure>ACH</UnitofMeasure>
-              <AirLeakage>7.5</AirLeakage>
+              <UnitofMeasure>ACHnatural</UnitofMeasure>
+              <AirLeakage>0.67</AirLeakage>
             </BuildingAirLeakage>
             <InfiltrationVolume>12312.0</InfiltrationVolume>
           </AirInfiltrationMeasurement>

--- a/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AD-HW-05.xml
+++ b/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AD-HW-05.xml
@@ -49,10 +49,9 @@
         <AirInfiltration>
           <AirInfiltrationMeasurement>
             <SystemIdentifier id='InfiltrationMeasurement'/>
-            <HousePressure>50.0</HousePressure>
             <BuildingAirLeakage>
-              <UnitofMeasure>ACH</UnitofMeasure>
-              <AirLeakage>7.5</AirLeakage>
+              <UnitofMeasure>ACHnatural</UnitofMeasure>
+              <AirLeakage>0.67</AirLeakage>
             </BuildingAirLeakage>
             <InfiltrationVolume>12312.0</InfiltrationVolume>
           </AirInfiltrationMeasurement>

--- a/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AD-HW-06.xml
+++ b/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AD-HW-06.xml
@@ -49,10 +49,9 @@
         <AirInfiltration>
           <AirInfiltrationMeasurement>
             <SystemIdentifier id='InfiltrationMeasurement'/>
-            <HousePressure>50.0</HousePressure>
             <BuildingAirLeakage>
-              <UnitofMeasure>ACH</UnitofMeasure>
-              <AirLeakage>7.5</AirLeakage>
+              <UnitofMeasure>ACHnatural</UnitofMeasure>
+              <AirLeakage>0.67</AirLeakage>
             </BuildingAirLeakage>
             <InfiltrationVolume>12312.0</InfiltrationVolume>
           </AirInfiltrationMeasurement>

--- a/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AD-HW-07.xml
+++ b/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AD-HW-07.xml
@@ -49,10 +49,9 @@
         <AirInfiltration>
           <AirInfiltrationMeasurement>
             <SystemIdentifier id='InfiltrationMeasurement'/>
-            <HousePressure>50.0</HousePressure>
             <BuildingAirLeakage>
-              <UnitofMeasure>ACH</UnitofMeasure>
-              <AirLeakage>7.5</AirLeakage>
+              <UnitofMeasure>ACHnatural</UnitofMeasure>
+              <AirLeakage>0.67</AirLeakage>
             </BuildingAirLeakage>
             <InfiltrationVolume>12312.0</InfiltrationVolume>
           </AirInfiltrationMeasurement>

--- a/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AM-HW-01.xml
+++ b/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AM-HW-01.xml
@@ -49,10 +49,9 @@
         <AirInfiltration>
           <AirInfiltrationMeasurement>
             <SystemIdentifier id='InfiltrationMeasurement'/>
-            <HousePressure>50.0</HousePressure>
             <BuildingAirLeakage>
-              <UnitofMeasure>ACH</UnitofMeasure>
-              <AirLeakage>7.5</AirLeakage>
+              <UnitofMeasure>ACHnatural</UnitofMeasure>
+              <AirLeakage>0.67</AirLeakage>
             </BuildingAirLeakage>
             <InfiltrationVolume>12312.0</InfiltrationVolume>
           </AirInfiltrationMeasurement>

--- a/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AM-HW-02.xml
+++ b/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AM-HW-02.xml
@@ -49,10 +49,9 @@
         <AirInfiltration>
           <AirInfiltrationMeasurement>
             <SystemIdentifier id='InfiltrationMeasurement'/>
-            <HousePressure>50.0</HousePressure>
             <BuildingAirLeakage>
-              <UnitofMeasure>ACH</UnitofMeasure>
-              <AirLeakage>7.5</AirLeakage>
+              <UnitofMeasure>ACHnatural</UnitofMeasure>
+              <AirLeakage>0.67</AirLeakage>
             </BuildingAirLeakage>
             <InfiltrationVolume>12312.0</InfiltrationVolume>
           </AirInfiltrationMeasurement>

--- a/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AM-HW-03.xml
+++ b/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AM-HW-03.xml
@@ -49,10 +49,9 @@
         <AirInfiltration>
           <AirInfiltrationMeasurement>
             <SystemIdentifier id='InfiltrationMeasurement'/>
-            <HousePressure>50.0</HousePressure>
             <BuildingAirLeakage>
-              <UnitofMeasure>ACH</UnitofMeasure>
-              <AirLeakage>7.5</AirLeakage>
+              <UnitofMeasure>ACHnatural</UnitofMeasure>
+              <AirLeakage>0.67</AirLeakage>
             </BuildingAirLeakage>
             <InfiltrationVolume>12312.0</InfiltrationVolume>
           </AirInfiltrationMeasurement>

--- a/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AM-HW-04.xml
+++ b/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AM-HW-04.xml
@@ -49,10 +49,9 @@
         <AirInfiltration>
           <AirInfiltrationMeasurement>
             <SystemIdentifier id='InfiltrationMeasurement'/>
-            <HousePressure>50.0</HousePressure>
             <BuildingAirLeakage>
-              <UnitofMeasure>ACH</UnitofMeasure>
-              <AirLeakage>7.5</AirLeakage>
+              <UnitofMeasure>ACHnatural</UnitofMeasure>
+              <AirLeakage>0.67</AirLeakage>
             </BuildingAirLeakage>
             <InfiltrationVolume>12312.0</InfiltrationVolume>
           </AirInfiltrationMeasurement>

--- a/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AM-HW-05.xml
+++ b/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AM-HW-05.xml
@@ -49,10 +49,9 @@
         <AirInfiltration>
           <AirInfiltrationMeasurement>
             <SystemIdentifier id='InfiltrationMeasurement'/>
-            <HousePressure>50.0</HousePressure>
             <BuildingAirLeakage>
-              <UnitofMeasure>ACH</UnitofMeasure>
-              <AirLeakage>7.5</AirLeakage>
+              <UnitofMeasure>ACHnatural</UnitofMeasure>
+              <AirLeakage>0.67</AirLeakage>
             </BuildingAirLeakage>
             <InfiltrationVolume>12312.0</InfiltrationVolume>
           </AirInfiltrationMeasurement>

--- a/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AM-HW-06.xml
+++ b/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AM-HW-06.xml
@@ -49,10 +49,9 @@
         <AirInfiltration>
           <AirInfiltrationMeasurement>
             <SystemIdentifier id='InfiltrationMeasurement'/>
-            <HousePressure>50.0</HousePressure>
             <BuildingAirLeakage>
-              <UnitofMeasure>ACH</UnitofMeasure>
-              <AirLeakage>7.5</AirLeakage>
+              <UnitofMeasure>ACHnatural</UnitofMeasure>
+              <AirLeakage>0.67</AirLeakage>
             </BuildingAirLeakage>
             <InfiltrationVolume>12312.0</InfiltrationVolume>
           </AirInfiltrationMeasurement>

--- a/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AM-HW-07.xml
+++ b/workflow/tests/RESNET_Tests/4.6_Hot_Water/L100AM-HW-07.xml
@@ -49,10 +49,9 @@
         <AirInfiltration>
           <AirInfiltrationMeasurement>
             <SystemIdentifier id='InfiltrationMeasurement'/>
-            <HousePressure>50.0</HousePressure>
             <BuildingAirLeakage>
-              <UnitofMeasure>ACH</UnitofMeasure>
-              <AirLeakage>7.5</AirLeakage>
+              <UnitofMeasure>ACHnatural</UnitofMeasure>
+              <AirLeakage>0.67</AirLeakage>
             </BuildingAirLeakage>
             <InfiltrationVolume>12312.0</InfiltrationVolume>
           </AirInfiltrationMeasurement>

--- a/workflow/tests/RESNET_Tests/Other_Hot_Water_PreAddendumA/L100AD-HW-01.xml
+++ b/workflow/tests/RESNET_Tests/Other_Hot_Water_PreAddendumA/L100AD-HW-01.xml
@@ -49,10 +49,9 @@
         <AirInfiltration>
           <AirInfiltrationMeasurement>
             <SystemIdentifier id='InfiltrationMeasurement'/>
-            <HousePressure>50.0</HousePressure>
             <BuildingAirLeakage>
-              <UnitofMeasure>ACH</UnitofMeasure>
-              <AirLeakage>7.5</AirLeakage>
+              <UnitofMeasure>ACHnatural</UnitofMeasure>
+              <AirLeakage>0.67</AirLeakage>
             </BuildingAirLeakage>
             <InfiltrationVolume>12312.0</InfiltrationVolume>
           </AirInfiltrationMeasurement>

--- a/workflow/tests/RESNET_Tests/Other_Hot_Water_PreAddendumA/L100AD-HW-02.xml
+++ b/workflow/tests/RESNET_Tests/Other_Hot_Water_PreAddendumA/L100AD-HW-02.xml
@@ -49,10 +49,9 @@
         <AirInfiltration>
           <AirInfiltrationMeasurement>
             <SystemIdentifier id='InfiltrationMeasurement'/>
-            <HousePressure>50.0</HousePressure>
             <BuildingAirLeakage>
-              <UnitofMeasure>ACH</UnitofMeasure>
-              <AirLeakage>7.5</AirLeakage>
+              <UnitofMeasure>ACHnatural</UnitofMeasure>
+              <AirLeakage>0.67</AirLeakage>
             </BuildingAirLeakage>
             <InfiltrationVolume>12312.0</InfiltrationVolume>
           </AirInfiltrationMeasurement>

--- a/workflow/tests/RESNET_Tests/Other_Hot_Water_PreAddendumA/L100AD-HW-03.xml
+++ b/workflow/tests/RESNET_Tests/Other_Hot_Water_PreAddendumA/L100AD-HW-03.xml
@@ -49,10 +49,9 @@
         <AirInfiltration>
           <AirInfiltrationMeasurement>
             <SystemIdentifier id='InfiltrationMeasurement'/>
-            <HousePressure>50.0</HousePressure>
             <BuildingAirLeakage>
-              <UnitofMeasure>ACH</UnitofMeasure>
-              <AirLeakage>7.5</AirLeakage>
+              <UnitofMeasure>ACHnatural</UnitofMeasure>
+              <AirLeakage>0.67</AirLeakage>
             </BuildingAirLeakage>
             <InfiltrationVolume>12312.0</InfiltrationVolume>
           </AirInfiltrationMeasurement>

--- a/workflow/tests/RESNET_Tests/Other_Hot_Water_PreAddendumA/L100AM-HW-01.xml
+++ b/workflow/tests/RESNET_Tests/Other_Hot_Water_PreAddendumA/L100AM-HW-01.xml
@@ -49,10 +49,9 @@
         <AirInfiltration>
           <AirInfiltrationMeasurement>
             <SystemIdentifier id='InfiltrationMeasurement'/>
-            <HousePressure>50.0</HousePressure>
             <BuildingAirLeakage>
-              <UnitofMeasure>ACH</UnitofMeasure>
-              <AirLeakage>7.5</AirLeakage>
+              <UnitofMeasure>ACHnatural</UnitofMeasure>
+              <AirLeakage>0.67</AirLeakage>
             </BuildingAirLeakage>
             <InfiltrationVolume>12312.0</InfiltrationVolume>
           </AirInfiltrationMeasurement>

--- a/workflow/tests/RESNET_Tests/Other_Hot_Water_PreAddendumA/L100AM-HW-02.xml
+++ b/workflow/tests/RESNET_Tests/Other_Hot_Water_PreAddendumA/L100AM-HW-02.xml
@@ -49,10 +49,9 @@
         <AirInfiltration>
           <AirInfiltrationMeasurement>
             <SystemIdentifier id='InfiltrationMeasurement'/>
-            <HousePressure>50.0</HousePressure>
             <BuildingAirLeakage>
-              <UnitofMeasure>ACH</UnitofMeasure>
-              <AirLeakage>7.5</AirLeakage>
+              <UnitofMeasure>ACHnatural</UnitofMeasure>
+              <AirLeakage>0.67</AirLeakage>
             </BuildingAirLeakage>
             <InfiltrationVolume>12312.0</InfiltrationVolume>
           </AirInfiltrationMeasurement>

--- a/workflow/tests/RESNET_Tests/Other_Hot_Water_PreAddendumA/L100AM-HW-03.xml
+++ b/workflow/tests/RESNET_Tests/Other_Hot_Water_PreAddendumA/L100AM-HW-03.xml
@@ -49,10 +49,9 @@
         <AirInfiltration>
           <AirInfiltrationMeasurement>
             <SystemIdentifier id='InfiltrationMeasurement'/>
-            <HousePressure>50.0</HousePressure>
             <BuildingAirLeakage>
-              <UnitofMeasure>ACH</UnitofMeasure>
-              <AirLeakage>7.5</AirLeakage>
+              <UnitofMeasure>ACHnatural</UnitofMeasure>
+              <AirLeakage>0.67</AirLeakage>
             </BuildingAirLeakage>
             <InfiltrationVolume>12312.0</InfiltrationVolume>
           </AirInfiltrationMeasurement>


### PR DESCRIPTION
Adds a workaround to ensure the eRatio check for Reference Home Auto-Generation tests doesn't fail due to changing mechanical ventilation fan power in the Reference of the Reference Home. Similar workarounds appear to be implemented by HERS accredited software tools, as the tests cannot otherwise be passed as written.

Also fixes missing mechanical ventilation airflow in the Reference Home when the Rated Home has no mechanical ventilation. Updated unit test.