### PR TITLE
DWHR documentation

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -8,7 +8,7 @@ Setup
 
 To get started:
 
-#. Either download `OpenStudio 2.8.1 <https://github.com/NREL/OpenStudio/releases/tag/v2.8.1>`_) and install the Command Line Interface/EnergyPlus components, or use the `nrel/openstudio docker image <https://hub.docker.com/r/nrel/openstudio>`_.
+#. Either download `OpenStudio 2.8.1 <https://github.com/NREL/OpenStudio/releases/tag/v2.8.1>`_ and install the Command Line Interface/EnergyPlus components, or use the `nrel/openstudio docker image <https://hub.docker.com/r/nrel/openstudio>`_.
 #. Download the `OpenStudio-ERI v0.2.0 Beta <https://github.com/NREL/OpenStudio-ERI/releases/tag/v0.2.0-beta>`_ release.
 #. To obtain all available weather files, run: ``openstudio workflow/energy_rating_index.rb --download-weather``
 

--- a/docs/source/software_connection.rst
+++ b/docs/source/software_connection.rst
@@ -360,7 +360,7 @@ For a ``SystemType/Recirculation`` system, the following fields are required:
 In addition, a ``HotWaterDistribution/DrainWaterHeatRecovery`` (DWHR) may be specified.
 The DWHR system is defined by:
 
-- ``FacilitiesConnected``: 'all' if all of the showers in the home are connected to DWHR units; 'one' if if there are 2 or more showers in the home and only 1 shower is connected to a DWHR unit
+- ``FacilitiesConnected``: 'one' if there are multiple showers and only one of them is connected to a DWHR; 'all' if there is one shower and it's connected to a DWHR or there are two or more showers connected to a DWHR
 - ``EqualFlow``: 'true' if the DWHR supplies pre-heated water to both the fixture cold water piping and the hot water heater potable supply piping
 - ``Efficiency``: As rated and labeled in accordance with CSA 55.1
 


### PR DESCRIPTION
Clarifies DWHR documentation given EnergyGauge documentation. Addresses the scenario where there are more than 2 showers in the home and exactly 2 are connected to the DWHR. (301 language doesn't seem to address it.)