### PR TITLE
Complex foundations

### DIFF
--- a/docs/source/software_connection.rst
+++ b/docs/source/software_connection.rst
@@ -179,12 +179,17 @@ Slabs
 Any space type that borders the ground should include an ``Enclosure/Slabs/Slab`` surface with the appropriate ``InteriorAdjacentTo``. 
 This includes basements, crawlspaces (even when there are dirt floors -- use zero for the ``Thickness``), garages, and slab-on-grade foundations.
 
-A primary input for a slab is its ``ExposedPerimeter``. The exposed perimeter should include any slab length that falls along the perimeter of the building's footprint (i.e., is exposed to ambient conditions).
+A primary input for a slab is its ``ExposedPerimeter``. 
+The exposed perimeter should include any slab length that falls along the perimeter of the building's footprint (i.e., is exposed to ambient conditions).
 So, a basement slab edge adjacent to a garage or crawlspace, for example, should not be included.
 
 Vertical insulation adjacent to the slab can be described by a ``PerimeterInsulation/Layer/NominalRValue`` and a ``PerimeterInsulationDepth``.
 
-Horizontal insulation under the slab can be described by a ``UnderSlabInsulation/Layer/NominalRValue``. The insulation can either have a depth (``UnderSlabInsulationWidth``) or can span the entire slab (``UnderSlabInsulationSpansEntireSlab``).
+Horizontal insulation under the slab can be described by a ``UnderSlabInsulation/Layer/NominalRValue``. 
+The insulation can either have a depth (``UnderSlabInsulationWidth``) or can span the entire slab (``UnderSlabInsulationSpansEntireSlab``).
+
+For foundation types without walls, the ``DepthBelowGrade`` field must be provided.
+For foundation types with walls, the slab's position relative to grade is determined by the ``FoundationWall/DepthBelowGrade`` values.
 
 Windows
 *******

--- a/measures/HPXMLtoOpenStudio/Rakefile
+++ b/measures/HPXMLtoOpenStudio/Rakefile
@@ -124,7 +124,8 @@ def create_hpxmls
     'base-foundation-unconditioned-basement-above-grade.xml' => 'base-foundation-unconditioned-basement.xml',
     'base-foundation-unvented-crawlspace.xml' => 'base.xml',
     'base-foundation-vented-crawlspace.xml' => 'base.xml',
-    'base-foundation-multiple-slab.xml' => 'base.xml',
+    'base-foundation-walkout-basement.xml' => 'base.xml',
+    'base-foundation-complex.xml' => 'base.xml',
     'base-hvac-air-to-air-heat-pump-1-speed.xml' => 'base.xml',
     'base-hvac-air-to-air-heat-pump-2-speed.xml' => 'base.xml',
     'base-hvac-air-to-air-heat-pump-var-speed.xml' => 'base.xml',
@@ -1062,6 +1063,80 @@ def get_hpxml_file_foundation_walls_values(hpxml_file, foundation_walls_values)
     foundation_walls_values[-1][:area] *= 0.75
     foundation_walls_values[-1][:id] += "Adiabatic"
     foundation_walls_values[-1][:exterior_adjacent_to] = "other housing unit"
+  elsif ['base-foundation-walkout-basement.xml'].include? hpxml_file
+    foundation_walls_values = [{ :id => "FoundationWall1",
+                                 :exterior_adjacent_to => "ground",
+                                 :interior_adjacent_to => "basement - conditioned",
+                                 :height => 8,
+                                 :area => 480,
+                                 :thickness => 8,
+                                 :depth_below_grade => 7,
+                                 :insulation_distance_to_bottom => 8,
+                                 :insulation_r_value => 8.9 },
+                               { :id => "FoundationWall2",
+                                 :exterior_adjacent_to => "ground",
+                                 :interior_adjacent_to => "basement - conditioned",
+                                 :height => 4,
+                                 :area => 120,
+                                 :thickness => 8,
+                                 :depth_below_grade => 3,
+                                 :insulation_distance_to_bottom => 4,
+                                 :insulation_r_value => 8.9 },
+                               { :id => "FoundationWall3",
+                                 :exterior_adjacent_to => "ground",
+                                 :interior_adjacent_to => "basement - conditioned",
+                                 :height => 2,
+                                 :area => 60,
+                                 :thickness => 8,
+                                 :depth_below_grade => 1,
+                                 :insulation_distance_to_bottom => 2,
+                                 :insulation_r_value => 8.9 }]
+  elsif ['base-foundation-complex.xml'].include? hpxml_file
+    foundation_walls_values = [{ :id => "FoundationWall1",
+                                 :exterior_adjacent_to => "ground",
+                                 :interior_adjacent_to => "basement - conditioned",
+                                 :height => 8,
+                                 :area => 160,
+                                 :thickness => 8,
+                                 :depth_below_grade => 7,
+                                 :insulation_distance_to_bottom => 0,
+                                 :insulation_r_value => 0.0 },
+                               { :id => "FoundationWall2",
+                                 :exterior_adjacent_to => "ground",
+                                 :interior_adjacent_to => "basement - conditioned",
+                                 :height => 8,
+                                 :area => 240,
+                                 :thickness => 8,
+                                 :depth_below_grade => 7,
+                                 :insulation_distance_to_bottom => 8,
+                                 :insulation_r_value => 8.9 },
+                               { :id => "FoundationWall3",
+                                 :exterior_adjacent_to => "ground",
+                                 :interior_adjacent_to => "basement - conditioned",
+                                 :height => 4,
+                                 :area => 160,
+                                 :thickness => 8,
+                                 :depth_below_grade => 3,
+                                 :insulation_distance_to_bottom => 0,
+                                 :insulation_r_value => 0.0 },
+                               { :id => "FoundationWall4",
+                                 :exterior_adjacent_to => "ground",
+                                 :interior_adjacent_to => "basement - conditioned",
+                                 :height => 4,
+                                 :area => 120,
+                                 :thickness => 8,
+                                 :depth_below_grade => 3,
+                                 :insulation_distance_to_bottom => 4,
+                                 :insulation_r_value => 8.9 },
+                               { :id => "FoundationWall5",
+                                 :exterior_adjacent_to => "ground",
+                                 :interior_adjacent_to => "basement - conditioned",
+                                 :height => 4,
+                                 :area => 80,
+                                 :thickness => 8,
+                                 :depth_below_grade => 3,
+                                 :insulation_distance_to_bottom => 4,
+                                 :insulation_r_value => 8.9 }]
   end
   return foundation_walls_values
 end
@@ -1142,15 +1217,12 @@ def get_hpxml_file_slabs_values(hpxml_file, slabs_values)
                       :exposed_perimeter => 150,
                       :perimeter_insulation_depth => 0,
                       :under_slab_insulation_width => 0,
-                      :depth_below_grade => 7,
                       :perimeter_insulation_r_value => 0,
                       :under_slab_insulation_r_value => 0,
                       :carpet_fraction => 0,
                       :carpet_r_value => 0 }]
   elsif ['base-foundation-unconditioned-basement.xml'].include? hpxml_file
     slabs_values[0][:interior_adjacent_to] = "basement - unconditioned"
-  elsif ['base-foundation-unconditioned-basement-above-grade.xml'].include? hpxml_file
-    slabs_values[0][:depth_below_grade] = 4
   elsif ['base-foundation-slab.xml'].include? hpxml_file or
         hpxml_file.include? 'hvac_partial' or
         hpxml_file.include? 'hvac_multiple' or
@@ -1172,7 +1244,6 @@ def get_hpxml_file_slabs_values(hpxml_file, slabs_values)
       slabs_values[0][:interior_adjacent_to] = "crawlspace - vented"
     end
     slabs_values[0][:thickness] = 0
-    slabs_values[0][:depth_below_grade] = 3
     slabs_values[0][:carpet_r_value] = 2.5
   elsif ['base-foundation-multiple.xml'].include? hpxml_file
     slabs_values[0][:area] = 675
@@ -1184,7 +1255,6 @@ def get_hpxml_file_slabs_values(hpxml_file, slabs_values)
                       :exposed_perimeter => 75,
                       :perimeter_insulation_depth => 0,
                       :under_slab_insulation_width => 0,
-                      :depth_below_grade => 3,
                       :perimeter_insulation_r_value => 0,
                       :under_slab_insulation_r_value => 0,
                       :carpet_fraction => 0,
@@ -1220,22 +1290,40 @@ def get_hpxml_file_slabs_values(hpxml_file, slabs_values)
                       :under_slab_insulation_r_value => 0,
                       :carpet_fraction => 0,
                       :carpet_r_value => 0 }
-  elsif ['base-foundation-multiple-slab.xml'].include? hpxml_file
-    # Multiple slabs for the same (basement) foundation
-    slabs_values[0][:area] = 450
-    slabs_values[0][:exposed_perimeter] = 50
-    slabs_values << { :id => "Slab2",
+  elsif ['base-foundation-complex.xml'].include? hpxml_file
+    slabs_values = [{ :id => "Slab1",
                       :interior_adjacent_to => "basement - conditioned",
-                      :area => 900,
+                      :area => 675,
                       :thickness => 4,
-                      :exposed_perimeter => 100,
+                      :exposed_perimeter => 75,
                       :perimeter_insulation_depth => 0,
                       :under_slab_insulation_width => 0,
-                      :depth_below_grade => 7,
                       :perimeter_insulation_r_value => 0,
                       :under_slab_insulation_r_value => 0,
                       :carpet_fraction => 0,
-                      :carpet_r_value => 0 }
+                      :carpet_r_value => 0 },
+                    { :id => "Slab2",
+                      :interior_adjacent_to => "basement - conditioned",
+                      :area => 405,
+                      :thickness => 4,
+                      :exposed_perimeter => 45,
+                      :perimeter_insulation_depth => 1,
+                      :under_slab_insulation_width => 0,
+                      :perimeter_insulation_r_value => 5,
+                      :under_slab_insulation_r_value => 0,
+                      :carpet_fraction => 0,
+                      :carpet_r_value => 0 },
+                    { :id => "Slab3",
+                      :interior_adjacent_to => "basement - conditioned",
+                      :area => 270,
+                      :thickness => 4,
+                      :exposed_perimeter => 30,
+                      :perimeter_insulation_depth => 1,
+                      :under_slab_insulation_width => 0,
+                      :perimeter_insulation_r_value => 5,
+                      :under_slab_insulation_r_value => 0,
+                      :carpet_fraction => 0,
+                      :carpet_r_value => 0 }]
   end
   return slabs_values
 end

--- a/measures/HPXMLtoOpenStudio/measure.rb
+++ b/measures/HPXMLtoOpenStudio/measure.rb
@@ -719,7 +719,7 @@ class OSModel
     return vertices
   end
 
-  def self.add_wall_polygon(x, y, z, azimuth = 0, offsets = [0] * 4)
+  def self.add_wall_polygon(x, y, z, azimuth = 0, offsets = [0] * 4, subsurface_area = 0)
     x = UnitConversions.convert(x, "ft", "m")
     y = UnitConversions.convert(y, "ft", "m")
     z = UnitConversions.convert(z, "ft", "m")
@@ -727,7 +727,20 @@ class OSModel
     vertices = OpenStudio::Point3dVector.new
     vertices << OpenStudio::Point3d.new(0 - (x / 2) - offsets[1], 0, z - offsets[0])
     vertices << OpenStudio::Point3d.new(0 - (x / 2) - offsets[1], 0, z + y + offsets[2])
-    vertices << OpenStudio::Point3d.new(x - (x / 2) + offsets[3], 0, z + y + offsets[2])
+    if subsurface_area > 0
+      subsurface_area = UnitConversions.convert(subsurface_area, "ft^2", "m^2")
+      sub_length = x / 10.0
+      sub_height = subsurface_area / sub_length
+      if sub_height >= y
+        sub_height = y - 0.1
+        sub_length = subsurface_area / sub_height
+      end
+      vertices << OpenStudio::Point3d.new(x - (x / 2) + offsets[3] - sub_length, 0, z + y + offsets[2])
+      vertices << OpenStudio::Point3d.new(x - (x / 2) + offsets[3] - sub_length, 0, z + y + offsets[2] - sub_height)
+      vertices << OpenStudio::Point3d.new(x - (x / 2) + offsets[3], 0, z + y + offsets[2] - sub_height)
+    else
+      vertices << OpenStudio::Point3d.new(x - (x / 2) + offsets[3], 0, z + y + offsets[2])
+    end
     vertices << OpenStudio::Point3d.new(x - (x / 2) + offsets[3], 0, z - offsets[0])
 
     # Rotate about the z axis
@@ -1134,8 +1147,6 @@ class OSModel
     end
 
     foundation_types.each do |foundation_type|
-      # Create Kiva foundation for each type
-
       # Get attached foundation walls/slabs
       fnd_walls = []
       slabs = []
@@ -1146,169 +1157,106 @@ class OSModel
         slabs << slab
       end
 
-      # Calculate sum of exterior foundation wall lengths
-      sum_wall_length = 0.0
-      fnd_walls.each do |fnd_wall|
+      # Calculate combinations of slabs/walls for each Kiva instance
+      kiva_instances, kiva_slabs = get_kiva_instances(fnd_walls, slabs)
+
+      # Obtain some wall/slab information
+      fnd_wall_gross_areas = {}
+      fnd_wall_net_areas = {}
+      fnd_wall_lengths = {}
+      fnd_walls.each_with_index do |fnd_wall, fnd_wall_idx|
         fnd_wall_values = HPXML.get_foundation_wall_values(foundation_wall: fnd_wall)
         next unless fnd_wall_values[:exterior_adjacent_to] == "ground"
 
-        net_area = net_surface_area(fnd_wall_values[:area], fnd_wall_values[:id], "Wall")
-        sum_wall_length += net_area / fnd_wall_values[:height]
+        fnd_wall_gross_areas[fnd_wall] = fnd_wall_values[:area]
+        fnd_wall_net_areas[fnd_wall] = net_surface_area(fnd_wall_values[:area], fnd_wall_values[:id], "Wall")
+        fnd_wall_lengths[fnd_wall] = fnd_wall_gross_areas[fnd_wall] / fnd_wall_values[:height]
       end
-
-      # Obtain the exposed perimeter for each slab
-      slabs_perimeter_exposed = {}
-      slabs.each do |slab|
+      slab_exp_perims = {}
+      slab_areas = {}
+      slabs.each_with_index do |slab, slab_idx|
         slab_values = HPXML.get_slab_values(slab: slab)
-        slabs_perimeter_exposed[slab_values[:id]] = slab_values[:exposed_perimeter]
+        slab_exp_perims[slab] = slab_values[:exposed_perimeter]
+        slab_areas[slab] = slab_values[:area]
       end
+      total_slab_exp_perim = slab_exp_perims.values.inject(0, :+)
+      total_slab_area = slab_areas.values.inject(0, :+)
+      total_fnd_wall_length = fnd_wall_lengths.values.inject(0, :+)
 
-      # Exterior foundation wall surfaces
-      foundation_object = {}
-      fnd_walls.each do |fnd_wall|
-        fnd_wall_values = HPXML.get_foundation_wall_values(foundation_wall: fnd_wall)
-        next unless fnd_wall_values[:exterior_adjacent_to] == "ground"
+      no_wall_slab_exp_perim = {}
 
-        height = fnd_wall_values[:height]
-        net_area = net_surface_area(fnd_wall_values[:area], fnd_wall_values[:id], "Wall")
-        height_ag = height - fnd_wall_values[:depth_below_grade]
-        z_origin = -1 * fnd_wall_values[:depth_below_grade]
-        total_length = net_area / height
+      kiva_instances.each do |fnd_walls_list, kiva_slabs_list|
+        kiva_foundation = nil
 
-        azimuth = @default_azimuth # don't split up surface due to the Kiva runtime impact
-        if not fnd_wall_values[:azimuth].nil?
-          azimuth = fnd_wall_values[:azimuth]
-        end
-
-        # Attach a portion of the foundation wall to each slab. This is
-        # needed if there are multiple Slab elements defined for the foundation.
-        slabs_perimeter_exposed.each do |slab_id, slab_perimeter_exposed|
-          # Calculate exposed section of wall based on slab's total exposed perimeter.
-          # Apportioned to each foundation wall.
-          length = total_length * slab_perimeter_exposed / sum_wall_length
-
-          surface = OpenStudio::Model::Surface.new(add_wall_polygon(length, height, z_origin, azimuth), model)
-          surface.additionalProperties.setFeature("Length", length)
-          surface.additionalProperties.setFeature("Azimuth", azimuth)
-          surface.additionalProperties.setFeature("Tilt", 90.0)
-          surface.setName(fnd_wall_values[:id])
-          surface.setSurfaceType("Wall")
-          set_surface_interior(model, spaces, surface, fnd_wall_values[:id], fnd_wall_values[:interior_adjacent_to])
-          set_surface_exterior(model, spaces, surface, fnd_wall_values[:id], fnd_wall_values[:exterior_adjacent_to])
-
-          if is_thermal_boundary(fnd_wall_values)
-            drywall_thick_in = 0.5
-          else
-            drywall_thick_in = 0.0
-          end
-          filled_cavity = true
-          concrete_thick_in = fnd_wall_values[:thickness]
-          cavity_r = 0.0
-          cavity_depth_in = 0.0
-          install_grade = 1
-          framing_factor = 0.0
-          assembly_r = fnd_wall_values[:insulation_assembly_r_value]
-          if not assembly_r.nil?
-            rigid_height = height
-            film_r = Material.AirFilmVertical.rvalue
-            rigid_r = assembly_r - Material.Concrete(concrete_thick_in).rvalue - Material.GypsumWall(drywall_thick_in).rvalue - film_r
-            if rigid_r < 0 # Try without drywall
-              drywall_thick_in = 0.0
-              rigid_r = assembly_r - Material.Concrete(concrete_thick_in).rvalue - Material.GypsumWall(drywall_thick_in).rvalue - film_r
-            end
-          else
-            rigid_height = fnd_wall_values[:insulation_distance_to_bottom]
-            rigid_r = fnd_wall_values[:insulation_r_value]
-          end
-
-          foundation = foundation_object[slab_id]
-
-          # TODO: Currently assumes all walls have the same height, insulation height, etc.
-          success = Constructions.apply_foundation_wall(runner, model, [surface], "#{fnd_wall_values[:id]} construction",
-                                                        rigid_height, cavity_r, install_grade,
-                                                        cavity_depth_in, filled_cavity, framing_factor,
-                                                        rigid_r, drywall_thick_in, concrete_thick_in,
-                                                        height, height_ag, foundation)
-          return false if not success
-
-          if not assembly_r.nil?
-            check_surface_assembly_rvalue(surface, film_r, assembly_r)
-          end
-
-          foundation_object[slab_id] = surface.adjacentFoundation.get
-        end
-      end
-
-      # Foundation slab surfaces
-      slabs.each do |slab|
-        slab_values = HPXML.get_slab_values(slab: slab)
-
-        # Need to ensure surface perimeter >= user-specified exposed perimeter
-        # (for Kiva) and surface area == user-specified area.
-        exp_perim = slab_values[:exposed_perimeter]
-        tot_perim = exp_perim
-        if tot_perim**2 - 16.0 * slab_values[:area] <= 0
-          # Cannot construct rectangle with this perimeter/area. Some of the
-          # perimeter is presumably not exposed, so bump up perimeter value.
-          tot_perim = Math.sqrt(16.0 * slab_values[:area])
-        end
-        sqrt_term = tot_perim**2 - 16.0 * slab_values[:area]
-        length = tot_perim / 4.0 + Math.sqrt(sqrt_term) / 4.0
-        width = tot_perim / 4.0 - Math.sqrt(sqrt_term) / 4.0
-
-        z_origin = -1 * slab_values[:depth_below_grade]
-
-        surface = OpenStudio::Model::Surface.new(add_floor_polygon(length, width, z_origin), model)
-        surface.setName(slab_values[:id])
-        surface.setSurfaceType("Floor")
-        surface.setOutsideBoundaryCondition("Foundation")
-        set_surface_interior(model, spaces, surface, slab_values[:id], slab_values[:interior_adjacent_to])
-        surface.setSunExposure("NoSun")
-        surface.setWindExposure("NoWind")
-
-        perim_r = slab_values[:perimeter_insulation_r_value]
-        perim_depth = slab_values[:perimeter_insulation_depth]
-        if perim_r == 0 or perim_depth == 0
-          perim_r = 0
-          perim_depth = 0
-        end
-
-        if slab_values[:under_slab_insulation_spans_entire_slab]
-          whole_r = slab_values[:under_slab_insulation_r_value]
-          under_r = 0
-          under_width = 0
+        # Apportion referenced walls/slabs for this Kiva instance
+        kiva_slab_exp_perim = kiva_slabs_list.flatten.map { |e| slab_exp_perims[e] }.inject(0, :+)
+        kiva_slab_area = kiva_slabs_list.flatten.map { |e| slab_areas[e] }.inject(0, :+)
+        kiva_fnd_wall_length = fnd_walls_list.flatten.map { |e| fnd_wall_lengths[e] }.inject(0, :+)
+        kiva_fnd_wall_net_area = fnd_walls_list.flatten.map { |e| fnd_wall_net_areas[e] }.inject(0, :+)
+        kiva_fnd_wall_gross_area = fnd_walls_list.flatten.map { |e| fnd_wall_gross_areas[e] }.inject(0, :+)
+        slab_frac = kiva_slab_exp_perim / total_slab_exp_perim
+        if total_fnd_wall_length > 0
+          fnd_wall_frac = kiva_fnd_wall_length / total_fnd_wall_length
         else
-          under_r = slab_values[:under_slab_insulation_r_value]
-          under_width = slab_values[:under_slab_insulation_width]
-          if under_r == 0 or under_width == 0
-            under_r = 0
-            under_width = 0
-          end
-          whole_r = 0
-        end
-        slab_gap_r = under_r
-
-        mat_carpet = nil
-        if slab_values[:carpet_fraction] > 0 and slab_values[:carpet_r_value] > 0
-          mat_carpet = Material.CoveringBare(slab_values[:carpet_fraction],
-                                             slab_values[:carpet_r_value])
+          fnd_wall_frac = 1.0 # Handle slab foundation type
         end
 
-        foundation = foundation_object[slab_values[:id]]
+        if not fnd_walls_list.empty?
+          # Add single combined exterior foundation wall surface (for similar surfaces)
+          fnd_wall = fnd_walls_list[0]
+          fnd_wall_values = HPXML.get_foundation_wall_values(foundation_wall: fnd_wall)
+          combined_wall_net_area = kiva_fnd_wall_net_area * slab_frac
+          combined_wall_gross_area = kiva_fnd_wall_gross_area * slab_frac
+          kiva_foundation = add_foundation_wall(runner, model, spaces, fnd_wall_values, combined_wall_net_area, combined_wall_gross_area,
+                                                total_fnd_wall_length, total_slab_exp_perim, kiva_foundation)
+          return false if kiva_foundation.nil?
+        end
 
-        success = Constructions.apply_foundation_slab(runner, model, surface, "#{slab_values[:id]} construction",
-                                                      under_r, under_width, slab_gap_r, perim_r,
-                                                      perim_depth, whole_r, slab_values[:thickness],
-                                                      exp_perim, mat_carpet, foundation)
-        return false if not success
+        # Add single combined foundation slab surface (for similar surfaces)
+        slab = kiva_slabs_list[0]
+        slab_values = HPXML.get_slab_values(slab: slab)
+        combined_slab_exp_perim = kiva_slab_exp_perim * fnd_wall_frac
+        combined_slab_area = kiva_slab_area * fnd_wall_frac
+        no_wall_slab_exp_perim[slab] = 0.0 if no_wall_slab_exp_perim[slab].nil?
+        if not fnd_walls_list.empty? and combined_slab_exp_perim > kiva_fnd_wall_length * slab_frac
+          # Keep track of no-wall slab exposed perimeter
+          no_wall_slab_exp_perim[slab] += (combined_slab_exp_perim - kiva_fnd_wall_length * slab_frac)
 
-        # FIXME: Temporary code for sizing
-        surface.additionalProperties.setFeature(Constants.SizingInfoSlabRvalue, 5.0)
+          # Reduce this slab's exposed perimeter so that EnergyPlus does not automatically
+          # create a second no-wall Kiva instance for each of our Kiva instances.
+          # Instead, we will later create our own Kiva instance to account for it.
+          # This reduces the number of Kiva instances we end up with.
+          exp_perim_frac = (kiva_fnd_wall_length * slab_frac) / combined_slab_exp_perim
+          combined_slab_exp_perim *= exp_perim_frac
+          combined_slab_area *= exp_perim_frac
+        end
+        if not fnd_walls_list.empty?
+          z_origin = -1 * fnd_wall_values[:depth_below_grade] # Position based on adjacent foundation walls
+        else
+          z_origin = -1 * slab_values[:depth_below_grade]
+        end
+        kiva_foundation = add_foundation_slab(runner, model, spaces, slab_values, combined_slab_exp_perim,
+                                              combined_slab_area, z_origin, kiva_foundation)
+        return false if kiva_foundation.nil?
+      end
+
+      # For each slab list, create a no-wall Kiva slab instance if needed.
+      kiva_slabs.each do |kiva_slabs_list|
+        # Single combined foundation slab surface
+        slab = kiva_slabs_list[0]
+        next unless no_wall_slab_exp_perim[slab] > 0
+
+        slab_values = HPXML.get_slab_values(slab: slab)
+        z_origin = 0
+        combined_slab_area = total_slab_area * no_wall_slab_exp_perim[slab] / total_slab_exp_perim
+        kiva_foundation = add_foundation_slab(runner, model, spaces, slab_values, no_wall_slab_exp_perim[slab],
+                                              combined_slab_area, z_origin, nil)
+        return false if kiva_foundation.nil?
       end
 
       # Interior foundation wall surfaces
-      # The above-grade portion of the walls are modeled as EnergyPlus surfaces with standard adjacency.
-      # The below-grade portion of the walls (in contact with ground) are not modeled, as Kiva does not
+      # The above-grade portion of these walls are modeled as EnergyPlus surfaces with standard adjacency.
+      # The below-grade portion of these walls (in contact with ground) are not modeled, as Kiva does not
       # calculate heat flow between two zones through the ground.
       fnd_walls.each do |fnd_wall|
         fnd_wall_values = HPXML.get_foundation_wall_values(foundation_wall: fnd_wall)
@@ -1357,6 +1305,141 @@ class OSModel
         return false if not success
       end
     end
+  end
+
+  def self.add_foundation_wall(runner, model, spaces, fnd_wall_values, combined_wall_net_area, combined_wall_gross_area,
+                               total_fnd_wall_length, total_slab_exp_perim, kiva_foundation)
+
+    height = fnd_wall_values[:height]
+    height_ag = height - fnd_wall_values[:depth_below_grade]
+    z_origin = -1 * fnd_wall_values[:depth_below_grade]
+    length = combined_wall_gross_area / height
+
+    if total_fnd_wall_length > total_slab_exp_perim
+      # Calculate exposed section of wall based on slab's total exposed perimeter.
+      length *= total_slab_exp_perim / total_fnd_wall_length
+    end
+
+    azimuth = @default_azimuth
+    if not fnd_wall_values[:azimuth].nil?
+      azimuth = fnd_wall_values[:azimuth]
+    end
+
+    if combined_wall_gross_area > combined_wall_net_area
+      # Create a "notch" in the wall to account for the subsurfaces. This ensures that
+      # we preserve the appropriate wall height, length, and area for Kiva.
+      subsurface_area = combined_wall_gross_area - combined_wall_net_area
+    else
+      subsurface_area = 0
+    end
+
+    surface = OpenStudio::Model::Surface.new(add_wall_polygon(length, height, z_origin, azimuth, [0] * 4, subsurface_area), model)
+    surface.additionalProperties.setFeature("Length", length)
+    surface.additionalProperties.setFeature("Azimuth", azimuth)
+    surface.additionalProperties.setFeature("Tilt", 90.0)
+    surface.setName(fnd_wall_values[:id])
+    surface.setSurfaceType("Wall")
+    set_surface_interior(model, spaces, surface, fnd_wall_values[:id], fnd_wall_values[:interior_adjacent_to])
+    set_surface_exterior(model, spaces, surface, fnd_wall_values[:id], fnd_wall_values[:exterior_adjacent_to])
+
+    if is_thermal_boundary(fnd_wall_values)
+      drywall_thick_in = 0.5
+    else
+      drywall_thick_in = 0.0
+    end
+    filled_cavity = true
+    concrete_thick_in = fnd_wall_values[:thickness]
+    cavity_r = 0.0
+    cavity_depth_in = 0.0
+    install_grade = 1
+    framing_factor = 0.0
+    assembly_r = fnd_wall_values[:insulation_assembly_r_value]
+    if not assembly_r.nil?
+      rigid_height = height
+      film_r = Material.AirFilmVertical.rvalue
+      rigid_r = assembly_r - Material.Concrete(concrete_thick_in).rvalue - Material.GypsumWall(drywall_thick_in).rvalue - film_r
+      if rigid_r < 0 # Try without drywall
+        drywall_thick_in = 0.0
+        rigid_r = assembly_r - Material.Concrete(concrete_thick_in).rvalue - Material.GypsumWall(drywall_thick_in).rvalue - film_r
+      end
+    else
+      rigid_height = fnd_wall_values[:insulation_distance_to_bottom]
+      rigid_r = fnd_wall_values[:insulation_r_value]
+    end
+
+    success = Constructions.apply_foundation_wall(runner, model, [surface], "#{fnd_wall_values[:id]} construction",
+                                                  rigid_height, cavity_r, install_grade,
+                                                  cavity_depth_in, filled_cavity, framing_factor,
+                                                  rigid_r, drywall_thick_in, concrete_thick_in,
+                                                  height, height_ag, kiva_foundation)
+    return nil if not success
+
+    if not assembly_r.nil?
+      check_surface_assembly_rvalue(surface, film_r, assembly_r)
+    end
+
+    return surface.adjacentFoundation.get
+  end
+
+  def self.add_foundation_slab(runner, model, spaces, slab_values, slab_exp_perim,
+                               combined_slab_area, z_origin, kiva_foundation)
+
+    slab_tot_perim = slab_exp_perim
+    if slab_tot_perim**2 - 16.0 * combined_slab_area <= 0
+      # Cannot construct rectangle with this perimeter/area. Some of the
+      # perimeter is presumably not exposed, so bump up perimeter value.
+      slab_tot_perim = Math.sqrt(16.0 * combined_slab_area)
+    end
+    sqrt_term = [slab_tot_perim**2 - 16.0 * combined_slab_area, 0.0].max
+    slab_length = slab_tot_perim / 4.0 + Math.sqrt(sqrt_term) / 4.0
+    slab_width = slab_tot_perim / 4.0 - Math.sqrt(sqrt_term) / 4.0
+
+    surface = OpenStudio::Model::Surface.new(add_floor_polygon(slab_length, slab_width, z_origin), model)
+    surface.setName(slab_values[:id])
+    surface.setSurfaceType("Floor")
+    surface.setOutsideBoundaryCondition("Foundation")
+    set_surface_interior(model, spaces, surface, slab_values[:id], slab_values[:interior_adjacent_to])
+    surface.setSunExposure("NoSun")
+    surface.setWindExposure("NoWind")
+
+    slab_perim_r = slab_values[:perimeter_insulation_r_value]
+    slab_perim_depth = slab_values[:perimeter_insulation_depth]
+    if slab_perim_r == 0 or slab_perim_depth == 0
+      slab_perim_r = 0
+      slab_perim_depth = 0
+    end
+
+    if slab_values[:under_slab_insulation_spans_entire_slab]
+      slab_whole_r = slab_values[:under_slab_insulation_r_value]
+      slab_under_r = 0
+      slab_under_width = 0
+    else
+      slab_under_r = slab_values[:under_slab_insulation_r_value]
+      slab_under_width = slab_values[:under_slab_insulation_width]
+      if slab_under_r == 0 or slab_under_width == 0
+        slab_under_r = 0
+        slab_under_width = 0
+      end
+      slab_whole_r = 0
+    end
+    slab_gap_r = slab_under_r
+
+    mat_carpet = nil
+    if slab_values[:carpet_fraction] > 0 and slab_values[:carpet_r_value] > 0
+      mat_carpet = Material.CoveringBare(slab_values[:carpet_fraction],
+                                         slab_values[:carpet_r_value])
+    end
+
+    success = Constructions.apply_foundation_slab(runner, model, surface, "#{slab_values[:id]} construction",
+                                                  slab_under_r, slab_under_width, slab_gap_r, slab_perim_r,
+                                                  slab_perim_depth, slab_whole_r, slab_values[:thickness],
+                                                  slab_exp_perim, mat_carpet, kiva_foundation)
+    return nil if not success
+
+    # FIXME: Temporary code for sizing
+    surface.additionalProperties.setFeature(Constants.SizingInfoSlabRvalue, 5.0)
+
+    return surface.adjacentFoundation.get
   end
 
   def self.add_conditioned_floor_area(runner, model, building, spaces)
@@ -3597,6 +3680,64 @@ class OSModel
       end
     end
     return min_neighbor_distance
+  end
+
+  def self.get_kiva_instances(fnd_walls, slabs)
+    # Identify unique Kiva foundations that are required.
+    # Some foundation walls or slabs with similar properties can share a Kiva foundation instance.
+    kiva_fnd_walls = []
+    fnd_walls.each_with_index do |fnd_wall, fnd_wall_idx|
+      fnd_wall_values = HPXML.get_foundation_wall_values(foundation_wall: fnd_wall)
+      next unless fnd_wall_values[:exterior_adjacent_to] == "ground"
+      next if kiva_fnd_walls.flatten.include? fnd_wall # Skip if already processed
+
+      kiva_fnd_walls << [fnd_wall]
+
+      # Identify any other foundation walls that can share the Kiva foundation.
+      fnd_walls[fnd_wall_idx + 1..-1].each do |fnd_wall2|
+        next if kiva_fnd_walls.flatten.include? fnd_wall2 # Skip if already processed
+
+        fnd_wall_values2 = HPXML.get_foundation_wall_values(foundation_wall: fnd_wall2)
+        next unless fnd_wall_values2[:exterior_adjacent_to] == fnd_wall_values[:exterior_adjacent_to]
+        next unless fnd_wall_values2[:height] == fnd_wall_values[:height]
+        next unless fnd_wall_values2[:azimuth] == fnd_wall_values[:azimuth]
+        next unless fnd_wall_values2[:thickness] == fnd_wall_values[:thickness]
+        next unless fnd_wall_values2[:depth_below_grade] == fnd_wall_values[:depth_below_grade]
+        next unless fnd_wall_values2[:insulation_distance_to_bottom] == fnd_wall_values[:insulation_distance_to_bottom]
+        next unless fnd_wall_values2[:insulation_r_value] == fnd_wall_values[:insulation_r_value]
+        next unless fnd_wall_values2[:insulation_assembly_r_value] == fnd_wall_values[:insulation_assembly_r_value]
+
+        kiva_fnd_walls[-1] << fnd_wall2
+      end
+    end
+    if kiva_fnd_walls.empty? # Handle slab foundation type
+      kiva_fnd_walls << []
+    end
+    kiva_slabs = []
+    slabs.each_with_index do |slab, slab_idx|
+      slab_values = HPXML.get_slab_values(slab: slab)
+      next if kiva_slabs.flatten.include? slab # Skip if already processed
+
+      kiva_slabs << [slab]
+
+      # Identify any other foundation slabs that can share the Kiva foundation.
+      slabs[slab_idx + 1..-1].each do |slab2|
+        next if kiva_slabs.flatten.include? slab2 # Skip if already processed
+
+        slab_values2 = HPXML.get_slab_values(slab: slab2)
+        next unless slab_values2[:thickness] == slab_values[:thickness]
+        next unless slab_values2[:perimeter_insulation_depth] == slab_values[:perimeter_insulation_depth]
+        next unless slab_values2[:under_slab_insulation_width] == slab_values[:under_slab_insulation_width]
+        next unless slab_values2[:under_slab_insulation_spans_entire_slab] == slab_values[:under_slab_insulation_spans_entire_slab]
+        next unless slab_values2[:carpet_fraction] == slab_values[:carpet_fraction]
+        next unless slab_values2[:carpet_r_value] == slab_values[:carpet_r_value]
+        next unless slab_values2[:perimeter_insulation_r_value] == slab_values[:perimeter_insulation_r_value]
+        next unless slab_values2[:under_slab_insulation_r_value] == slab_values[:under_slab_insulation_r_value]
+
+        kiva_slabs[-1] << slab2
+      end
+    end
+    return kiva_fnd_walls.product(kiva_slabs), kiva_slabs
   end
 end
 

--- a/measures/HPXMLtoOpenStudio/resources/EPvalidator.rb
+++ b/measures/HPXMLtoOpenStudio/resources/EPvalidator.rb
@@ -178,7 +178,7 @@ class EnergyPlusValidator
         "ExposedPerimeter" => one,
         "PerimeterInsulationDepth" => one,
         "[UnderSlabInsulationWidth | [UnderSlabInsulationSpansEntireSlab='true']]" => one,
-        "DepthBelowGrade" => one,
+        "[DepthBelowGrade | [InteriorAdjacentTo!='living space']]" => one_or_more, # DepthBelowGrade only required when InteriorAdjacentTo='living space'
         "PerimeterInsulation/SystemIdentifier" => one, # Required by HPXML schema
         "PerimeterInsulation/Layer[InstallationType='continuous']/NominalRValue" => one,
         "UnderSlabInsulation/SystemIdentifier" => one, # Required by HPXML schema

--- a/measures/HPXMLtoOpenStudio/resources/airflow.rb
+++ b/measures/HPXMLtoOpenStudio/resources/airflow.rb
@@ -1055,7 +1055,7 @@ class Airflow
     end
     return true if all_ducts_conditioned
 
-    def self.create_duct_actuator(model, name, space, is_outside = false)
+    def self.create_duct_actuator_and_equipment(model, name, space, is_latent, is_outside = false)
       var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, name.gsub(" ", "_"))
       other_equip_def = OpenStudio::Model::OtherEquipmentDefinition.new(model)
       other_equip_def.setName("#{var.name} equip")
@@ -1066,6 +1066,8 @@ class Airflow
       other_equip.setSpace(space)
       if is_outside
         other_equip_def.setFractionLost(1.0)
+      elsif is_latent
+        other_equip_def.setFractionLatent(1.0)
       end
       actuator = OpenStudio::Model::EnergyManagementSystemActuator.new(other_equip, "OtherEquipment", "Power Level")
       actuator.setName("#{other_equip.name} act")
@@ -1196,47 +1198,47 @@ class Airflow
         # -- Actuators --
 
         # Other equipment objects to cancel out the supply air leakage directly into the return plenum
-        supply_sens_lk_to_liv_var, supply_sens_lk_to_liv_actuator = create_duct_actuator(model, "#{air_loop_name_idx} SupSensLkToLv", living_space)
-        supply_lat_lk_to_liv_var, supply_lat_lk_to_liv_actuator = create_duct_actuator(model, "#{air_loop_name_idx} SupLatLkToLv", living_space)
+        supply_sens_lk_to_liv_var, supply_sens_lk_to_liv_actuator = create_duct_actuator_and_equipment(model, "#{air_loop_name_idx} SupSensLkToLv", living_space, false)
+        supply_lat_lk_to_liv_var, supply_lat_lk_to_liv_actuator = create_duct_actuator_and_equipment(model, "#{air_loop_name_idx} SupLatLkToLv", living_space, true)
 
         # Supply duct conduction load added to the living space
-        supply_cond_to_liv_var, supply_cond_to_liv_actuator = create_duct_actuator(model, "#{air_loop_name_idx} SupCondToLv", living_space)
+        supply_cond_to_liv_var, supply_cond_to_liv_actuator = create_duct_actuator_and_equipment(model, "#{air_loop_name_idx} SupCondToLv", living_space, false)
 
         # Return duct conduction load added to the return plenum zone
-        return_cond_to_rp_var, return_cond_to_rp_actuator = create_duct_actuator(model, "#{air_loop_name_idx} RetCondToRP", ra_duct_zone.spaces[0])
+        return_cond_to_rp_var, return_cond_to_rp_actuator = create_duct_actuator_and_equipment(model, "#{air_loop_name_idx} RetCondToRP", ra_duct_zone.spaces[0], false)
 
         # Return duct sensible leakage impact on the return plenum
-        return_sens_lk_to_rp_var, return_sens_lk_to_rp_actuator = create_duct_actuator(model, "#{air_loop_name_idx} RetSensLkToRP", ra_duct_zone.spaces[0])
+        return_sens_lk_to_rp_var, return_sens_lk_to_rp_actuator = create_duct_actuator_and_equipment(model, "#{air_loop_name_idx} RetSensLkToRP", ra_duct_zone.spaces[0], false)
 
         # Return duct latent leakage impact on the return plenum
-        return_lat_lk_to_rp_var, return_lat_lk_to_rp_actuator = create_duct_actuator(model, "#{air_loop_name_idx} RetLatLkToRP", ra_duct_zone.spaces[0])
+        return_lat_lk_to_rp_var, return_lat_lk_to_rp_actuator = create_duct_actuator_and_equipment(model, "#{air_loop_name_idx} RetLatLkToRP", ra_duct_zone.spaces[0], true)
 
         # Supply duct conduction impact on the duct zone
         if duct_zone.nil? # Outside
-          supply_cond_to_dz_var, supply_cond_to_dz_actuator = create_duct_actuator(model, "#{air_loop_name_idx} SupCondToDZ", living_space, true)
+          supply_cond_to_dz_var, supply_cond_to_dz_actuator = create_duct_actuator_and_equipment(model, "#{air_loop_name_idx} SupCondToDZ", living_space, false, true)
         else
-          supply_cond_to_dz_var, supply_cond_to_dz_actuator = create_duct_actuator(model, "#{air_loop_name_idx} SupCondToDZ", duct_zone.spaces[0])
+          supply_cond_to_dz_var, supply_cond_to_dz_actuator = create_duct_actuator_and_equipment(model, "#{air_loop_name_idx} SupCondToDZ", duct_zone.spaces[0], false)
         end
 
         # Return duct conduction impact on the duct zone
         if duct_zone.nil? # Outside
-          return_cond_to_dz_var, return_cond_to_dz_actuator = create_duct_actuator(model, "#{air_loop_name_idx} RetCondToDZ", living_space, true)
+          return_cond_to_dz_var, return_cond_to_dz_actuator = create_duct_actuator_and_equipment(model, "#{air_loop_name_idx} RetCondToDZ", living_space, false, true)
         else
-          return_cond_to_dz_var, return_cond_to_dz_actuator = create_duct_actuator(model, "#{air_loop_name_idx} RetCondToDZ", duct_zone.spaces[0])
+          return_cond_to_dz_var, return_cond_to_dz_actuator = create_duct_actuator_and_equipment(model, "#{air_loop_name_idx} RetCondToDZ", duct_zone.spaces[0], false)
         end
 
         # Supply duct sensible leakage impact on the duct zone
         if duct_zone.nil? # Outside
-          supply_sens_lk_to_dz_var, supply_sens_lk_to_dz_actuator = create_duct_actuator(model, "#{air_loop_name_idx} SupSensLkToDZ", living_space, true)
+          supply_sens_lk_to_dz_var, supply_sens_lk_to_dz_actuator = create_duct_actuator_and_equipment(model, "#{air_loop_name_idx} SupSensLkToDZ", living_space, false, true)
         else
-          supply_sens_lk_to_dz_var, supply_sens_lk_to_dz_actuator = create_duct_actuator(model, "#{air_loop_name_idx} SupSensLkToDZ", duct_zone.spaces[0])
+          supply_sens_lk_to_dz_var, supply_sens_lk_to_dz_actuator = create_duct_actuator_and_equipment(model, "#{air_loop_name_idx} SupSensLkToDZ", duct_zone.spaces[0], false)
         end
 
         # Supply duct latent leakage impact on the duct zone
         if duct_zone.nil? # Outside
-          supply_lat_lk_to_dz_var, supply_lat_lk_to_dz_actuator = create_duct_actuator(model, "#{air_loop_name_idx} SupLatLkToDZ", living_space, true)
+          supply_lat_lk_to_dz_var, supply_lat_lk_to_dz_actuator = create_duct_actuator_and_equipment(model, "#{air_loop_name_idx} SupLatLkToDZ", living_space, true, true)
         else
-          supply_lat_lk_to_dz_var, supply_lat_lk_to_dz_actuator = create_duct_actuator(model, "#{air_loop_name_idx} SupLatLkToDZ", duct_zone.spaces[0])
+          supply_lat_lk_to_dz_var, supply_lat_lk_to_dz_actuator = create_duct_actuator_and_equipment(model, "#{air_loop_name_idx} SupLatLkToDZ", duct_zone.spaces[0], true)
         end
 
         # Two objects are required to model the air exchange between the duct zone and the living space since
@@ -1595,7 +1597,7 @@ class Airflow
     bath_sch_sensor.setKeyName(bath_exhaust_sch.schedule.name.to_s)
 
     if mech_vent.has_dryer and mech_vent.dryer_exhaust > 0
-      dryer_exhaust_sch = HotWaterSchedule.new(model, runner, Constants.ObjectNameMechanicalVentilation + " dryer exhaust schedule", Constants.ObjectNameMechanicalVentilation + " dryer exhaust temperature schedule", building.nbeds, mech_vent.dryer_exhaust_day_shift, "ClothesDryerExhaust", 0, create_sch_object = true, schedule_type_limits_name = Constants.ScheduleTypeLimitsFraction)
+      dryer_exhaust_sch = HotWaterSchedule.new(model, runner, Constants.ObjectNameMechanicalVentilation + " dryer exhaust schedule", building.nbeds, 0, true)
       dryer_sch_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, "Schedule Value")
       dryer_sch_sensor.setName("#{Constants.ObjectNameMechanicalVentilation} dryer sch s")
       dryer_sch_sensor.setKeyName(dryer_exhaust_sch.schedule.name.to_s)

--- a/measures/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/measures/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -626,7 +626,7 @@ class HPXML
                     perimeter_insulation_depth:,
                     under_slab_insulation_width: nil,
                     under_slab_insulation_spans_entire_slab: nil,
-                    depth_below_grade:,
+                    depth_below_grade: nil,
                     carpet_fraction:,
                     carpet_r_value:,
                     perimeter_insulation_id: nil,
@@ -645,7 +645,7 @@ class HPXML
     XMLHelper.add_element(slab, "PerimeterInsulationDepth", Float(perimeter_insulation_depth))
     XMLHelper.add_element(slab, "UnderSlabInsulationWidth", Float(under_slab_insulation_width)) unless under_slab_insulation_width.nil?
     XMLHelper.add_element(slab, "UnderSlabInsulationSpansEntireSlab", Boolean(under_slab_insulation_spans_entire_slab)) unless under_slab_insulation_spans_entire_slab.nil?
-    XMLHelper.add_element(slab, "DepthBelowGrade", Float(depth_below_grade))
+    XMLHelper.add_element(slab, "DepthBelowGrade", Float(depth_below_grade)) unless depth_below_grade.nil?
     add_layer_insulation(parent: slab,
                          element_name: "PerimeterInsulation",
                          id: perimeter_insulation_id,

--- a/measures/HPXMLtoOpenStudio/tests/base-addenda-exclude-g-e-a.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-addenda-exclude-g-e-a.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-addenda-exclude-g-e.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-addenda-exclude-g-e.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-addenda-exclude-g.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-addenda-exclude-g.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-appliances-dishwasher-ef.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-appliances-dishwasher-ef.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-appliances-dryer-cef.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-appliances-dryer-cef.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-appliances-gas.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-appliances-gas.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-appliances-none.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-appliances-none.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-appliances-washer-imef.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-appliances-washer-imef.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-atticroof-cathedral.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-atticroof-cathedral.xml
@@ -146,7 +146,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-atticroof-conditioned.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-atticroof-conditioned.xml
@@ -201,7 +201,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-atticroof-flat.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-atticroof-flat.xml
@@ -131,7 +131,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-atticroof-vented.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-atticroof-vented.xml
@@ -172,7 +172,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-combi-tankless-outside.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-combi-tankless-outside.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-combi-tankless.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-combi-tankless.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-dwhr.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-dwhr.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-indirect-outside.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-indirect-outside.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-indirect.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-indirect.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-jacket-electric.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-jacket-electric.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-jacket-gas.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-jacket-gas.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-jacket-hpwh.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-jacket-hpwh.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-jacket-indirect.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-jacket-indirect.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-low-flow-fixtures.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-low-flow-fixtures.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-multiple.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-multiple.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-none.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-none.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-recirc-demand.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-recirc-demand.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-recirc-manual.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-recirc-manual.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-recirc-nocontrol.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-recirc-nocontrol.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-recirc-temperature.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-recirc-temperature.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-recirc-timer.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-recirc-timer.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-tank-gas-outside.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-tank-gas-outside.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-tank-gas.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-tank-gas.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-tank-heat-pump-outside.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-tank-heat-pump-outside.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-tank-heat-pump.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-tank-heat-pump.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-tank-oil.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-tank-oil.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-tank-propane.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-tank-propane.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-tankless-electric-outside.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-tankless-electric-outside.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-tankless-electric.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-tankless-electric.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-tankless-gas.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-tankless-gas.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-tankless-oil.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-tankless-oil.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-tankless-propane.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-tankless-propane.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-dhw-uef.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-dhw-uef.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-enclosure-2stories-garage.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-enclosure-2stories-garage.xml
@@ -195,7 +195,6 @@
             <ExposedPerimeter>110.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-enclosure-2stories.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-enclosure-2stories.xml
@@ -170,7 +170,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-enclosure-adiabatic-surfaces.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-enclosure-adiabatic-surfaces.xml
@@ -172,7 +172,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-enclosure-garage.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-enclosure-garage.xml
@@ -196,7 +196,6 @@
             <ExposedPerimeter>120.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-enclosure-infil-cfm50.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-enclosure-infil-cfm50.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-enclosure-no-natural-ventilation.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-enclosure-no-natural-ventilation.xml
@@ -161,7 +161,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-enclosure-overhangs.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-enclosure-overhangs.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-enclosure-skylights.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-enclosure-skylights.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-enclosure-walltype-cmu.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-enclosure-walltype-cmu.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-enclosure-walltype-doublestud.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-enclosure-walltype-doublestud.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-enclosure-walltype-icf.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-enclosure-walltype-icf.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-enclosure-walltype-log.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-enclosure-walltype-log.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-enclosure-walltype-sip.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-enclosure-walltype-sip.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-enclosure-walltype-solidconcrete.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-enclosure-walltype-solidconcrete.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-enclosure-walltype-steelstud.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-enclosure-walltype-steelstud.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-enclosure-walltype-stone.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-enclosure-walltype-stone.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-enclosure-walltype-strawbale.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-enclosure-walltype-strawbale.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-enclosure-walltype-structuralbrick.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-enclosure-walltype-structuralbrick.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-enclosure-windows-interior-shading.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-enclosure-windows-interior-shading.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-foundation-complex.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-foundation-complex.xml
@@ -3,7 +3,7 @@
   <XMLTransactionHeaderInformation>
     <XMLType>HPXML</XMLType>
     <XMLGeneratedBy>Rakefile</XMLGeneratedBy>
-    <CreatedDateAndTime>2019-05-10T08:18:36-06:00</CreatedDateAndTime>
+    <CreatedDateAndTime>2019-08-20T16:31:35-06:00</CreatedDateAndTime>
     <Transaction>create</Transaction>
   </XMLTransactionHeaderInformation>
   <SoftwareInfo>
@@ -120,16 +120,84 @@
         </Walls>
         <FoundationWalls>
           <FoundationWall>
-            <SystemIdentifier id='FoundationWall'/>
+            <SystemIdentifier id='FoundationWall1'/>
             <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
             <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
             <Height>8.0</Height>
-            <Area>1200.0</Area>
+            <Area>160.0</Area>
+            <Thickness>8.0</Thickness>
+            <DepthBelowGrade>7.0</DepthBelowGrade>
+            <DistanceToBottomOfInsulation>0.0</DistanceToBottomOfInsulation>
+            <Insulation>
+              <SystemIdentifier id='FoundationWall1Insulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </Insulation>
+          </FoundationWall>
+          <FoundationWall>
+            <SystemIdentifier id='FoundationWall2'/>
+            <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Height>8.0</Height>
+            <Area>240.0</Area>
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>7.0</DepthBelowGrade>
             <DistanceToBottomOfInsulation>8.0</DistanceToBottomOfInsulation>
             <Insulation>
-              <SystemIdentifier id='FoundationWallInsulation'/>
+              <SystemIdentifier id='FoundationWall2Insulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>8.9</NominalRValue>
+              </Layer>
+            </Insulation>
+          </FoundationWall>
+          <FoundationWall>
+            <SystemIdentifier id='FoundationWall3'/>
+            <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Height>4.0</Height>
+            <Area>160.0</Area>
+            <Thickness>8.0</Thickness>
+            <DepthBelowGrade>3.0</DepthBelowGrade>
+            <DistanceToBottomOfInsulation>0.0</DistanceToBottomOfInsulation>
+            <Insulation>
+              <SystemIdentifier id='FoundationWall3Insulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </Insulation>
+          </FoundationWall>
+          <FoundationWall>
+            <SystemIdentifier id='FoundationWall4'/>
+            <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Height>4.0</Height>
+            <Area>120.0</Area>
+            <Thickness>8.0</Thickness>
+            <DepthBelowGrade>3.0</DepthBelowGrade>
+            <DistanceToBottomOfInsulation>4.0</DistanceToBottomOfInsulation>
+            <Insulation>
+              <SystemIdentifier id='FoundationWall4Insulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>8.9</NominalRValue>
+              </Layer>
+            </Insulation>
+          </FoundationWall>
+          <FoundationWall>
+            <SystemIdentifier id='FoundationWall5'/>
+            <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Height>4.0</Height>
+            <Area>80.0</Area>
+            <Thickness>8.0</Thickness>
+            <DepthBelowGrade>3.0</DepthBelowGrade>
+            <DistanceToBottomOfInsulation>4.0</DistanceToBottomOfInsulation>
+            <Insulation>
+              <SystemIdentifier id='FoundationWall5Insulation'/>
               <Layer>
                 <InstallationType>continuous</InstallationType>
                 <NominalRValue>8.9</NominalRValue>
@@ -151,23 +219,22 @@
         </FrameFloors>
         <Slabs>
           <Slab>
-            <SystemIdentifier id='Slab'/>
+            <SystemIdentifier id='Slab1'/>
             <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
-            <Area>450.0</Area>
+            <Area>675.0</Area>
             <Thickness>4.0</Thickness>
-            <ExposedPerimeter>50.0</ExposedPerimeter>
+            <ExposedPerimeter>75.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
-              <SystemIdentifier id='SlabPerimeterInsulation'/>
+              <SystemIdentifier id='Slab1PerimeterInsulation'/>
               <Layer>
                 <InstallationType>continuous</InstallationType>
                 <NominalRValue>0.0</NominalRValue>
               </Layer>
             </PerimeterInsulation>
             <UnderSlabInsulation>
-              <SystemIdentifier id='SlabUnderSlabInsulation'/>
+              <SystemIdentifier id='Slab1UnderSlabInsulation'/>
               <Layer>
                 <InstallationType>continuous</InstallationType>
                 <NominalRValue>0.0</NominalRValue>
@@ -181,21 +248,47 @@
           <Slab>
             <SystemIdentifier id='Slab2'/>
             <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
-            <Area>900.0</Area>
+            <Area>405.0</Area>
             <Thickness>4.0</Thickness>
-            <ExposedPerimeter>100.0</ExposedPerimeter>
-            <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
+            <ExposedPerimeter>45.0</ExposedPerimeter>
+            <PerimeterInsulationDepth>1.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='Slab2PerimeterInsulation'/>
               <Layer>
                 <InstallationType>continuous</InstallationType>
-                <NominalRValue>0.0</NominalRValue>
+                <NominalRValue>5.0</NominalRValue>
               </Layer>
             </PerimeterInsulation>
             <UnderSlabInsulation>
               <SystemIdentifier id='Slab2UnderSlabInsulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>0.0</NominalRValue>
+              </Layer>
+            </UnderSlabInsulation>
+            <extension>
+              <CarpetFraction>0.0</CarpetFraction>
+              <CarpetRValue>0.0</CarpetRValue>
+            </extension>
+          </Slab>
+          <Slab>
+            <SystemIdentifier id='Slab3'/>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Area>270.0</Area>
+            <Thickness>4.0</Thickness>
+            <ExposedPerimeter>30.0</ExposedPerimeter>
+            <PerimeterInsulationDepth>1.0</PerimeterInsulationDepth>
+            <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
+            <PerimeterInsulation>
+              <SystemIdentifier id='Slab3PerimeterInsulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>5.0</NominalRValue>
+              </Layer>
+            </PerimeterInsulation>
+            <UnderSlabInsulation>
+              <SystemIdentifier id='Slab3UnderSlabInsulation'/>
               <Layer>
                 <InstallationType>continuous</InstallationType>
                 <NominalRValue>0.0</NominalRValue>

--- a/measures/HPXMLtoOpenStudio/tests/base-foundation-multiple.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-foundation-multiple.xml
@@ -224,7 +224,6 @@
             <ExposedPerimeter>75.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>
@@ -252,7 +251,6 @@
             <ExposedPerimeter>75.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>3.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabUnderCrawlspacePerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-foundation-unconditioned-basement-above-grade.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-foundation-unconditioned-basement-above-grade.xml
@@ -168,7 +168,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>4.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-foundation-unconditioned-basement-assembly-r.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-foundation-unconditioned-basement-assembly-r.xml
@@ -164,7 +164,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-foundation-unconditioned-basement.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-foundation-unconditioned-basement.xml
@@ -168,7 +168,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-foundation-unvented-crawlspace.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-foundation-unvented-crawlspace.xml
@@ -168,7 +168,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>3.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-foundation-vented-crawlspace.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-foundation-vented-crawlspace.xml
@@ -182,7 +182,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>3.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-foundation-walkout-basement.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-foundation-walkout-basement.xml
@@ -3,7 +3,7 @@
   <XMLTransactionHeaderInformation>
     <XMLType>HPXML</XMLType>
     <XMLGeneratedBy>Rakefile</XMLGeneratedBy>
-    <CreatedDateAndTime>2019-05-03T11:46:43-06:00</CreatedDateAndTime>
+    <CreatedDateAndTime>2019-08-20T08:43:52-06:00</CreatedDateAndTime>
     <Transaction>create</Transaction>
   </XMLTransactionHeaderInformation>
   <SoftwareInfo>
@@ -120,16 +120,50 @@
         </Walls>
         <FoundationWalls>
           <FoundationWall>
-            <SystemIdentifier id='FoundationWall'/>
+            <SystemIdentifier id='FoundationWall1'/>
             <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
             <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
             <Height>8.0</Height>
-            <Area>1200.0</Area>
+            <Area>480.0</Area>
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>7.0</DepthBelowGrade>
             <DistanceToBottomOfInsulation>8.0</DistanceToBottomOfInsulation>
             <Insulation>
-              <SystemIdentifier id='FoundationWallInsulation'/>
+              <SystemIdentifier id='FoundationWall1Insulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>8.9</NominalRValue>
+              </Layer>
+            </Insulation>
+          </FoundationWall>
+          <FoundationWall>
+            <SystemIdentifier id='FoundationWall2'/>
+            <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Height>4.0</Height>
+            <Area>120.0</Area>
+            <Thickness>8.0</Thickness>
+            <DepthBelowGrade>3.0</DepthBelowGrade>
+            <DistanceToBottomOfInsulation>4.0</DistanceToBottomOfInsulation>
+            <Insulation>
+              <SystemIdentifier id='FoundationWall2Insulation'/>
+              <Layer>
+                <InstallationType>continuous</InstallationType>
+                <NominalRValue>8.9</NominalRValue>
+              </Layer>
+            </Insulation>
+          </FoundationWall>
+          <FoundationWall>
+            <SystemIdentifier id='FoundationWall3'/>
+            <ExteriorAdjacentTo>ground</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
+            <Height>2.0</Height>
+            <Area>60.0</Area>
+            <Thickness>8.0</Thickness>
+            <DepthBelowGrade>1.0</DepthBelowGrade>
+            <DistanceToBottomOfInsulation>2.0</DistanceToBottomOfInsulation>
+            <Insulation>
+              <SystemIdentifier id='FoundationWall3Insulation'/>
               <Layer>
                 <InstallationType>continuous</InstallationType>
                 <NominalRValue>8.9</NominalRValue>
@@ -286,32 +320,19 @@
                 <Ducts>
                   <DuctType>supply</DuctType>
                   <DuctInsulationRValue>4.0</DuctInsulationRValue>
-                  <DuctLocation>living space</DuctLocation>
+                  <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>150.0</DuctSurfaceArea>
                 </Ducts>
                 <Ducts>
                   <DuctType>return</DuctType>
                   <DuctInsulationRValue>0.0</DuctInsulationRValue>
-                  <DuctLocation>living space</DuctLocation>
+                  <DuctLocation>attic - unvented</DuctLocation>
                   <DuctSurfaceArea>50.0</DuctSurfaceArea>
                 </Ducts>
               </AirDistribution>
             </DistributionSystemType>
           </HVACDistribution>
         </HVAC>
-        <MechanicalVentilation>
-          <VentilationFans>
-            <VentilationFan>
-              <SystemIdentifier id='MechanicalVentilation'/>
-              <FanType>central fan integrated supply</FanType>
-              <TestedFlowRate>330.0</TestedFlowRate>
-              <HoursInOperation>8.0</HoursInOperation>
-              <UsedForWholeBuildingVentilation>true</UsedForWholeBuildingVentilation>
-              <FanPower>300.0</FanPower>
-              <AttachedToHVACDistributionSystem idref='HVACDistribution'/>
-            </VentilationFan>
-          </VentilationFans>
-        </MechanicalVentilation>
         <WaterHeating>
           <WaterHeatingSystem>
             <SystemIdentifier id='WaterHeater'/>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-air-to-air-heat-pump-1-speed.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-air-to-air-heat-pump-1-speed.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-air-to-air-heat-pump-2-speed.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-air-to-air-heat-pump-2-speed.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-air-to-air-heat-pump-var-speed.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-air-to-air-heat-pump-var-speed.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-boiler-elec-only.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-boiler-elec-only.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-boiler-gas-central-ac-1-speed.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-boiler-gas-central-ac-1-speed.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-boiler-gas-only-no-eae.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-boiler-gas-only-no-eae.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-boiler-gas-only.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-boiler-gas-only.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-boiler-oil-only.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-boiler-oil-only.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-boiler-propane-only.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-boiler-propane-only.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-central-ac-only-1-speed.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-central-ac-only-1-speed.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-central-ac-only-2-speed.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-central-ac-only-2-speed.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-central-ac-only-var-speed.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-central-ac-only-var-speed.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-central-ac-plus-air-to-air-heat-pump-heating.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-central-ac-plus-air-to-air-heat-pump-heating.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-dse.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-dse.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-ducts-in-conditioned-space.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-ducts-in-conditioned-space.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-ducts-multiple.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-ducts-multiple.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-ducts-outside.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-ducts-outside.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-elec-resistance-only.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-elec-resistance-only.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-furnace-elec-only.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-furnace-elec-only.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-furnace-gas-central-ac-2-speed.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-furnace-gas-central-ac-2-speed.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-furnace-gas-central-ac-var-speed.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-furnace-gas-central-ac-var-speed.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-furnace-gas-only-no-eae.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-furnace-gas-only-no-eae.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-furnace-gas-only.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-furnace-gas-only.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-furnace-gas-room-ac.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-furnace-gas-room-ac.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-furnace-oil-only.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-furnace-oil-only.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-furnace-propane-only.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-furnace-propane-only.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-ground-to-air-heat-pump.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-ground-to-air-heat-pump.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-ideal-air.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-ideal-air.xml
@@ -161,7 +161,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-mini-split-heat-pump-ducted.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-mini-split-heat-pump-ducted.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-mini-split-heat-pump-ductless-no-backup.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-mini-split-heat-pump-ductless-no-backup.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-mini-split-heat-pump-ductless.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-mini-split-heat-pump-ductless.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-multiple.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-multiple.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-none-no-fuel-access.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-none-no-fuel-access.xml
@@ -157,7 +157,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-none.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-none.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-programmable-thermostat.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-programmable-thermostat.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-room-ac-furnace-gas.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-room-ac-furnace-gas.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-room-ac-only.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-room-ac-only.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-setpoints.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-setpoints.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-stove-oil-only-no-eae.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-stove-oil-only-no-eae.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-stove-oil-only.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-stove-oil-only.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-wall-furnace-elec-only.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-wall-furnace-elec-only.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-wall-furnace-propane-only-no-eae.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-wall-furnace-propane-only-no-eae.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-hvac-wall-furnace-propane-only.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-hvac-wall-furnace-propane-only.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-infiltration-ach-natural.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-infiltration-ach-natural.xml
@@ -156,7 +156,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-mechvent-balanced.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-mechvent-balanced.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-mechvent-cfis.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-mechvent-cfis.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-mechvent-erv-asre.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-mechvent-erv-asre.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-mechvent-erv-atre-asre.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-mechvent-erv-atre-asre.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-mechvent-erv-atre.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-mechvent-erv-atre.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-mechvent-erv.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-mechvent-erv.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-mechvent-exhaust-rated-flow-rate.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-mechvent-exhaust-rated-flow-rate.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-mechvent-exhaust.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-mechvent-exhaust.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-mechvent-hrv-asre.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-mechvent-hrv-asre.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-mechvent-hrv.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-mechvent-hrv.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-mechvent-supply.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-mechvent-supply.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-misc-ceiling-fans.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-misc-ceiling-fans.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-misc-lighting-none.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-misc-lighting-none.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-misc-loads-detailed.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-misc-loads-detailed.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-misc-number-of-occupants.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-misc-number-of-occupants.xml
@@ -161,7 +161,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-pv-array-1axis-backtracked.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-pv-array-1axis-backtracked.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-pv-array-1axis.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-pv-array-1axis.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-pv-array-2axis.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-pv-array-2axis.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-pv-array-fixed-open-rack.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-pv-array-fixed-open-rack.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-pv-module-premium.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-pv-module-premium.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-pv-module-standard.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-pv-module-standard.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-pv-module-thinfilm.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-pv-module-thinfilm.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-pv-multiple.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-pv-multiple.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base-site-neighbors.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base-site-neighbors.xml
@@ -170,7 +170,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/base.xml
+++ b/measures/HPXMLtoOpenStudio/tests/base.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/cfis/base-cfis.xml
+++ b/measures/HPXMLtoOpenStudio/tests/cfis/base-cfis.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-air-to-air-heat-pump-1-speed-cfis.xml
+++ b/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-air-to-air-heat-pump-1-speed-cfis.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-air-to-air-heat-pump-2-speed-cfis.xml
+++ b/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-air-to-air-heat-pump-2-speed-cfis.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-air-to-air-heat-pump-var-speed-cfis.xml
+++ b/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-air-to-air-heat-pump-var-speed-cfis.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-boiler-gas-central-ac-1-speed-cfis.xml
+++ b/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-boiler-gas-central-ac-1-speed-cfis.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-central-ac-only-1-speed-cfis.xml
+++ b/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-central-ac-only-1-speed-cfis.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-central-ac-only-2-speed-cfis.xml
+++ b/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-central-ac-only-2-speed-cfis.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-central-ac-only-var-speed-cfis.xml
+++ b/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-central-ac-only-var-speed-cfis.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-furnace-elec-only-cfis.xml
+++ b/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-furnace-elec-only-cfis.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-furnace-gas-central-ac-2-speed-cfis.xml
+++ b/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-furnace-gas-central-ac-2-speed-cfis.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-furnace-gas-central-ac-var-speed-cfis.xml
+++ b/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-furnace-gas-central-ac-var-speed-cfis.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-furnace-gas-only-cfis.xml
+++ b/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-furnace-gas-only-cfis.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-furnace-gas-room-ac-cfis.xml
+++ b/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-furnace-gas-room-ac-cfis.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-ground-to-air-heat-pump-cfis.xml
+++ b/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-ground-to-air-heat-pump-cfis.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-room-ac-furnace-gas-cfis.xml
+++ b/measures/HPXMLtoOpenStudio/tests/cfis/base-hvac-room-ac-furnace-gas-cfis.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-atticroof-cathedral-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-atticroof-cathedral-autosize.xml
@@ -146,7 +146,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-atticroof-conditioned-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-atticroof-conditioned-autosize.xml
@@ -201,7 +201,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-atticroof-flat-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-atticroof-flat-autosize.xml
@@ -131,7 +131,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-atticroof-vented-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-atticroof-vented-autosize.xml
@@ -172,7 +172,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-enclosure-garage-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-enclosure-garage-autosize.xml
@@ -196,7 +196,6 @@
             <ExposedPerimeter>120.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-enclosure-overhangs-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-enclosure-overhangs-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-enclosure-skylights-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-enclosure-skylights-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-enclosure-walltype-cmu-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-enclosure-walltype-cmu-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-enclosure-walltype-doublestud-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-enclosure-walltype-doublestud-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-enclosure-walltype-icf-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-enclosure-walltype-icf-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-enclosure-walltype-sip-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-enclosure-walltype-sip-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-enclosure-walltype-structuralbrick-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-enclosure-walltype-structuralbrick-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-foundation-unconditioned-basement-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-foundation-unconditioned-basement-autosize.xml
@@ -168,7 +168,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-foundation-unvented-crawlspace-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-foundation-unvented-crawlspace-autosize.xml
@@ -168,7 +168,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>3.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-foundation-vented-crawlspace-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-foundation-vented-crawlspace-autosize.xml
@@ -182,7 +182,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>3.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-air-to-air-heat-pump-1-speed-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-air-to-air-heat-pump-1-speed-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-air-to-air-heat-pump-2-speed-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-air-to-air-heat-pump-2-speed-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-air-to-air-heat-pump-var-speed-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-air-to-air-heat-pump-var-speed-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-boiler-elec-only-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-boiler-elec-only-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-boiler-gas-central-ac-1-speed-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-boiler-gas-central-ac-1-speed-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-boiler-gas-only-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-boiler-gas-only-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-central-ac-only-1-speed-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-central-ac-only-1-speed-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-central-ac-only-2-speed-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-central-ac-only-2-speed-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-central-ac-only-var-speed-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-central-ac-only-var-speed-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-central-ac-plus-air-to-air-heat-pump-heating-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-central-ac-plus-air-to-air-heat-pump-heating-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-ducts-outside-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-ducts-outside-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-elec-resistance-only-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-elec-resistance-only-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-furnace-elec-only-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-furnace-elec-only-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-furnace-gas-central-ac-2-speed-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-furnace-gas-central-ac-2-speed-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-furnace-gas-central-ac-var-speed-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-furnace-gas-central-ac-var-speed-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-furnace-gas-only-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-furnace-gas-only-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-furnace-gas-room-ac-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-furnace-gas-room-ac-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-ground-to-air-heat-pump-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-ground-to-air-heat-pump-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-mini-split-heat-pump-ducted-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-mini-split-heat-pump-ducted-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-mini-split-heat-pump-ductless-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-mini-split-heat-pump-ductless-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-room-ac-furnace-gas-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-room-ac-furnace-gas-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-room-ac-only-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-room-ac-only-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-stove-oil-only-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-stove-oil-only-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-wall-furnace-elec-only-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-wall-furnace-elec-only-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-wall-furnace-propane-only-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-hvac-wall-furnace-propane-only-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-mechvent-erv-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-mechvent-erv-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-mechvent-exhaust-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-mechvent-exhaust-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-mechvent-supply-autosize.xml
+++ b/measures/HPXMLtoOpenStudio/tests/hvac_autosizing/base-mechvent-supply-autosize.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/bad-site-neighbor-azimuth.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/bad-site-neighbor-azimuth.xml
@@ -170,7 +170,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/bad-wmo.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/bad-wmo.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/cfis-with-hydronic-distribution.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/cfis-with-hydronic-distribution.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/clothes-dryer-location-other.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/clothes-dryer-location-other.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/clothes-dryer-location.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/clothes-dryer-location.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/clothes-washer-location-other.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/clothes-washer-location-other.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/clothes-washer-location.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/clothes-washer-location.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/dhw-frac-load-served.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/dhw-frac-load-served.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/duct-location-other.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/duct-location-other.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/duct-location.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/duct-location.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/hvac-distribution-multiple-attached-cooling.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/hvac-distribution-multiple-attached-cooling.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/hvac-distribution-multiple-attached-heating.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/hvac-distribution-multiple-attached-heating.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/hvac-frac-load-served.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/hvac-frac-load-served.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/invalid-idref-dhw-indirect.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/invalid-idref-dhw-indirect.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/missing-elements.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/missing-elements.xml
@@ -156,7 +156,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/missing-surfaces.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/missing-surfaces.xml
@@ -173,7 +173,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/net-area-negative-roof.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/net-area-negative-roof.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/net-area-negative-wall.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/net-area-negative-wall.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/refrigerator-location-other.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/refrigerator-location-other.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/refrigerator-location.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/refrigerator-location.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/two-repeating-idref-dhw-indirect.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/two-repeating-idref-dhw-indirect.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/unattached-cfis.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/unattached-cfis.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/unattached-door.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/unattached-door.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/unattached-hvac-distribution.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/unattached-hvac-distribution.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/unattached-skylight.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/unattached-skylight.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/unattached-window.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/unattached-window.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/water-heater-location-other.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/water-heater-location-other.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/invalid_files/water-heater-location.xml
+++ b/measures/HPXMLtoOpenStudio/tests/invalid_files/water-heater-location.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/water_heating_multiple/base-dhw-tankless-electric-x3.xml
+++ b/measures/HPXMLtoOpenStudio/tests/water_heating_multiple/base-dhw-tankless-electric-x3.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/water_heating_multiple/base-dhw-tankless-gas-x3.xml
+++ b/measures/HPXMLtoOpenStudio/tests/water_heating_multiple/base-dhw-tankless-gas-x3.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/water_heating_multiple/base-dhw-tankless-oil-x3.xml
+++ b/measures/HPXMLtoOpenStudio/tests/water_heating_multiple/base-dhw-tankless-oil-x3.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>

--- a/measures/HPXMLtoOpenStudio/tests/water_heating_multiple/base-dhw-tankless-propane-x3.xml
+++ b/measures/HPXMLtoOpenStudio/tests/water_heating_multiple/base-dhw-tankless-propane-x3.xml
@@ -158,7 +158,6 @@
             <ExposedPerimeter>150.0</ExposedPerimeter>
             <PerimeterInsulationDepth>0.0</PerimeterInsulationDepth>
             <UnderSlabInsulationWidth>0.0</UnderSlabInsulationWidth>
-            <DepthBelowGrade>7.0</DepthBelowGrade>
             <PerimeterInsulation>
               <SystemIdentifier id='SlabPerimeterInsulation'/>
               <Layer>


### PR DESCRIPTION
Improve use of Kiva to handle more complex foundation configurations (walkout basements, multiple foundation walls/slabs with different insulation properties, etc.). The code also combines similar surfaces in order to reduce the number of Kiva instances called.

`DepthBelowGrade` is now only used for slab foundation types.