### PR TITLE
Interior shading

### DIFF
--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L100AC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L100AC.xml
@@ -153,11 +153,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -165,11 +163,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -177,11 +173,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -189,11 +183,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L100AL.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L100AL.xml
@@ -153,11 +153,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -165,11 +163,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -177,11 +173,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -189,11 +183,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L110AC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L110AC.xml
@@ -153,11 +153,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -165,11 +163,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -177,11 +173,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -189,11 +183,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L110AL.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L110AL.xml
@@ -153,11 +153,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -165,11 +163,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -177,11 +173,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -189,11 +183,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L120AC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L120AC.xml
@@ -153,11 +153,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -165,11 +163,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -177,11 +173,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -189,11 +183,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L120AL.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L120AL.xml
@@ -153,11 +153,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -165,11 +163,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -177,11 +173,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -189,11 +183,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L130AC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L130AC.xml
@@ -153,11 +153,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.3</UFactor>
             <SHGC>0.335</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -165,11 +163,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>0.3</UFactor>
             <SHGC>0.335</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -177,11 +173,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.3</UFactor>
             <SHGC>0.335</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -189,11 +183,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>0.3</UFactor>
             <SHGC>0.335</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L130AL.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L130AL.xml
@@ -153,11 +153,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.3</UFactor>
             <SHGC>0.335</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -165,11 +163,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>0.3</UFactor>
             <SHGC>0.335</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -177,11 +173,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.3</UFactor>
             <SHGC>0.335</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -189,11 +183,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>0.3</UFactor>
             <SHGC>0.335</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L150AC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L150AC.xml
@@ -153,11 +153,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L150AL.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L150AL.xml
@@ -153,11 +153,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L155AC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L155AC.xml
@@ -153,16 +153,14 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <Overhangs>
               <Depth>2.5</Depth>
               <DistanceToTopOfWindow>1.0</DistanceToTopOfWindow>
               <DistanceToBottomOfWindow>6.0</DistanceToBottomOfWindow>
             </Overhangs>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L155AL.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L155AL.xml
@@ -153,16 +153,14 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <Overhangs>
               <Depth>2.5</Depth>
               <DistanceToTopOfWindow>1.0</DistanceToTopOfWindow>
               <DistanceToBottomOfWindow>6.0</DistanceToBottomOfWindow>
             </Overhangs>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L160AC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L160AC.xml
@@ -153,11 +153,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -165,11 +163,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L160AL.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L160AL.xml
@@ -153,11 +153,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -165,11 +163,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L170AC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L170AC.xml
@@ -153,11 +153,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -165,11 +163,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -177,11 +173,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -189,11 +183,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L170AL.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L170AL.xml
@@ -153,11 +153,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -165,11 +163,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -177,11 +173,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -189,11 +183,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L200AC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L200AC.xml
@@ -153,11 +153,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -165,11 +163,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -177,11 +173,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -189,11 +183,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L200AL.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L200AL.xml
@@ -153,11 +153,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -165,11 +163,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -177,11 +173,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -189,11 +183,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L202AC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L202AC.xml
@@ -153,11 +153,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -165,11 +163,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -177,11 +173,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -189,11 +183,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L202AL.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L202AL.xml
@@ -153,11 +153,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -165,11 +163,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -177,11 +173,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -189,11 +183,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L302XC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L302XC.xml
@@ -173,11 +173,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -185,11 +183,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -197,11 +193,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -209,11 +203,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L304XC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L304XC.xml
@@ -173,11 +173,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -185,11 +183,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -197,11 +193,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -209,11 +203,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L322XC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L322XC.xml
@@ -206,11 +206,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -218,11 +216,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -230,11 +226,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -242,11 +236,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L324XC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L324XC.xml
@@ -206,11 +206,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -218,11 +216,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -230,11 +226,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -242,11 +236,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.4_HVAC/HVAC1a.xml
+++ b/workflow/tests/RESNET_Tests/4.4_HVAC/HVAC1a.xml
@@ -150,11 +150,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -162,11 +160,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -174,11 +170,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -186,11 +180,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.4_HVAC/HVAC1b.xml
+++ b/workflow/tests/RESNET_Tests/4.4_HVAC/HVAC1b.xml
@@ -150,11 +150,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -162,11 +160,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -174,11 +170,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -186,11 +180,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.4_HVAC/HVAC2a.xml
+++ b/workflow/tests/RESNET_Tests/4.4_HVAC/HVAC2a.xml
@@ -150,11 +150,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -162,11 +160,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -174,11 +170,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -186,11 +180,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.4_HVAC/HVAC2b.xml
+++ b/workflow/tests/RESNET_Tests/4.4_HVAC/HVAC2b.xml
@@ -150,11 +150,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -162,11 +160,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -174,11 +170,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -186,11 +180,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.4_HVAC/HVAC2c.xml
+++ b/workflow/tests/RESNET_Tests/4.4_HVAC/HVAC2c.xml
@@ -150,11 +150,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -162,11 +160,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -174,11 +170,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -186,11 +180,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.4_HVAC/HVAC2d.xml
+++ b/workflow/tests/RESNET_Tests/4.4_HVAC/HVAC2d.xml
@@ -150,11 +150,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -162,11 +160,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -174,11 +170,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -186,11 +180,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.4_HVAC/HVAC2e.xml
+++ b/workflow/tests/RESNET_Tests/4.4_HVAC/HVAC2e.xml
@@ -150,11 +150,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -162,11 +160,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -174,11 +170,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -186,11 +180,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.5_DSE/HVAC3a.xml
+++ b/workflow/tests/RESNET_Tests/4.5_DSE/HVAC3a.xml
@@ -199,11 +199,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -211,11 +209,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -223,11 +219,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -235,11 +229,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.5_DSE/HVAC3b.xml
+++ b/workflow/tests/RESNET_Tests/4.5_DSE/HVAC3b.xml
@@ -199,11 +199,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -211,11 +209,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -223,11 +219,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -235,11 +229,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.5_DSE/HVAC3c.xml
+++ b/workflow/tests/RESNET_Tests/4.5_DSE/HVAC3c.xml
@@ -199,11 +199,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -211,11 +209,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -223,11 +219,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -235,11 +229,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.5_DSE/HVAC3d.xml
+++ b/workflow/tests/RESNET_Tests/4.5_DSE/HVAC3d.xml
@@ -199,11 +199,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -211,11 +209,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -223,11 +219,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -235,11 +229,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.5_DSE/HVAC3e.xml
+++ b/workflow/tests/RESNET_Tests/4.5_DSE/HVAC3e.xml
@@ -150,11 +150,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -162,11 +160,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -174,11 +170,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -186,11 +180,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.5_DSE/HVAC3f.xml
+++ b/workflow/tests/RESNET_Tests/4.5_DSE/HVAC3f.xml
@@ -150,11 +150,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -162,11 +160,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -174,11 +170,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -186,11 +180,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.5_DSE/HVAC3g.xml
+++ b/workflow/tests/RESNET_Tests/4.5_DSE/HVAC3g.xml
@@ -150,11 +150,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -162,11 +160,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -174,11 +170,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -186,11 +180,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/RESNET_Tests/4.5_DSE/HVAC3h.xml
+++ b/workflow/tests/RESNET_Tests/4.5_DSE/HVAC3h.xml
@@ -150,11 +150,9 @@
             <Azimuth>0</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowEast'/>
@@ -162,11 +160,9 @@
             <Azimuth>90</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -174,11 +170,9 @@
             <Azimuth>180</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
           <Window>
             <SystemIdentifier id='WindowWest'/>
@@ -186,11 +180,9 @@
             <Azimuth>270</Azimuth>
             <UFactor>1.039</UFactor>
             <SHGC>0.67</SHGC>
+            <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
+            <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
             <AttachedToWall idref='Wall'/>
-            <extension>
-              <InteriorShadingFactorSummer>1.0</InteriorShadingFactorSummer>
-              <InteriorShadingFactorWinter>1.0</InteriorShadingFactorWinter>
-            </extension>
           </Window>
         </Windows>
         <Doors>

--- a/workflow/tests/energy_rating_index_test.rb
+++ b/workflow/tests/energy_rating_index_test.rb
@@ -1420,8 +1420,8 @@ class EnergyRatingIndexTest < Minitest::Test
       areas[azimuth] += Float(XMLHelper.get_value(win, "Area"))
       u_factor += Float(XMLHelper.get_value(win, "UFactor"))
       shgc = Float(XMLHelper.get_value(win, "SHGC"))
-      shading_winter = Float(XMLHelper.get_value(win, "extension/InteriorShadingFactorWinter"))
-      shading_summer = Float(XMLHelper.get_value(win, "extension/InteriorShadingFactorSummer"))
+      shading_winter = Float(XMLHelper.get_value(win, "InteriorShadingFactorWinter"))
+      shading_summer = Float(XMLHelper.get_value(win, "InteriorShadingFactorSummer"))
       shgc_htg += (shgc * shading_winter)
       shgc_clg += (shgc * shading_summer)
       num += 1


### PR DESCRIPTION
Uses HPXML v3 proposed fields `InteriorShadingFractionSummer` and `InteriorShadingFractionWinter` to remove use of extension. Only used for ASHRAE 140-based test files.