### PR TITLE
Simplify hourly output querying

### DIFF
--- a/workflow/design.rb
+++ b/workflow/design.rb
@@ -94,29 +94,10 @@ def create_idf(design, basedir, output_dir, resultsdir, hpxml, debug, skip_valid
     output_var.setKeyValue('*')
 
     # Energy use by fuel:
-
-    # Electricity and Natural Gas can be retrieved from meters
-    ['Electricity:Facility', 'Gas:Facility'].each do |meter_fuel|
+    ['Electricity:Facility', 'Gas:Facility', 'FuelOil#1:Facility', 'Propane:Facility'].each do |meter_fuel|
       output_meter = OpenStudio::Model::OutputMeter.new(model)
       output_meter.setName(meter_fuel)
       output_meter.setReportingFrequency('hourly')
-    end
-
-    # Other fuels need to be rolled up
-    other_fuels = ['Heating Coil Propane Energy',
-                   'Heating Coil FuelOil#1 Energy',
-                   'Baseboard Propane Energy',
-                   'Baseboard FuelOil#1 Energy',
-                   'Boiler Propane Energy',
-                   'Boiler FuelOil#1 Energy',
-                   'Water Heater Propane Energy',
-                   'Water Heater FuelOil#1 Energy',
-                   'Other Equipment Propane Energy',
-                   'Other Equipment FuelOil#1 Energy']
-    other_fuels.each do |var_fuel|
-      output_var = OpenStudio::Model::OutputVariable.new(var_fuel, model)
-      output_var.setReportingFrequency('hourly')
-      output_var.setKeyValue('*')
     end
   end
 

--- a/workflow/energy_rating_index.rb
+++ b/workflow/energy_rating_index.rb
@@ -528,13 +528,13 @@ def read_output(design, designdir, output_hpxml_path, hourly_output)
     fail "Unexpected result" if gas_use.size != 8760
 
     # Fuel Oil
-    query = "SELECT SUM(VariableValue)*#{j_to_kbtu} FROM ReportVariableData WHERE ReportVariableDataDictionaryIndex IN (SELECT ReportVariableDataDictionaryIndex FROM ReportVariableDataDictionary WHERE VariableName LIKE '%FuelOil#1 Energy' AND ReportingFrequency='Hourly') GROUP BY TimeIndex ORDER BY TimeIndex"
+    query = "SELECT VariableValue*#{j_to_kbtu} FROM ReportMeterData WHERE ReportMeterDataDictionaryIndex = (SELECT ReportMeterDataDictionaryIndex FROM ReportMeterDataDictionary WHERE VariableName='FuelOil#1:Facility' AND ReportingFrequency='Hourly') ORDER BY TimeIndex"
     oil_use = [] + sqlFile.execAndReturnVectorOfDouble(query).get
     oil_use += [0.0] * 8760 if oil_use.size == 0
     fail "Unexpected result" if oil_use.size != 8760
 
     # Propane
-    query = "SELECT SUM(VariableValue)*#{j_to_kbtu} FROM ReportVariableData WHERE ReportVariableDataDictionaryIndex IN (SELECT ReportVariableDataDictionaryIndex FROM ReportVariableDataDictionary WHERE VariableName LIKE '%Propane Energy' AND ReportingFrequency='Hourly') GROUP BY TimeIndex ORDER BY TimeIndex"
+    query = "SELECT VariableValue*#{j_to_kbtu} FROM ReportMeterData WHERE ReportMeterDataDictionaryIndex = (SELECT ReportMeterDataDictionaryIndex FROM ReportMeterDataDictionary WHERE VariableName='Propane:Facility' AND ReportingFrequency='Hourly') ORDER BY TimeIndex"
     propane_use = [] + sqlFile.execAndReturnVectorOfDouble(query).get
     propane_use += [0.0] * 8760 if propane_use.size == 0
     fail "Unexpected result" if propane_use.size != 8760

--- a/workflow/energy_rating_index.rb
+++ b/workflow/energy_rating_index.rb
@@ -509,8 +509,8 @@ def read_output(design, designdir, output_hpxml_path, hourly_output)
     design_hourly_output = [["Hour",
                              "Electricity Use [kWh]",
                              "Natural Gas Use [kBtu]",
-                             "Propane Use [kBtu]",
-                             "Fuel Oil Use [kBtu]"]]
+                             "Fuel Oil Use [kBtu]",
+                             "Propane Use [kBtu]"]]
     zone_names.each do |zone_name|
       design_hourly_output[0] << "#{zone_name.split.map(&:capitalize).join(' ')} Temperature [F]"
     end


### PR DESCRIPTION
Use `FuelOil#1:Facility` and `Propane:Facility` meters for hourly output to simplify code. Not sure why I previously thought they didn't exist...