### PR TITLE
Foundation wall insulation

### DIFF
--- a/measures/HPXMLtoOpenStudio/measure.rb
+++ b/measures/HPXMLtoOpenStudio/measure.rb
@@ -1637,6 +1637,9 @@ class OSModel
         drywall_thick_in = 0.0
         rigid_r = assembly_r - Material.Concrete(concrete_thick_in).rvalue - Material.GypsumWall(drywall_thick_in).rvalue - film_r
       end
+      if rigid_r < 0.1
+        rigid_r = 0.0
+      end
       if rigid_r < 0
         rigid_r = 0.0
         match = false


### PR DESCRIPTION
Prevent possibility of tiny slivers of rigid insulation on foundation walls.