### PR TITLE
Detect duplicate IDs

### DIFF
--- a/measures/301EnergyRatingIndexRuleset/resources/301validator.rb
+++ b/measures/301EnergyRatingIndexRuleset/resources/301validator.rb
@@ -637,6 +637,16 @@ class EnergyRatingIndex301Validator
       errors << "Expected FractionDHWLoadServed to sum to 1, but calculated sum is #{frac_dhw_load.round(2)}."
     end
 
+    # Check for unique SystemIdentifier IDs
+    sys_ids = {}
+    REXML::XPath.each(hpxml_doc, "//SystemIdentifier/@id") do |sys_id|
+      sys_ids[sys_id.value] = 0 if sys_ids[sys_id.value].nil?
+      sys_ids[sys_id.value] += 1
+    end
+    sys_ids.each do |sys_id, cnt|
+      errors << "Duplicate SystemIdentifier IDs detected for '#{sys_id}'." if cnt > 1
+    end
+
     return errors
   end
 

--- a/measures/HPXMLtoOpenStudio/resources/EPvalidator.rb
+++ b/measures/HPXMLtoOpenStudio/resources/EPvalidator.rb
@@ -691,6 +691,16 @@ class EnergyPlusValidator
       errors << "Expected FractionDHWLoadServed to sum to 1, but calculated sum is #{frac_dhw_load.round(2)}."
     end
 
+    # Check for unique SystemIdentifier IDs
+    sys_ids = {}
+    REXML::XPath.each(hpxml_doc, "//SystemIdentifier/@id") do |sys_id|
+      sys_ids[sys_id.value] = 0 if sys_ids[sys_id.value].nil?
+      sys_ids[sys_id.value] += 1
+    end
+    sys_ids.each do |sys_id, cnt|
+      errors << "Duplicate SystemIdentifier IDs detected for '#{sys_id}'." if cnt > 1
+    end
+
     return errors
   end
 

--- a/workflow/tests/energy_rating_index_test.rb
+++ b/workflow/tests/energy_rating_index_test.rb
@@ -2159,7 +2159,7 @@ class EnergyRatingIndexTest < Minitest::Test
     unless orig_mech_vent_values.nil?
       ventilation_fan = XMLHelper.add_element(extension, "OverrideVentilationFan")
       sys_id = XMLHelper.add_element(ventilation_fan, "SystemIdentifier")
-      XMLHelper.add_attribute(sys_id, "id", orig_mech_vent_values[:id])
+      XMLHelper.add_attribute(sys_id, "id", "Override#{orig_mech_vent_values[:id]}")
       XMLHelper.add_element(ventilation_fan, "FanType", orig_mech_vent_values[:fan_type])
       XMLHelper.add_element(ventilation_fan, "TestedFlowRate", Float(orig_mech_vent_values[:tested_flow_rate]))
       XMLHelper.add_element(ventilation_fan, "HoursInOperation", Float(orig_mech_vent_values[:hours_in_operation]))
@@ -2178,7 +2178,7 @@ class EnergyRatingIndexTest < Minitest::Test
     extension = XMLHelper.add_element(ref_infil, "extension")
     air_infiltration_measurement = XMLHelper.add_element(extension, "OverrideAirInfiltrationMeasurement")
     sys_id = XMLHelper.add_element(air_infiltration_measurement, "SystemIdentifier")
-    XMLHelper.add_attribute(sys_id, "id", orig_infil_values[:id])
+    XMLHelper.add_attribute(sys_id, "id", "Override#{orig_infil_values[:id]}")
     XMLHelper.add_element(air_infiltration_measurement, "HousePressure", Float(orig_infil_values[:house_pressure])) unless orig_infil_values[:house_pressure].nil?
     if not orig_infil_values[:unit_of_measure].nil? and not orig_infil_values[:air_leakage].nil?
       building_air_leakage = XMLHelper.add_element(air_infiltration_measurement, "BuildingAirLeakage")


### PR DESCRIPTION
Detect and report duplicate SystemIdentifier IDs, as they can result in unpredictable behavior. SystemIdentifier IDs are supposed to be unique per the HPXML schema.