### PR TITLE
Fix the --cache-weather command

### DIFF
--- a/workflow/energy_rating_index.rb
+++ b/workflow/energy_rating_index.rb
@@ -432,6 +432,8 @@ end
 
 def cache_weather
   # Process all epw files through weather.rb and serialize objects
+  require_relative "../measures/HPXMLtoOpenStudio/resources/weather"
+
   # OpenStudio::Logger.instance.standardOutLogger.setLogLevel(OpenStudio::Fatal)
   weather_dir = File.join(File.dirname(__FILE__), "..", "weather")
   OpenStudio::Logger.instance.standardOutLogger.setLogLevel(OpenStudio::Fatal)


### PR DESCRIPTION
## Pull Request Description

Fixes the --cache-weather command and adds a test so that it doesn't break again.

## Checklist

Not all may apply:

- [ ] OS-HPXML git subtree has been pulled
- [ ] 301 ruleset and unit tests have been updated
- [ ] 301validator.rb has been updated (reference EPvalidator.rb)
- [x] Workflow tests have been updated
- [ ] Documentation has been updated
- [x] `rake update_measures` has been run
- [ ] No unexpected regression test changes on CI
