### PR TITLE
More hourly outputs

### DIFF
--- a/workflow/hourly_outputs.csv
+++ b/workflow/hourly_outputs.csv
@@ -1,0 +1,5 @@
+Enabled,E+ Output(s),Note
+TRUE,Zone Temperatures,Temperatures for each E+ thermal zone
+TRUE,Fuel Consumptions,Total energy consumptions for each fuel type
+FALSE,Total Loads,Total heating/cooling loads
+FALSE,Component Loads,Heating/cooling loads disaggregated by component type

--- a/workflow/hourly_outputs.csv
+++ b/workflow/hourly_outputs.csv
@@ -1,4 +1,4 @@
-Enabled,E+ Output(s),Note
+Enabled,Hourly Output,Note
 TRUE,Zone Temperatures,Temperatures for each E+ thermal zone
 TRUE,Fuel Consumptions,Total energy consumptions for each fuel type
 FALSE,Total Loads,Total heating/cooling loads


### PR DESCRIPTION
## Pull Request Description

Allows selection of hourly outputs to be obtained. See the [hourly_outputs.csv](https://github.com/NREL/OpenStudio-ERI/blob/more_hourly_outputs/workflow/hourly_outputs.csv) file for the list of outputs available. This CSV is used when the `--hourly-output` argument is provided.

## Checklist

Not all may apply:

- [ ] OS-HPXML git subtree has been pulled
- [ ] 301 ruleset and unit tests have been updated
- [ ] 301validator.rb has been updated (reference EPvalidator.rb)
- [ ] Workflow tests have been updated
- [ ] Documentation has been updated
- [ ] `rake update_measures` has been run
- [ ] No unexpected regression test changes on CI
