### PR TITLE
Allow small tolerance for hvac load fractions

### DIFF
--- a/hpxml-measures/HPXMLtoOpenStudio/measure.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/measure.rb
@@ -2271,6 +2271,23 @@ class OSModel
     end
   end
 
+  def self.calc_sequential_load_fraction(load_fraction, remaining_fraction)
+    if remaining_fraction > 0
+      if (load_fraction - remaining_fraction).abs <= 0.010001
+        # Last equipment to handle all the remaining load (within 0.01 tolerance)
+        load_fraction = remaining_fraction
+        sequential_load_frac = 1.0 # Fraction of remaining load served by this system
+      else
+        sequential_load_frac = load_fraction / remaining_fraction # Fraction of remaining load served by this system
+      end
+    else
+      sequential_load_frac = 0.0
+    end
+    remaining_fraction -= load_fraction
+
+    return sequential_load_frac, remaining_fraction, load_fraction
+  end
+
   def self.add_cooling_system(runner, model, building)
     return if @use_only_ideal_air
 
@@ -2287,12 +2304,7 @@ class OSModel
       end
 
       load_frac = cooling_system_values[:fraction_cool_load_served]
-      if @total_frac_remaining_cool_load_served > 0
-        sequential_load_frac = load_frac / @total_frac_remaining_cool_load_served # Fraction of remaining load served by this system
-      else
-        sequential_load_frac = 0.0
-      end
-      @total_frac_remaining_cool_load_served -= load_frac
+      sequential_load_frac, @total_frac_remaining_cool_load_served, load_frac = calc_sequential_load_fraction(load_frac, @total_frac_remaining_cool_load_served)
 
       sys_id = cooling_system_values[:id]
 
@@ -2411,12 +2423,7 @@ class OSModel
         end
 
         load_frac = heating_system_values[:fraction_heat_load_served]
-        if @total_frac_remaining_heat_load_served > 0
-          sequential_load_frac = load_frac / @total_frac_remaining_heat_load_served # Fraction of remaining load served by this system
-        else
-          sequential_load_frac = 0.0
-        end
-        @total_frac_remaining_heat_load_served -= load_frac
+        sequential_load_frac, @total_frac_remaining_heat_load_served, load_frac = calc_sequential_load_fraction(load_frac, @total_frac_remaining_heat_load_served)
 
         @hvac_map[sys_id] = []
 
@@ -2509,20 +2516,10 @@ class OSModel
       end
 
       load_frac_heat = heat_pump_values[:fraction_heat_load_served]
-      if @total_frac_remaining_heat_load_served > 0
-        sequential_load_frac_heat = load_frac_heat / @total_frac_remaining_heat_load_served # Fraction of remaining load served by this system
-      else
-        sequential_load_frac_heat = 0.0
-      end
-      @total_frac_remaining_heat_load_served -= load_frac_heat
+      sequential_load_frac_heat, @total_frac_remaining_heat_load_served, load_frac_heat = calc_sequential_load_fraction(load_frac_heat, @total_frac_remaining_heat_load_served)
 
       load_frac_cool = heat_pump_values[:fraction_cool_load_served]
-      if @total_frac_remaining_cool_load_served > 0
-        sequential_load_frac_cool = load_frac_cool / @total_frac_remaining_cool_load_served # Fraction of remaining load served by this system
-      else
-        sequential_load_frac_cool = 0.0
-      end
-      @total_frac_remaining_cool_load_served -= load_frac_cool
+      sequential_load_frac_cool, @total_frac_remaining_cool_load_served, load_frac_cool = calc_sequential_load_fraction(load_frac_cool, @total_frac_remaining_cool_load_served)
 
       backup_heat_fuel = heat_pump_values[:backup_heating_fuel]
       if not backup_heat_fuel.nil?

--- a/hpxml-measures/HPXMLtoOpenStudio/measure.xml
+++ b/hpxml-measures/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>3aa50d09-ada8-462f-ade9-6a5441bc878d</version_id>
-  <version_modified>20200222T211803Z</version_modified>
+  <version_id>bda99197-d64c-40a5-9f95-70db3d6552a5</version_id>
+  <version_modified>20200227T192712Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -465,7 +465,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>BA046B24</checksum>
+      <checksum>CC14FD04</checksum>
     </file>
   </files>
 </measure>

--- a/hpxml-measures/SimulationOutputReport/measure.rb
+++ b/hpxml-measures/SimulationOutputReport/measure.rb
@@ -229,17 +229,21 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     # get the last model and sql file
     model = runner.lastOpenStudioModel
     if model.empty?
-      runner.registerError("Cannot find last model.")
+      runner.registerError("Cannot find OpenStudio model.")
       return false
     end
     @model = model.get
 
     sqlFile = runner.lastEnergyPlusSqlFile
     if sqlFile.empty?
-      runner.registerError("Cannot find last sql file.")
+      runner.registerError("Cannot find EnergyPlus sql file.")
       return false
     end
     @sqlFile = sqlFile.get
+    if not @sqlFile.connectionOpen
+      runner.registerError("EnergyPlus simulation failed.")
+      return false
+    end
     @model.setSqlFile(@sqlFile)
 
     setup_outputs

--- a/hpxml-measures/SimulationOutputReport/measure.xml
+++ b/hpxml-measures/SimulationOutputReport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>070de322-e51e-4964-b882-ca8cb2bdd0fa</version_id>
-  <version_modified>20200210T145949Z</version_modified>
+  <version_id>6d329778-a11f-4a8f-86c3-82376bf1edb7</version_id>
+  <version_modified>20200224T000259Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -422,7 +422,7 @@
       <filename>output_report_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>2E8D6F3B</checksum>
+      <checksum>EA89E92D</checksum>
     </file>
     <file>
       <version>
@@ -433,7 +433,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>B26B0F5A</checksum>
+      <checksum>77105D44</checksum>
     </file>
   </files>
 </measure>

--- a/hpxml-measures/tasks.rb
+++ b/hpxml-measures/tasks.rb
@@ -1890,6 +1890,12 @@ def get_hpxml_file_heating_systems_values(hpxml_file, heating_systems_values)
     heating_systems_values << heating_systems_values[0].dup
     heating_systems_values[2][:id] = "HeatingSystem3"
     heating_systems_values[2][:distribution_system_idref] = "HVACDistribution3" unless heating_systems_values[2][:distribution_system_idref].nil?
+    if ['hvac_multiple/base-hvac-boiler-gas-only-x3.xml'].include? hpxml_file
+      # Test a file where sum is slightly greater than 1
+      heating_systems_values[0][:fraction_heat_load_served] = 0.33
+      heating_systems_values[1][:fraction_heat_load_served] = 0.33
+      heating_systems_values[2][:fraction_heat_load_served] = 0.35
+    end
   elsif hpxml_file.include? 'hvac_partial' and not heating_systems_values.nil? and heating_systems_values.size > 0
     heating_systems_values[0][:heating_capacity] /= 3.0
     heating_systems_values[0][:fraction_heat_load_served] = 0.333

--- a/hpxml-measures/workflow/run_simulation.rb
+++ b/hpxml-measures/workflow/run_simulation.rb
@@ -153,7 +153,7 @@ OptionParser.new do |opts|
   opts.on('-v', '--version', 'Reports the version') do |t|
     options[:version] = true
   end
-  
+
   options[:debug] = false
   opts.on('-d', '--debug') do |t|
     options[:debug] = true

--- a/hpxml-measures/workflow/sample_files/hvac_multiple/base-hvac-boiler-gas-only-x3.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_multiple/base-hvac-boiler-gas-only-x3.xml
@@ -249,7 +249,7 @@
                 <Units>AFUE</Units>
                 <Value>0.92</Value>
               </AnnualHeatingEfficiency>
-              <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
+              <FractionHeatLoadServed>0.33</FractionHeatLoadServed>
               <ElectricAuxiliaryEnergy>66.66666666666667</ElectricAuxiliaryEnergy>
             </HeatingSystem>
             <HeatingSystem>
@@ -264,7 +264,7 @@
                 <Units>AFUE</Units>
                 <Value>0.92</Value>
               </AnnualHeatingEfficiency>
-              <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
+              <FractionHeatLoadServed>0.33</FractionHeatLoadServed>
               <ElectricAuxiliaryEnergy>66.66666666666667</ElectricAuxiliaryEnergy>
             </HeatingSystem>
             <HeatingSystem>
@@ -279,7 +279,7 @@
                 <Units>AFUE</Units>
                 <Value>0.92</Value>
               </AnnualHeatingEfficiency>
-              <FractionHeatLoadServed>0.333</FractionHeatLoadServed>
+              <FractionHeatLoadServed>0.35</FractionHeatLoadServed>
               <ElectricAuxiliaryEnergy>66.66666666666667</ElectricAuxiliaryEnergy>
             </HeatingSystem>
           </HVACPlant>


### PR DESCRIPTION
## Pull Request Description

Fixes a simulation error when `FractionHeatLoadServed` or `FractionCoolLoadServed` sum to slightly greater than 1. 

The simulation was already successful if they sum to slightly less than 1. And `FractionDHWLoadServed` already works in both situations.

## Checklist

Not all may apply:

- [x] OS-HPXML git subtree has been pulled
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
