### PR TITLE
Hot water outputs

### DIFF
--- a/docs/source/outputs.rst
+++ b/docs/source/outputs.rst
@@ -90,6 +90,9 @@ Component loads are currently disaggregated as follows:
    Internal Gains          Heat gains/losses due to appliances, lighting, plug loads, water heater tank losses, etc. in the conditioned space
    ======================= =======================================================================================================================================
 
+8. **Hot Water Uses**
+Values, in gallons, are reported for hot water usage by end use.
+End uses include clothes washers, dishwashers, fixtures, and distribution waste.
 
 See the `example ERIRatedHome.csv <https://github.com/NREL/OpenStudio-ERI/tree/master/workflow/sample_results/results/ERIRatedHome.csv>`_.
 
@@ -105,6 +108,7 @@ Depending on the hourly output types requested, CSV files may include:
 - ``enduses``: Energy use for each end use type (in kBtu for fossil fuels and kWh for electricity).
 - ``loads``: Heating and cooling loads (in kBtu) for the building.
 - ``componentloads``: Heating and cooling loads (in kBtu) disaggregated by component (e.g., Walls, Windows, Infiltration, Ducts, etc.).
+- ``hotwater``: Water use for each end use type (in gallons).
 
 See the `example ERIRatedHome_Hourly.csv <https://github.com/NREL/OpenStudio-ERI/tree/master/workflow/sample_results/results/ERIRatedHome_Hourly.csv>`_.
 

--- a/hpxml-measures/HPXMLtoOpenStudio/measure.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/measure.rb
@@ -342,7 +342,6 @@ class OSModel
       @hpxml.building_construction.conditioned_building_volume = @cfa * @hpxml.building_construction.average_ceiling_height
     end
     @cvolume = @hpxml.building_construction.conditioned_building_volume
-    @nbaths = @hpxml.building_construction.number_of_bathrooms
     if @hpxml.building_construction.number_of_bathrooms.nil?
       @nbaths = Waterheater.get_default_num_bathrooms(@nbeds)
     else
@@ -480,6 +479,21 @@ class OSModel
         sqft_by_gal = surface_area / act_vol # sqft/gal
         water_heating_system.standby_loss = (2.9721 * sqft_by_gal - 0.4732).round(3) # linear equation assuming a constant u, F/hr
       end
+      if (water_heating_system.water_heater_type == HPXML::WaterHeaterTypeStorage)
+        if water_heating_system.heating_capacity.nil?
+          water_heating_system.heating_capacity = Waterheater.get_default_heating_capacity(water_heating_system.fuel_type, @nbeds, @hpxml.water_heating_systems.size, @nbaths) * 1000.0
+        end
+        if water_heating_system.tank_volume.nil?
+          water_heating_system.tank_volume = Waterheater.get_default_tank_volume(water_heating_system.fuel_type, @nbeds, @nbaths)
+        end
+        if water_heating_system.recovery_efficiency.nil?
+          ef = water_heating_system.energy_factor
+          if ef.nil?
+            ef = Waterheater.calc_ef_from_uef(water_heating_system.uniform_energy_factor, water_heating_system.water_heater_type, water_heating_system.fuel_type)
+          end
+          water_heating_system.recovery_efficiency = Waterheater.get_default_recovery_efficiency(water_heating_system.fuel_type, ef)
+        end
+      end
       if water_heating_system.location.nil?
         water_heating_system.location = Waterheater.get_default_location(@hpxml, @hpxml.climate_and_risk_zones.iecc_zone)
       end
@@ -492,12 +506,34 @@ class OSModel
         if hot_water_distribution.standard_piping_length.nil?
           hot_water_distribution.standard_piping_length = HotWaterAndAppliances.get_default_std_pipe_length(@has_uncond_bsmnt, @cfa, @ncfl)
         end
+      elsif hot_water_distribution.system_type == HPXML::DHWDistTypeRecirc
+        if hot_water_distribution.recirculation_piping_length.nil?
+          hot_water_distribution.recirculation_piping_length = HotWaterAndAppliances.get_default_recirc_loop_length(HotWaterAndAppliances.get_default_std_pipe_length(@has_uncond_bsmnt, @cfa, @ncfl))
+        end
+        if hot_water_distribution.recirculation_branch_piping_length.nil?
+          hot_water_distribution.recirculation_branch_piping_length = HotWaterAndAppliances.get_default_recirc_branch_loop_length()
+        end
+        if hot_water_distribution.recirculation_pump_power.nil?
+          hot_water_distribution.recirculation_pump_power = HotWaterAndAppliances.get_default_recirc_pump_power()
+        end
       end
     end
 
     # Default water fixtures
     if @hpxml.water_heating.water_fixtures_usage_multiplier.nil?
       @hpxml.water_heating.water_fixtures_usage_multiplier = 1.0
+    end
+
+    # Default solar thermal systems
+    if @hpxml.solar_thermal_systems.size > 0
+      solar_thermal_system = @hpxml.solar_thermal_systems[0]
+      collector_area = solar_thermal_system.collector_area
+
+      if not collector_area.nil? # Detailed solar water heater
+        if solar_thermal_system.storage_volume.nil?
+          solar_thermal_system.storage_volume = Waterheater.calc_default_solar_thermal_system_storage_volume(collector_area)
+        end
+      end
     end
 
     # Default kitchen fan

--- a/hpxml-measures/HPXMLtoOpenStudio/measure.xml
+++ b/hpxml-measures/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>fcc882d8-8921-4415-afaa-1f60af08acf0</version_id>
-  <version_modified>20200423T150854Z</version_modified>
+  <version_id>4367f93b-61a2-4cbe-8169-efc7055cce2b</version_id>
+  <version_modified>20200424T181253Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -402,12 +402,6 @@
       <checksum>54943094</checksum>
     </file>
     <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B25F263A</checksum>
-    </file>
-    <file>
       <filename>lighting.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -420,28 +414,10 @@
       <checksum>6AB64ECB</checksum>
     </file>
     <file>
-      <filename>hotwater_appliances.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>D9C13D5F</checksum>
-    </file>
-    <file>
-      <filename>constructions.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C4B05406</checksum>
-    </file>
-    <file>
       <filename>BaseElements.xsd</filename>
       <filetype>xsd</filetype>
       <usage_type>resource</usage_type>
       <checksum>CE0F105B</checksum>
-    </file>
-    <file>
-      <filename>waterheater.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>DD52784E</checksum>
     </file>
     <file>
       <filename>hvac.rb</filename>
@@ -456,16 +432,22 @@
       <checksum>E07814AC</checksum>
     </file>
     <file>
-      <filename>EPvalidator.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>34B9D4BA</checksum>
-    </file>
-    <file>
       <filename>hpxml.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>D2131124</checksum>
+    </file>
+    <file>
+      <filename>waterheater.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>8CF1A2DD</checksum>
+    </file>
+    <file>
+      <filename>EPvalidator.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>6C7529E8</checksum>
     </file>
     <file>
       <version>
@@ -476,7 +458,25 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>82BBAB8B</checksum>
+      <checksum>D8070AF2</checksum>
+    </file>
+    <file>
+      <filename>constructions.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>99D52803</checksum>
+    </file>
+    <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>61AD1556</checksum>
+    </file>
+    <file>
+      <filename>hotwater_appliances.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>1FB97E55</checksum>
     </file>
   </files>
 </measure>

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/EPvalidator.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/EPvalidator.rb
@@ -535,16 +535,12 @@ class EnergyPlusValidator
 
       ## [WHType=Tank]
       '/HPXML/Building/BuildingDetails/Systems/WaterHeating/WaterHeatingSystem[WaterHeaterType="storage water heater"]' => {
-        'FuelType[text()="natural gas" or text()="fuel oil" or text()="propane" or text()="electricity" or text()="wood"]' => one, # If not electricity, see [WHType=FuelTank]
-        'TankVolume' => one,
-        'HeatingCapacity' => one,
+        'FuelType[text()="natural gas" or text()="fuel oil" or text()="propane" or text()="electricity" or text()="wood"]' => one,
+        'TankVolume' => zero_or_one,
+        'HeatingCapacity' => zero_or_one,
         'EnergyFactor | UniformEnergyFactor' => one,
+        'RecoveryEfficiency' => zero_or_one,
         'WaterHeaterInsulation/Jacket/JacketRValue' => zero_or_one, # Capable to model tank wrap insulation
-      },
-
-      ## [WHType=FuelTank]
-      '/HPXML/Building/BuildingDetails/Systems/WaterHeating/WaterHeatingSystem[WaterHeaterType="storage water heater" and FuelType!="electricity"]' => {
-        'RecoveryEfficiency' => one,
       },
 
       ## [WHType=Tankless]
@@ -597,9 +593,9 @@ class EnergyPlusValidator
       ## [HWDistType=Recirculation]
       '/HPXML/Building/BuildingDetails/Systems/WaterHeating/HotWaterDistribution/SystemType/Recirculation' => {
         'ControlType[text()="manual demand control" or text()="presence sensor demand control" or text()="temperature" or text()="timer" or text()="no control"]' => one,
-        'RecirculationPipingLoopLength' => one,
-        'BranchPipingLoopLength' => one,
-        'PumpPower' => one,
+        'RecirculationPipingLoopLength' => zero_or_one,
+        'BranchPipingLoopLength' => zero_or_one,
+        'PumpPower' => zero_or_one,
       },
 
       ## [DrainWaterHeatRecovery]
@@ -632,7 +628,7 @@ class EnergyPlusValidator
         'CollectorTilt' => one,
         'CollectorRatedOpticalEfficiency' => one,
         'CollectorRatedThermalLosses' => one,
-        'StorageVolume' => one,
+        'StorageVolume' => zero_or_one,
         'ConnectedTo' => one, # WaterHeatingSystem (any type but space-heating boiler)
       },
 

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/constants.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/constants.rb
@@ -223,6 +223,10 @@ class Constants
     return 'dishwasher'
   end
 
+  def self.ObjectNameDistributionWaste
+    return 'dhw distribution waste'
+  end
+
   def self.ObjectNameDucts
     return 'ducts'
   end
@@ -369,6 +373,10 @@ class Constants
 
   def self.ObjectNameUnitHeater
     return 'unit heater'
+  end
+
+  def self.ObjectNameWater
+    return 'water'
   end
 
   def self.ObjectNameWaterHeater

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/constructions.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/constructions.rb
@@ -9,7 +9,7 @@ class Constructions
   def self.apply_wood_stud_wall(model, surfaces, constr_name,
                                 cavity_r, install_grade, cavity_depth_in, cavity_filled,
                                 framing_factor, drywall_thick_in, osb_thick_in,
-                                rigid_r, mat_ext_finish)
+                                rigid_r, mat_ext_finish, otherside_drywall_thick_in = 0)
 
     return if surfaces.empty?
 
@@ -49,6 +49,9 @@ class Constructions
       constr.add_layer(mat_ext_finish)
     else # interior wall
       constr.add_layer(Material.AirFilmVertical)
+    end
+    if otherside_drywall_thick_in > 0 # E.g., interior partition wall
+      constr.add_layer(Material.GypsumWall(otherside_drywall_thick_in))
     end
     if not mat_rigid.nil?
       constr.add_layer(mat_rigid)
@@ -971,7 +974,7 @@ class Constructions
 
     Constructions.apply_wood_stud_wall(model, imdefs, constr_name,
                                        0, 1, 3.5, false, 0.16,
-                                       drywall_thick_in, 0, 0, nil)
+                                       drywall_thick_in, 0, 0, nil, drywall_thick_in)
   end
 
   def self.apply_furniture(model, mass_lb_per_sqft, density_lb_per_cuft,

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/hotwater_appliances.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/hotwater_appliances.rb
@@ -132,58 +132,40 @@ class HotWaterAndAppliances
     end
 
     if not dist_type.nil?
-      # Fixtures (showers, sinks, baths) + distribution losses
+      # Fixtures (showers, sinks, baths) + distribution waste
       fx_gpd = get_fixtures_gpd(eri_version, nbeds, fixtures_all_low_flow, daily_mw_fractions)
-      w_gpd = get_dist_waste_gpd(eri_version, nbeds, has_uncond_bsmnt, cfa, ncfl, dist_type, pipe_r, std_pipe_length, recirc_branch_length, fixtures_all_low_flow)
-      fx_sens_btu, fx_lat_btu = get_fixtures_gains_sens_lat(nbeds)
-
       fx_gpd *= fixtures_usage_multiplier
-      w_gpd *= fixtures_usage_multiplier
-      fx_sens_btu *= fixtures_usage_multiplier
-      fx_lat_btu *= fixtures_usage_multiplier
-
-      disaggregate_sinks_showers_baths = false
-      if disaggregate_sinks_showers_baths
-        fx_names = [Constants.ObjectNameShower,
-                    Constants.ObjectNameSink,
-                    Constants.ObjectNameBath]
-      else
-        fx_names = [Constants.ObjectNameFixtures]
-      end
-
-      fx_schedules = {}
-      fx_names.each do |fx_name|
-        fx_schedules[fx_name] = HotWaterSchedule.new(model, fx_name, nbeds)
-      end
-
-      # Calculate sum_total_flow
-      sum_total_flow = 0.0
-      fx_schedules.each do |fx_name, fx_schedule|
-        sum_total_flow += fx_schedule.totalFlow
-      end
+      w_gpd = get_dist_waste_gpd(eri_version, nbeds, has_uncond_bsmnt, cfa, ncfl, dist_type, pipe_r, std_pipe_length, recirc_branch_length, fixtures_all_low_flow)
 
       mw_schedule = OpenStudio::Model::ScheduleConstant.new(model)
       mw_schedule.setValue(UnitConversions.convert(t_mix, 'F', 'C'))
       Schedule.set_schedule_type_limits(model, mw_schedule, Constants.ScheduleTypeLimitsTemperature)
 
-      fx_schedules.each do |fx_name, fx_schedule|
-        fx_name_sens = "#{fx_name} Sensible"
-        fx_name_lat = "#{fx_name} Latent"
+      water_name = Constants.ObjectNameWater
+      water_schedule = HotWaterSchedule.new(model, Constants.ObjectNameFixtures, nbeds)
 
-        fx_schedule = fx_schedules[fx_name]
-        fx_frac = fx_schedule.totalFlow / sum_total_flow
-
-        fx_peak_flow = fx_schedule.calcPeakFlowFromDailygpm((fx_gpd + w_gpd) * fx_frac)
-        fx_design_level_sens = fx_schedule.calcDesignLevelFromDailykWh(UnitConversions.convert(fx_sens_btu * fx_frac, 'Btu', 'kWh') / 365.0)
-        fx_design_level_lat = fx_schedule.calcDesignLevelFromDailykWh(UnitConversions.convert(fx_lat_btu * fx_frac, 'Btu', 'kWh') / 365.0)
-
-        dhw_loop_fracs.each do |sys_id, dhw_load_frac|
-          dhw_loop = dhw_loops[sys_id]
-          add_water_use_equipment(model, fx_name, fx_peak_flow * dhw_load_frac, fx_schedule.schedule, mw_schedule, water_use_connections[dhw_loop])
-        end
-        add_other_equipment(model, fx_name_sens, living_space, fx_design_level_sens, 1.0, 0.0, fx_schedule.schedule, nil)
-        add_other_equipment(model, fx_name_lat, living_space, fx_design_level_lat, 0.0, 1.0, fx_schedule.schedule, nil)
+      # Fixtures
+      fx_name = Constants.ObjectNameFixtures
+      fx_peak_flow = water_schedule.calcPeakFlowFromDailygpm(fx_gpd)
+      dhw_loop_fracs.each do |sys_id, dhw_load_frac|
+        dhw_loop = dhw_loops[sys_id]
+        add_water_use_equipment(model, fx_name, fx_peak_flow * dhw_load_frac, water_schedule.schedule, mw_schedule, water_use_connections[dhw_loop])
       end
+
+      # Distribution waste
+      dist_water_name = Constants.ObjectNameDistributionWaste
+      dist_water_peak_flow = water_schedule.calcPeakFlowFromDailygpm(w_gpd)
+      dhw_loop_fracs.each do |sys_id, dhw_load_frac|
+        dhw_loop = dhw_loops[sys_id]
+        add_water_use_equipment(model, dist_water_name, dist_water_peak_flow * dhw_load_frac, water_schedule.schedule, mw_schedule, water_use_connections[dhw_loop])
+      end
+
+      # Internal gains
+      water_sens_btu, water_lat_btu = get_water_gains_sens_lat(nbeds)
+      water_design_level_sens = water_schedule.calcDesignLevelFromDailykWh(UnitConversions.convert(water_sens_btu, 'Btu', 'kWh') / 365.0)
+      water_design_level_lat = water_schedule.calcDesignLevelFromDailykWh(UnitConversions.convert(water_lat_btu, 'Btu', 'kWh') / 365.0)
+      add_other_equipment(model, "#{water_name} Sensible", living_space, water_design_level_sens, 1.0, 0.0, water_schedule.schedule, nil)
+      add_other_equipment(model, "#{water_name} Latent", living_space, water_design_level_lat, 0.0, 1.0, water_schedule.schedule, nil)
 
       # Recirculation pump
       dist_pump_annual_kwh = get_hwdist_recirc_pump_energy(dist_type, recirc_control_type, recirc_pump_power)
@@ -523,6 +505,14 @@ class HotWaterAndAppliances
     return 2.0 * std_pipe_length - 20.0 # Eq. 4.2-17 (refLoopL)
   end
 
+  def self.get_default_recirc_branch_loop_length()
+    return 10.0  # ft
+  end
+
+  def self.get_default_recirc_pump_power()
+    return 50.0  # Watts
+  end
+
   private
 
   def self.add_electric_equipment(model, obj_name, space, design_level_w, frac_sens, frac_lat, schedule)
@@ -692,7 +682,7 @@ class HotWaterAndAppliances
     return f_eff * ref_f_gpd
   end
 
-  def self.get_fixtures_gains_sens_lat(nbeds)
+  def self.get_water_gains_sens_lat(nbeds)
     # Table 4.2.2(3). Internal Gains for Reference Homes
     sens_gains = -1227.0 - 409.0 * nbeds # Btu/day
     lat_gains = 1245.0 + 415.0 * nbeds # Btu/day

--- a/hpxml-measures/SimulationOutputReport/measure.rb
+++ b/hpxml-measures/SimulationOutputReport/measure.rb
@@ -56,6 +56,12 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     arg.setDefaultValue(false)
     args << arg
 
+    arg = OpenStudio::Measure::OSArgument::makeBoolArgument('include_timeseries_hot_water_uses', true)
+    arg.setDisplayName('Generate Timeseries Output: Hot Water Uses')
+    arg.setDescription('Generates timeseries hot water usages for each end use.')
+    arg.setDefaultValue(false)
+    args << arg
+
     arg = OpenStudio::Measure::OSArgument::makeBoolArgument('include_timeseries_total_loads', true)
     arg.setDisplayName('Generate Timeseries Output: Total Loads')
     arg.setDescription('Generates timeseries heating/cooling loads.')
@@ -132,6 +138,11 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       result << OpenStudio::IdfObject.load("Output:Meter,#{meter},runperiod;").get
     end
 
+    # Add hot water use outputs
+    @hot_water_uses.each do |hot_water_type, hot_water|
+      result << OpenStudio::IdfObject.load('Output:Variable,*,Water Use Equipment Hot Water Volume,runperiod;').get
+    end
+
     # Add peak electricity outputs
     @peak_fuels.each do |key, peak_fuel|
       result << OpenStudio::IdfObject.load("Output:Table:Monthly,#{peak_fuel.report},2,#{peak_fuel.meter},HoursPositive,Electricity:Facility,MaximumDuringHoursShown;").get
@@ -160,6 +171,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     include_timeseries_zone_temperatures = runner.getBoolArgumentValue('include_timeseries_zone_temperatures', user_arguments)
     include_timeseries_fuel_consumptions = runner.getBoolArgumentValue('include_timeseries_fuel_consumptions', user_arguments)
     include_timeseries_end_use_consumptions = runner.getBoolArgumentValue('include_timeseries_end_use_consumptions', user_arguments)
+    include_timeseries_hot_water_uses = runner.getBoolArgumentValue('include_timeseries_hot_water_uses', user_arguments)
     include_timeseries_total_loads = runner.getBoolArgumentValue('include_timeseries_total_loads', user_arguments)
     include_timeseries_component_loads = runner.getBoolArgumentValue('include_timeseries_component_loads', user_arguments)
 
@@ -190,6 +202,10 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       add_object_output_variables(timeseries_frequency).each do |outvar|
         result << outvar
       end
+    end
+
+    if include_timeseries_hot_water_uses
+      result << OpenStudio::IdfObject.load("Output:Variable,*,Water Use Equipment Hot Water Volume,#{timeseries_frequency};").get
     end
 
     if include_timeseries_total_loads
@@ -224,6 +240,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     include_timeseries_zone_temperatures = runner.getBoolArgumentValue('include_timeseries_zone_temperatures', user_arguments)
     include_timeseries_fuel_consumptions = runner.getBoolArgumentValue('include_timeseries_fuel_consumptions', user_arguments)
     include_timeseries_end_use_consumptions = runner.getBoolArgumentValue('include_timeseries_end_use_consumptions', user_arguments)
+    include_timeseries_hot_water_uses = runner.getBoolArgumentValue('include_timeseries_hot_water_uses', user_arguments)
     include_timeseries_total_loads = runner.getBoolArgumentValue('include_timeseries_total_loads', user_arguments)
     include_timeseries_component_loads = runner.getBoolArgumentValue('include_timeseries_component_loads', user_arguments)
 
@@ -278,6 +295,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
                           include_timeseries_zone_temperatures,
                           include_timeseries_fuel_consumptions,
                           include_timeseries_end_use_consumptions,
+                          include_timeseries_hot_water_uses,
                           include_timeseries_total_loads,
                           include_timeseries_component_loads)
     if not check_for_errors(runner, outputs)
@@ -292,6 +310,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
                                     include_timeseries_zone_temperatures,
                                     include_timeseries_fuel_consumptions,
                                     include_timeseries_end_use_consumptions,
+                                    include_timeseries_hot_water_uses,
                                     include_timeseries_total_loads,
                                     include_timeseries_component_loads)
 
@@ -327,6 +346,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
                   include_timeseries_zone_temperatures,
                   include_timeseries_fuel_consumptions,
                   include_timeseries_end_use_consumptions,
+                  include_timeseries_hot_water_uses,
                   include_timeseries_total_loads,
                   include_timeseries_component_loads)
     outputs = {}
@@ -360,7 +380,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
 
     # Fuel Uses
     @fuels.each do |fuel_type, fuel|
-      fuel.annual_output = get_report_meter_data_annual_mbtu(fuel.meter)
+      fuel.annual_output = get_report_meter_data_annual(fuel.meter)
       if include_timeseries_fuel_consumptions
         fuel.timeseries_output = get_report_meter_data_timeseries('', fuel.meter, UnitConversions.convert(1.0, 'J', fuel.timeseries_units), 0, timeseries_frequency)
       end
@@ -375,7 +395,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     @loads.each do |load_type, load|
       next if load.ems_variable.nil?
 
-      load.annual_output = get_report_variable_data_annual_mbtu(['EMS'], ["#{load.ems_variable}_annual_outvar"])
+      load.annual_output = get_report_variable_data_annual(['EMS'], ["#{load.ems_variable}_annual_outvar"])
       if include_timeseries_total_loads
         load.timeseries_output = get_report_variable_data_timeseries(['EMS'], ["#{load.ems_variable}_timeseries_outvar"], UnitConversions.convert(1.0, 'J', load.timeseries_units), 0, timeseries_frequency)
       end
@@ -383,7 +403,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
 
     # Component Loads
     @component_loads.each do |key, comp_load|
-      comp_load.annual_output = get_report_variable_data_annual_mbtu(['EMS'], ["#{comp_load.ems_variable}_annual_outvar"])
+      comp_load.annual_output = get_report_variable_data_annual(['EMS'], ["#{comp_load.ems_variable}_annual_outvar"])
       if include_timeseries_component_loads
         comp_load.timeseries_output = get_report_variable_data_timeseries(['EMS'], ["#{comp_load.ems_variable}_timeseries_outvar"], UnitConversions.convert(1.0, 'J', comp_load.timeseries_units), 0, timeseries_frequency)
       end
@@ -391,7 +411,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
 
     # Unmet loads (heating/cooling energy delivered by backup ideal air system)
     @unmet_loads.each do |load_type, unmet_load|
-      unmet_load.annual_output = get_report_meter_data_annual_mbtu(unmet_load.meter)
+      unmet_load.annual_output = get_report_meter_data_annual(unmet_load.meter)
     end
 
     # Peak Building Space Heating/Cooling Loads (total heating/cooling energy delivered including backup ideal air system)
@@ -404,7 +424,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       next if end_use.meter.nil?
 
       fuel_type, end_use_type = key
-      end_use.annual_output = get_report_meter_data_annual_mbtu(end_use.meter)
+      end_use.annual_output = get_report_meter_data_annual(end_use.meter)
       if (end_use_type == EUT::PV) && (@end_uses[key].annual_output > 0)
         end_use.annual_output *= -1.0
       end
@@ -417,6 +437,14 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       end_use.timeseries_output = get_report_meter_data_timeseries('', end_use.meter, timeseries_unit_conv, 0, timeseries_frequency)
     end
 
+    # Hot Water Uses
+    @hot_water_uses.each do |hot_water_type, hot_water|
+      hot_water.annual_output = get_report_variable_data_annual([hot_water.key.upcase], [hot_water.variable], UnitConversions.convert(1.0, 'm^3', hot_water.annual_units))
+      if include_timeseries_hot_water_uses
+        hot_water.timeseries_output = get_report_variable_data_timeseries([hot_water.key.upcase], [hot_water.variable], UnitConversions.convert(1.0, 'm^3', hot_water.timeseries_units), 0, timeseries_frequency)
+      end
+    end
+
     # Space Heating (by System)
     dfhp_loads = get_dfhp_loads(outputs) # Calculate dual-fuel heat pump load
     outputs[:hpxml_heat_sys_ids].each do |sys_id|
@@ -427,7 +455,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       @fuels.each do |fuel_type, fuel|
         end_use = @end_uses[[fuel_type, EUT::Heating]]
         vars = get_all_var_keys(end_use.variable)
-        end_use.annual_output_by_system[sys_id] = get_report_variable_data_annual_mbtu(keys, vars)
+        end_use.annual_output_by_system[sys_id] = get_report_variable_data_annual(keys, vars)
         if include_timeseries_end_use_consumptions
           end_use.timeseries_output_by_system[sys_id] = get_report_variable_data_timeseries(keys, vars, UnitConversions.convert(1.0, 'J', end_use.timeseries_units), 0, timeseries_frequency)
         end
@@ -435,7 +463,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
 
       # Disaggregated Fan/Pump Energy Use
       end_use = @end_uses[[FT::Elec, EUT::HeatingFanPump]]
-      end_use.annual_output_by_system[sys_id] = get_report_variable_data_annual_mbtu(['EMS'], ep_output_names.select { |name| name.end_with?(Constants.ObjectNameFanPumpDisaggregatePrimaryHeat) || name.end_with?(Constants.ObjectNameFanPumpDisaggregateBackupHeat) })
+      end_use.annual_output_by_system[sys_id] = get_report_variable_data_annual(['EMS'], ep_output_names.select { |name| name.end_with?(Constants.ObjectNameFanPumpDisaggregatePrimaryHeat) || name.end_with?(Constants.ObjectNameFanPumpDisaggregateBackupHeat) })
       if include_timeseries_end_use_consumptions
         end_use.timeseries_output_by_system[sys_id] = get_report_variable_data_timeseries(['EMS'], ep_output_names.select { |name| name.end_with?(Constants.ObjectNameFanPumpDisaggregatePrimaryHeat) || name.end_with?(Constants.ObjectNameFanPumpDisaggregateBackupHeat) }, UnitConversions.convert(1.0, 'J', end_use.timeseries_units), 0, timeseries_frequency)
       end
@@ -454,14 +482,14 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       # End Uses
       end_use = @end_uses[[FT::Elec, EUT::Cooling]]
       vars = get_all_var_keys(end_use.variable)
-      end_use.annual_output_by_system[sys_id] = get_report_variable_data_annual_mbtu(keys, vars)
+      end_use.annual_output_by_system[sys_id] = get_report_variable_data_annual(keys, vars)
       if include_timeseries_end_use_consumptions
         end_use.timeseries_output_by_system[sys_id] = get_report_variable_data_timeseries(keys, vars, UnitConversions.convert(1.0, 'J', end_use.timeseries_units), 0, timeseries_frequency)
       end
 
       # Disaggregated Fan/Pump Energy Use
       end_use = @end_uses[[FT::Elec, EUT::CoolingFanPump]]
-      end_use.annual_output_by_system[sys_id] = get_report_variable_data_annual_mbtu(['EMS'], ep_output_names.select { |name| name.end_with? Constants.ObjectNameFanPumpDisaggregateCool })
+      end_use.annual_output_by_system[sys_id] = get_report_variable_data_annual(['EMS'], ep_output_names.select { |name| name.end_with? Constants.ObjectNameFanPumpDisaggregateCool })
       if include_timeseries_end_use_consumptions
         end_use.timeseries_output_by_system[sys_id] = get_report_variable_data_timeseries(['EMS'], ep_output_names.select { |name| name.end_with? Constants.ObjectNameFanPumpDisaggregateCool }, UnitConversions.convert(1.0, 'J', end_use.timeseries_units), 0, timeseries_frequency)
       end
@@ -478,7 +506,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     ep_output_name = @hvac_map[outputs[:hpxml_dehumidifier_id]]
     if not ep_output_name.nil?
       keys = ep_output_name.map(&:upcase)
-      end_use.annual_output = get_report_variable_data_annual_mbtu(keys, vars)
+      end_use.annual_output = get_report_variable_data_annual(keys, vars)
       if include_timeseries_end_use_consumptions
         end_use.timeseries_output = get_report_variable_data_timeseries(keys, vars, UnitConversions.convert(1.0, 'J', end_use.timeseries_units), 0, timeseries_frequency)
       end
@@ -502,7 +530,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
 
           vars = get_all_var_keys(end_use.variable)
 
-          end_use.annual_output_by_system[sys_id] = get_report_variable_data_annual_mbtu(keys, vars)
+          end_use.annual_output_by_system[sys_id] = get_report_variable_data_annual(keys, vars)
           if include_timeseries_end_use_consumptions
             end_use.timeseries_output_by_system[sys_id] = get_report_variable_data_timeseries(keys, vars, UnitConversions.convert(1.0, 'J', end_use.timeseries_units), 0, timeseries_frequency)
           end
@@ -510,7 +538,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       end
 
       # Loads
-      @loads[LT::HotWaterDelivered].annual_output_by_system[sys_id] = get_report_variable_data_annual_mbtu(keys, get_all_var_keys(@loads[LT::HotWaterDelivered].variable))
+      @loads[LT::HotWaterDelivered].annual_output_by_system[sys_id] = get_report_variable_data_annual(keys, get_all_var_keys(@loads[LT::HotWaterDelivered].variable))
 
       # Combi boiler water system
       hvac_id = get_combi_hvac_id(sys_id)
@@ -524,7 +552,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
 
           combi_hw_vars = ep_output_names.select { |name| name.include? Constants.ObjectNameCombiWaterHeatingEnergy(nil) }
 
-          hw_energy = get_report_variable_data_annual_mbtu(['EMS'], combi_hw_vars)
+          hw_energy = get_report_variable_data_annual(['EMS'], combi_hw_vars)
           hw_end_use.annual_output_by_system[sys_id] += hw_energy
           htg_end_use.annual_output_by_system[hvac_id] -= hw_energy
           if include_timeseries_end_use_consumptions
@@ -546,8 +574,8 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
         ec_vars = ep_output_names.select { |name| name.include? Constants.ObjectNameWaterHeaterAdjustment(nil) }
         dsh_vars = ep_output_names.select { |name| name.include? Constants.ObjectNameDesuperheaterEnergy(nil) }
 
-        ec_adj = get_report_variable_data_annual_mbtu(['EMS'], ec_vars)
-        dsh_adj = get_report_variable_data_annual_mbtu(['EMS'], dsh_vars)
+        ec_adj = get_report_variable_data_annual(['EMS'], ec_vars)
+        dsh_adj = get_report_variable_data_annual(['EMS'], dsh_vars)
         break if ec_adj + dsh_adj == 0 # No adjustment
 
         end_use.annual_output_by_system[sys_id] += ec_adj + dsh_adj
@@ -592,15 +620,15 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     end
 
     # Hot Water Load - Solar Thermal
-    @loads[LT::HotWaterSolarThermal].annual_output = get_report_variable_data_annual_mbtu(solar_keys, get_all_var_keys(OutputVars.WaterHeaterLoadSolarThermal))
+    @loads[LT::HotWaterSolarThermal].annual_output = get_report_variable_data_annual(solar_keys, get_all_var_keys(OutputVars.WaterHeaterLoadSolarThermal))
     @loads[LT::HotWaterSolarThermal].annual_output *= -1 if @loads[LT::HotWaterSolarThermal].annual_output != 0
 
     # Hot Water Load - Desuperheater
-    @loads[LT::HotWaterDesuperheater].annual_output = get_report_variable_data_annual_mbtu(['EMS'], desuperheater_vars)
+    @loads[LT::HotWaterDesuperheater].annual_output = get_report_variable_data_annual(['EMS'], desuperheater_vars)
     @loads[LT::HotWaterDesuperheater].annual_output *= -1.0 if @loads[LT::HotWaterDesuperheater].annual_output != 0
 
     # Hot Water Load - Tank Losses (excluding solar storage tank)
-    @loads[LT::HotWaterTankLosses].annual_output = get_report_variable_data_annual_mbtu(solar_keys, ['Water Heater Heat Loss Energy'], not_key: true)
+    @loads[LT::HotWaterTankLosses].annual_output = get_report_variable_data_annual(solar_keys, ['Water Heater Heat Loss Energy'], not_key: true)
     @loads[LT::HotWaterTankLosses].annual_output *= -1.0 if @loads[LT::HotWaterTankLosses].annual_output < 0
 
     # Apply solar fraction to load for simple solar water heating systems
@@ -721,6 +749,10 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     @component_loads.each do |load_type, load|
       results_out << ["#{load.name} (#{load.annual_units})", load.annual_output.round(2)]
     end
+    results_out << [line_break]
+    @hot_water_uses.each do |hot_water_type, hot_water|
+      results_out << ["#{hot_water.name} (#{hot_water.annual_units})", hot_water.annual_output.round(2)]
+    end
 
     CSV.open(csv_path, 'wb') { |csv| results_out.to_a.each { |elem| csv << elem } }
     runner.registerInfo("Wrote annual output results to #{csv_path}.")
@@ -808,6 +840,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
                                       include_timeseries_zone_temperatures,
                                       include_timeseries_fuel_consumptions,
                                       include_timeseries_end_use_consumptions,
+                                      include_timeseries_hot_water_uses,
                                       include_timeseries_total_loads,
                                       include_timeseries_component_loads)
     # Time column
@@ -836,6 +869,11 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     else
       end_use_data = []
     end
+    if include_timeseries_hot_water_uses
+      hot_water_use_data = @hot_water_uses.values.select { |x| !x.timeseries_output.empty? }.map { |x| [x.name, x.timeseries_units] + x.timeseries_output.map { |v| v.round(2) } }
+    else
+      hot_water_use_data = []
+    end
     if include_timeseries_zone_temperatures
       zone_temps_data = @zone_temps.values.select { |x| !x.timeseries_output.empty? }.map { |x| [x.name, x.timeseries_units] + x.timeseries_output.map { |v| v.round(2) } }
     else
@@ -852,10 +890,10 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       comp_loads_data = []
     end
 
-    return if fuel_data.size + end_use_data.size + zone_temps_data.size + total_loads_data.size + comp_loads_data.size == 0
+    return if fuel_data.size + end_use_data.size + hot_water_use_data.size + zone_temps_data.size + total_loads_data.size + comp_loads_data.size == 0
 
     # Assemble data
-    data = data.zip(*fuel_data, *end_use_data, *zone_temps_data, *total_loads_data, *comp_loads_data)
+    data = data.zip(*fuel_data, *end_use_data, *hot_water_use_data, *zone_temps_data, *total_loads_data, *comp_loads_data)
 
     # Error-check
     n_elements = []
@@ -1154,15 +1192,15 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     return sys.id
   end
 
-  def get_report_meter_data_annual_mbtu(variable)
-    query = "SELECT SUM(VariableValue/1000000000) FROM ReportMeterData WHERE ReportMeterDataDictionaryIndex IN (SELECT ReportMeterDataDictionaryIndex FROM ReportMeterDataDictionary WHERE VariableName='#{variable}' AND ReportingFrequency='Run Period' AND VariableUnits='J')"
+  def get_report_meter_data_annual(variable, unit_conv = UnitConversions.convert(1.0, 'J', 'MBtu'))
+    query = "SELECT SUM(VariableValue*#{unit_conv}) FROM ReportMeterData WHERE ReportMeterDataDictionaryIndex IN (SELECT ReportMeterDataDictionaryIndex FROM ReportMeterDataDictionary WHERE VariableName='#{variable}' AND ReportingFrequency='Run Period' AND VariableUnits='J')"
     value = @sqlFile.execAndReturnFirstDouble(query)
     fail "Query error: #{query}" unless value.is_initialized
 
-    return UnitConversions.convert(value.get, 'GJ', 'MBtu')
+    return value.get
   end
 
-  def get_report_variable_data_annual_mbtu(key_values_list, variable_names_list, not_key: false)
+  def get_report_variable_data_annual(key_values_list, variable_names_list, unit_conv = UnitConversions.convert(1.0, 'J', 'MBtu'), not_key: false)
     keys = "'" + key_values_list.join("','") + "'"
     vars = "'" + variable_names_list.join("','") + "'"
     if not_key
@@ -1170,11 +1208,11 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     else
       s_not = ''
     end
-    query = "SELECT SUM(VariableValue/1000000000) FROM ReportVariableData WHERE ReportVariableDataDictionaryIndex IN (SELECT ReportVariableDataDictionaryIndex FROM ReportVariableDataDictionary WHERE KeyValue #{s_not}IN (#{keys}) AND VariableName IN (#{vars}) AND ReportingFrequency='Run Period')"
+    query = "SELECT SUM(VariableValue*#{unit_conv}) FROM ReportVariableData WHERE ReportVariableDataDictionaryIndex IN (SELECT ReportVariableDataDictionaryIndex FROM ReportVariableDataDictionary WHERE KeyValue #{s_not}IN (#{keys}) AND VariableName IN (#{vars}) AND ReportingFrequency='Run Period')"
     value = @sqlFile.execAndReturnFirstDouble(query)
     fail "Query error: #{query}" unless value.is_initialized
 
-    return UnitConversions.convert(value.get, 'GJ', 'MBtu')
+    return value.get
   end
 
   def get_report_meter_data_timeseries(key_value, variable_name, unit_conv, unit_adder, timeseries_frequency)
@@ -1257,7 +1295,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
         vars = get_all_var_keys(OutputVars.SpaceHeatingDFHPBackupLoad)
         sys_id = dfhp_primary_sys_id(sys_id)
       end
-      dfhp_loads[[sys_id, dfhp_primary]] = get_report_variable_data_annual_mbtu(keys, vars)
+      dfhp_loads[[sys_id, dfhp_primary]] = get_report_variable_data_annual(keys, vars)
     end
     return dfhp_loads
   end
@@ -1550,6 +1588,14 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     attr_accessor(:meter, :variable, :annual_output_by_system, :timeseries_output_by_system)
   end
 
+  class HotWater < BaseOutput
+    def initialize(key:)
+      super()
+      @key = key
+    end
+    attr_accessor(:key, :variable)
+  end
+
   class PeakFuel < BaseOutput
     def initialize(meter:, report:)
       super()
@@ -1678,6 +1724,21 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       end_use.name = "#{fuel_type}: #{end_use_type}"
       end_use.annual_units = 'MBtu'
       end_use.timeseries_units = get_timeseries_units_from_fuel_type(fuel_type)
+    end
+
+    # Hot Water Uses
+    @hot_water_uses = {
+      HWT::ClothesWasher => HotWater.new(key: Constants.ObjectNameClothesWasher),
+      HWT::Dishwasher => HotWater.new(key: Constants.ObjectNameDishwasher),
+      HWT::Fixtures => HotWater.new(key: Constants.ObjectNameFixtures),
+      HWT::DistributionWaste => HotWater.new(key: Constants.ObjectNameDistributionWaste)
+    }
+
+    @hot_water_uses.each do |hot_water_type, hot_water|
+      hot_water.variable = 'Water Use Equipment Hot Water Volume'
+      hot_water.name = "Hot Water: #{hot_water_type}"
+      hot_water.annual_units = 'gal'
+      hot_water.timeseries_units = 'gal'
     end
 
     # Peak Fuels

--- a/hpxml-measures/SimulationOutputReport/measure.xml
+++ b/hpxml-measures/SimulationOutputReport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>91a2ca57-a30c-4347-91fd-b815a6d1f682</version_id>
-  <version_modified>20200423T150856Z</version_modified>
+  <version_id>18d07dac-7e5c-4100-a917-8039f9047e65</version_id>
+  <version_modified>20200424T181255Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -79,6 +79,25 @@
       <name>include_timeseries_end_use_consumptions</name>
       <display_name>Generate Timeseries Output: End Use Consumptions</display_name>
       <description>Generates timeseries energy consumptions for each end use.</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>false</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>include_timeseries_hot_water_uses</name>
+      <display_name>Generate Timeseries Output: Hot Water Uses</display_name>
+      <description>Generates timeseries hot water usages for each end use.</description>
       <type>Boolean</type>
       <required>true</required>
       <model_dependent>false</model_dependent>
@@ -476,7 +495,7 @@
       <filename>constants.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>55D54003</checksum>
+      <checksum>CE3C849E</checksum>
     </file>
     <file>
       <version>
@@ -487,13 +506,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>47C8150F</checksum>
+      <checksum>94545E5E</checksum>
     </file>
     <file>
       <filename>output_report_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>800B0C65</checksum>
+      <checksum>A66B95EE</checksum>
     </file>
   </files>
 </measure>

--- a/hpxml-measures/SimulationOutputReport/resources/constants.rb
+++ b/hpxml-measures/SimulationOutputReport/resources/constants.rb
@@ -34,6 +34,14 @@ class EUT
   PV = 'PV'
 end
 
+class HWT
+  # Hot Water Types
+  ClothesWasher = 'Clothes Washer'
+  Dishwasher = 'Dishwasher'
+  Fixtures = 'Fixtures'
+  DistributionWaste = 'Distribution Waste'
+end
+
 class LT
   # Load Types
   Heating = 'Heating'

--- a/hpxml-measures/SimulationOutputReport/tests/output_report_test.rb
+++ b/hpxml-measures/SimulationOutputReport/tests/output_report_test.rb
@@ -101,6 +101,10 @@ class SimulationOutputReportTest < MiniTest::Test
     'Component Load: Cooling: Whole House Fan (MBtu)',
     'Component Load: Cooling: Ducts (MBtu)',
     'Component Load: Cooling: Internal Gains (MBtu)',
+    'Hot Water: Clothes Washer (gal)',
+    'Hot Water: Dishwasher (gal)',
+    'Hot Water: Fixtures (gal)',
+    'Hot Water: Distribution Waste (gal)',
   ]
 
   TimeseriesColsFuels = [
@@ -152,6 +156,13 @@ class SimulationOutputReportTest < MiniTest::Test
     'Wood: Clothes Dryer',
     'Wood: Range/Oven',
     'Wood Pellets: Heating',
+  ]
+
+  TimeseriesColsWaterUses = [
+    'Hot Water: Clothes Washer',
+    'Hot Water: Dishwasher',
+    'Hot Water: Fixtures',
+    'Hot Water: Distribution Waste',
   ]
 
   TimeseriesColsTotalLoads = [
@@ -266,6 +277,7 @@ class SimulationOutputReportTest < MiniTest::Test
                   'include_timeseries_zone_temperatures' => false,
                   'include_timeseries_fuel_consumptions' => false,
                   'include_timeseries_end_use_consumptions' => false,
+                  'include_timeseries_hot_water_uses' => false,
                   'include_timeseries_total_loads' => false,
                   'include_timeseries_component_loads' => false }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
@@ -282,6 +294,7 @@ class SimulationOutputReportTest < MiniTest::Test
                   'include_timeseries_zone_temperatures' => true,
                   'include_timeseries_fuel_consumptions' => false,
                   'include_timeseries_end_use_consumptions' => false,
+                  'include_timeseries_hot_water_uses' => false,
                   'include_timeseries_total_loads' => false,
                   'include_timeseries_component_loads' => false }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
@@ -299,6 +312,7 @@ class SimulationOutputReportTest < MiniTest::Test
                   'include_timeseries_zone_temperatures' => false,
                   'include_timeseries_fuel_consumptions' => true,
                   'include_timeseries_end_use_consumptions' => false,
+                  'include_timeseries_hot_water_uses' => false,
                   'include_timeseries_total_loads' => false,
                   'include_timeseries_component_loads' => false }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
@@ -316,6 +330,7 @@ class SimulationOutputReportTest < MiniTest::Test
                   'include_timeseries_zone_temperatures' => false,
                   'include_timeseries_fuel_consumptions' => false,
                   'include_timeseries_end_use_consumptions' => true,
+                  'include_timeseries_hot_water_uses' => false,
                   'include_timeseries_total_loads' => false,
                   'include_timeseries_component_loads' => false }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
@@ -327,12 +342,31 @@ class SimulationOutputReportTest < MiniTest::Test
     assert_equal(8760, File.readlines(timeseries_csv).size - 2)
   end
 
+  def test_timeseries_hourly_hotwateruses
+    args_hash = { 'hpxml_path' => '../workflow/sample_files/base.xml',
+                  'timeseries_frequency' => 'hourly',
+                  'include_timeseries_zone_temperatures' => false,
+                  'include_timeseries_fuel_consumptions' => false,
+                  'include_timeseries_end_use_consumptions' => false,
+                  'include_timeseries_hot_water_uses' => true,
+                  'include_timeseries_total_loads' => false,
+                  'include_timeseries_component_loads' => false }
+    annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
+    assert(File.exist?(annual_csv))
+    assert(File.exist?(timeseries_csv))
+    expected_timeseries_cols = ['Hour'] + TimeseriesColsWaterUses
+    actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
+    assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
+    assert_equal(8760, File.readlines(timeseries_csv).size - 2)
+  end
+
   def test_timeseries_hourly_loads
     args_hash = { 'hpxml_path' => '../workflow/sample_files/base.xml',
                   'timeseries_frequency' => 'hourly',
                   'include_timeseries_zone_temperatures' => false,
                   'include_timeseries_fuel_consumptions' => false,
                   'include_timeseries_end_use_consumptions' => false,
+                  'include_timeseries_hot_water_uses' => false,
                   'include_timeseries_total_loads' => true,
                   'include_timeseries_component_loads' => false }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
@@ -350,6 +384,7 @@ class SimulationOutputReportTest < MiniTest::Test
                   'include_timeseries_zone_temperatures' => false,
                   'include_timeseries_fuel_consumptions' => false,
                   'include_timeseries_end_use_consumptions' => false,
+                  'include_timeseries_hot_water_uses' => false,
                   'include_timeseries_total_loads' => false,
                   'include_timeseries_component_loads' => true }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
@@ -367,12 +402,13 @@ class SimulationOutputReportTest < MiniTest::Test
                   'include_timeseries_zone_temperatures' => true,
                   'include_timeseries_fuel_consumptions' => true,
                   'include_timeseries_end_use_consumptions' => true,
+                  'include_timeseries_hot_water_uses' => true,
                   'include_timeseries_total_loads' => true,
                   'include_timeseries_component_loads' => true }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Hour'] + TimeseriesColsFuels + TimeseriesColsEndUses + TimeseriesColsTotalLoads + TimeseriesColsComponentLoads + TimeseriesColsTemperatures
+    expected_timeseries_cols = ['Hour'] + TimeseriesColsFuels + TimeseriesColsEndUses + TimeseriesColsWaterUses + TimeseriesColsTotalLoads + TimeseriesColsComponentLoads + TimeseriesColsTemperatures
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(8760, File.readlines(timeseries_csv).size - 2)
@@ -384,12 +420,13 @@ class SimulationOutputReportTest < MiniTest::Test
                   'include_timeseries_zone_temperatures' => true,
                   'include_timeseries_fuel_consumptions' => true,
                   'include_timeseries_end_use_consumptions' => true,
+                  'include_timeseries_hot_water_uses' => true,
                   'include_timeseries_total_loads' => true,
                   'include_timeseries_component_loads' => true }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Day'] + TimeseriesColsFuels + TimeseriesColsEndUses + TimeseriesColsTotalLoads + TimeseriesColsComponentLoads + TimeseriesColsTemperatures
+    expected_timeseries_cols = ['Day'] + TimeseriesColsFuels + TimeseriesColsEndUses + TimeseriesColsWaterUses + TimeseriesColsTotalLoads + TimeseriesColsComponentLoads + TimeseriesColsTemperatures
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(365, File.readlines(timeseries_csv).size - 2)
@@ -401,12 +438,13 @@ class SimulationOutputReportTest < MiniTest::Test
                   'include_timeseries_zone_temperatures' => true,
                   'include_timeseries_fuel_consumptions' => true,
                   'include_timeseries_end_use_consumptions' => true,
+                  'include_timeseries_hot_water_uses' => true,
                   'include_timeseries_total_loads' => true,
                   'include_timeseries_component_loads' => true }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Month'] + TimeseriesColsFuels + TimeseriesColsEndUses + TimeseriesColsTotalLoads + TimeseriesColsComponentLoads + TimeseriesColsTemperatures
+    expected_timeseries_cols = ['Month'] + TimeseriesColsFuels + TimeseriesColsEndUses + TimeseriesColsWaterUses + TimeseriesColsTotalLoads + TimeseriesColsComponentLoads + TimeseriesColsTemperatures
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(12, File.readlines(timeseries_csv).size - 2)
@@ -418,12 +456,13 @@ class SimulationOutputReportTest < MiniTest::Test
                   'include_timeseries_zone_temperatures' => true,
                   'include_timeseries_fuel_consumptions' => true,
                   'include_timeseries_end_use_consumptions' => true,
+                  'include_timeseries_hot_water_uses' => true,
                   'include_timeseries_total_loads' => true,
                   'include_timeseries_component_loads' => true }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Timestep'] + TimeseriesColsFuels + TimeseriesColsEndUses + TimeseriesColsTotalLoads + TimeseriesColsComponentLoads + TimeseriesColsTemperatures
+    expected_timeseries_cols = ['Timestep'] + TimeseriesColsFuels + TimeseriesColsEndUses + TimeseriesColsWaterUses + TimeseriesColsTotalLoads + TimeseriesColsComponentLoads + TimeseriesColsTemperatures
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(8760, File.readlines(timeseries_csv).size - 2)
@@ -435,12 +474,13 @@ class SimulationOutputReportTest < MiniTest::Test
                   'include_timeseries_zone_temperatures' => true,
                   'include_timeseries_fuel_consumptions' => true,
                   'include_timeseries_end_use_consumptions' => true,
+                  'include_timeseries_hot_water_uses' => true,
                   'include_timeseries_total_loads' => true,
                   'include_timeseries_component_loads' => true }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Timestep'] + TimeseriesColsFuels + TimeseriesColsEndUses + TimeseriesColsTotalLoads + TimeseriesColsComponentLoads + TimeseriesColsTemperatures
+    expected_timeseries_cols = ['Timestep'] + TimeseriesColsFuels + TimeseriesColsEndUses + TimeseriesColsWaterUses + TimeseriesColsTotalLoads + TimeseriesColsComponentLoads + TimeseriesColsTemperatures
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(52560, File.readlines(timeseries_csv).size - 2)
@@ -452,12 +492,13 @@ class SimulationOutputReportTest < MiniTest::Test
                   'include_timeseries_zone_temperatures' => true,
                   'include_timeseries_fuel_consumptions' => true,
                   'include_timeseries_end_use_consumptions' => true,
+                  'include_timeseries_hot_water_uses' => true,
                   'include_timeseries_total_loads' => true,
                   'include_timeseries_component_loads' => true }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Hour'] + TimeseriesColsFuels + TimeseriesColsEndUses + TimeseriesColsTotalLoads + TimeseriesColsComponentLoads + TimeseriesColsTemperatures
+    expected_timeseries_cols = ['Hour'] + TimeseriesColsFuels + TimeseriesColsEndUses + TimeseriesColsWaterUses + TimeseriesColsTotalLoads + TimeseriesColsComponentLoads + TimeseriesColsTemperatures
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(31 * 24, File.readlines(timeseries_csv).size - 2)
@@ -469,12 +510,13 @@ class SimulationOutputReportTest < MiniTest::Test
                   'include_timeseries_zone_temperatures' => true,
                   'include_timeseries_fuel_consumptions' => true,
                   'include_timeseries_end_use_consumptions' => true,
+                  'include_timeseries_hot_water_uses' => true,
                   'include_timeseries_total_loads' => true,
                   'include_timeseries_component_loads' => true }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Day'] + TimeseriesColsFuels + TimeseriesColsEndUses + TimeseriesColsTotalLoads + TimeseriesColsComponentLoads + TimeseriesColsTemperatures
+    expected_timeseries_cols = ['Day'] + TimeseriesColsFuels + TimeseriesColsEndUses + TimeseriesColsWaterUses + TimeseriesColsTotalLoads + TimeseriesColsComponentLoads + TimeseriesColsTemperatures
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(31, File.readlines(timeseries_csv).size - 2)
@@ -486,12 +528,13 @@ class SimulationOutputReportTest < MiniTest::Test
                   'include_timeseries_zone_temperatures' => true,
                   'include_timeseries_fuel_consumptions' => true,
                   'include_timeseries_end_use_consumptions' => true,
+                  'include_timeseries_hot_water_uses' => true,
                   'include_timeseries_total_loads' => true,
                   'include_timeseries_component_loads' => true }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Month'] + TimeseriesColsFuels + TimeseriesColsEndUses + TimeseriesColsTotalLoads + TimeseriesColsComponentLoads + TimeseriesColsTemperatures
+    expected_timeseries_cols = ['Month'] + TimeseriesColsFuels + TimeseriesColsEndUses + TimeseriesColsWaterUses + TimeseriesColsTotalLoads + TimeseriesColsComponentLoads + TimeseriesColsTemperatures
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(1, File.readlines(timeseries_csv).size - 2)
@@ -503,12 +546,13 @@ class SimulationOutputReportTest < MiniTest::Test
                   'include_timeseries_zone_temperatures' => true,
                   'include_timeseries_fuel_consumptions' => true,
                   'include_timeseries_end_use_consumptions' => true,
+                  'include_timeseries_hot_water_uses' => true,
                   'include_timeseries_total_loads' => true,
                   'include_timeseries_component_loads' => true }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Timestep'] + TimeseriesColsFuels + TimeseriesColsEndUses + TimeseriesColsTotalLoads + TimeseriesColsComponentLoads + TimeseriesColsTemperatures
+    expected_timeseries_cols = ['Timestep'] + TimeseriesColsFuels + TimeseriesColsEndUses + TimeseriesColsWaterUses + TimeseriesColsTotalLoads + TimeseriesColsComponentLoads + TimeseriesColsTemperatures
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(31 * 24, File.readlines(timeseries_csv).size - 2)
@@ -520,12 +564,13 @@ class SimulationOutputReportTest < MiniTest::Test
                   'include_timeseries_zone_temperatures' => true,
                   'include_timeseries_fuel_consumptions' => true,
                   'include_timeseries_end_use_consumptions' => true,
+                  'include_timeseries_hot_water_uses' => true,
                   'include_timeseries_total_loads' => true,
                   'include_timeseries_component_loads' => true }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Hour'] + TimeseriesColsFuels + TimeseriesColsEndUses + TimeseriesColsTotalLoads + TimeseriesColsComponentLoads + TimeseriesColsTemperatures
+    expected_timeseries_cols = ['Hour'] + TimeseriesColsFuels + TimeseriesColsEndUses + TimeseriesColsWaterUses + TimeseriesColsTotalLoads + TimeseriesColsComponentLoads + TimeseriesColsTemperatures
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(8784, File.readlines(timeseries_csv).size - 2)
@@ -537,12 +582,13 @@ class SimulationOutputReportTest < MiniTest::Test
                   'include_timeseries_zone_temperatures' => true,
                   'include_timeseries_fuel_consumptions' => true,
                   'include_timeseries_end_use_consumptions' => true,
+                  'include_timeseries_hot_water_uses' => true,
                   'include_timeseries_total_loads' => true,
                   'include_timeseries_component_loads' => true }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Day'] + TimeseriesColsFuels + TimeseriesColsEndUses + TimeseriesColsTotalLoads + TimeseriesColsComponentLoads + TimeseriesColsTemperatures
+    expected_timeseries_cols = ['Day'] + TimeseriesColsFuels + TimeseriesColsEndUses + TimeseriesColsWaterUses + TimeseriesColsTotalLoads + TimeseriesColsComponentLoads + TimeseriesColsTemperatures
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(366, File.readlines(timeseries_csv).size - 2)
@@ -554,12 +600,13 @@ class SimulationOutputReportTest < MiniTest::Test
                   'include_timeseries_zone_temperatures' => true,
                   'include_timeseries_fuel_consumptions' => true,
                   'include_timeseries_end_use_consumptions' => true,
+                  'include_timeseries_hot_water_uses' => true,
                   'include_timeseries_total_loads' => true,
                   'include_timeseries_component_loads' => true }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Timestep'] + TimeseriesColsFuels + TimeseriesColsEndUses + TimeseriesColsTotalLoads + TimeseriesColsComponentLoads + TimeseriesColsTemperatures
+    expected_timeseries_cols = ['Timestep'] + TimeseriesColsFuels + TimeseriesColsEndUses + TimeseriesColsWaterUses + TimeseriesColsTotalLoads + TimeseriesColsComponentLoads + TimeseriesColsTemperatures
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(8784, File.readlines(timeseries_csv).size - 2)
@@ -584,6 +631,7 @@ class SimulationOutputReportTest < MiniTest::Test
                     'include_timeseries_zone_temperatures' => true,
                     'include_timeseries_fuel_consumptions' => true,
                     'include_timeseries_end_use_consumptions' => true,
+                    'include_timeseries_hot_water_uses' => true,
                     'include_timeseries_total_loads' => true,
                     'include_timeseries_component_loads' => true }
       annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash, eri_design)
@@ -627,7 +675,7 @@ class SimulationOutputReportTest < MiniTest::Test
     workflow.setWorkflowSteps(steps)
     osw_path = File.join(File.dirname(template_osw), 'test.osw')
     workflow.saveAs(osw_path)
-    assert_equal(7, found_args.size)
+    assert_equal(8, found_args.size)
 
     # Run OSW
     success = system("#{OpenStudio.getOpenStudioCLI} run -w #{osw_path}")

--- a/hpxml-measures/docs/source/hpxml_to_openstudio.rst
+++ b/hpxml-measures/docs/source/hpxml_to_openstudio.rst
@@ -73,12 +73,9 @@ The simulation controls currently offered are timestep, begin month, begin day o
 Timestep can be optionally provided as ``Timestep``, where the value is in minutes and must be a divisor of 60.
 If not provided, the default value of 60 is used.
 
-Begin month and end month can be optionally provided as ``BeginMonth`` and ``EndMonth``, respectively, where the value is an integer and must be between 1 and 12.
-Begin day of month and end day of month can be optionally provided as ``BeginDayOfMonth`` and ``EndDayOfMonth``, respectively, where the value is an integer and must have a valid number of days depending on the begin month.
-Either both, or neither, ``BeginMonth`` and ``BeginDayOfMonth`` or ``EndMonth`` and ``EndDayOfMonth`` must be provided.
-If not provided, the default value of 1/1 (January 1st) and 12/31 (December 31st), respectively, will be used.
-
-You cannot supply a combination of ``BeginMonth`` and ``BeginDayOfMonth`` that occurs after the supplied combination of ``EndMonth`` and ``EndDayOfMonth`` (e.g., a run period from 10/1 to 3/31 is invalid).
+The simulation run period can be optionally specified with ``BeginMonth``/``BeginDayOfMonth`` and/or ``EndMonth``/``EndDayOfMonth``.
+The ``BeginMonth``/``BeginDayOfMonth`` provided must occur before ``EndMonth``/``EndDayOfMonth`` provided (e.g., a run period from 10/1 to 3/31 is invalid).
+If not provided, default values of January 1st and December 31st will be used.
 
 Building Details
 ~~~~~~~~~~~~~~~~
@@ -93,8 +90,7 @@ It is used for high-level building information including conditioned floor area,
 Most occupancy assumptions are based on the number of bedrooms, while the number of residents is solely used to determine heat gains from the occupants themselves.
 Note that a walkout basement should be included in ``NumberofConditionedFloorsAboveGrade``.
 
-If ``NumberofBathrooms`` is not provided, it is calculated using the following equation.
-The equation is from the `Building America House Simulation Protocols <https://www1.eere.energy.gov/buildings/publications/pdfs/building_america/house_simulation.pdf>`_.
+If ``NumberofBathrooms`` is not provided, it is calculated using the following equation based on the `Building America House Simulation Protocols <https://www1.eere.energy.gov/buildings/publications/pdfs/building_america/house_simulation.pdf>`_.
 
 .. math:: NumberofBathrooms = \frac{NumberofBedrooms}{2} + 0.5
 
@@ -177,7 +173,7 @@ Vented Attics/Crawlspaces
 The ventilation rate for vented attics (or crawlspaces) can be specified using an ``Attic`` (or ``Foundation``) element.
 First, define the ``AtticType`` as ``Attic[Vented='true']`` (or ``FoundationType`` as ``Crawlspace[Vented='true']``).
 Then use the ``VentilationRate[UnitofMeasure='SLA']/Value`` element to specify a specific leakage area (SLA).
-If these elements are not provided, default values will be used.
+If these elements are not provided, default values of 1/300 for vented attics and 1/150 for vented crawlspaces will be used based on `ANSI/RESNET/ICC 301-2019 <https://codes.iccsafe.org/content/RESNETICC3012019>`_.
 
 Roofs
 *****
@@ -268,7 +264,7 @@ Windows must also have an ``Azimuth`` specified, even if the attached wall does 
 In addition, the summer/winter interior shading coefficients can be optionally entered as ``InteriorShading/SummerShadingCoefficient`` and ``InteriorShading/WinterShadingCoefficient``.
 The summer interior shading coefficient must be less than or equal to the winter interior shading coefficient.
 Note that a value of 0.7 indicates a 30% reduction in solar gains (i.e., 30% shading).
-If not provided, default values will be assumed.
+If not provided, default values of 0.70 for summer and 0.85 for winter will be used based on `ANSI/RESNET/ICC 301-2019 <https://codes.iccsafe.org/content/RESNETICC3012019>`_.
 
 Overhangs (e.g., a roof eave) can optionally be defined for a window by specifying a ``Window/Overhangs`` element.
 Overhangs are defined by the vertical distance between the overhang and the top of the window (``DistanceToTopOfWindow``), and the vertical distance between the overhang and the bottom of the window (``DistanceToBottomOfWindow``).
@@ -394,15 +390,15 @@ The heating setpoint (``SetpointTempHeatingSeason``) and cooling setpoint (``Set
 
 If there is a heating setback, it is defined with:
 
-- Temperature during heating setback (``SetbackTempHeatingSeason``)
-- The start hour of the heating setback where 0=midnight and 12=noon (``extension/SetbackStartHourHeating``)
-- The number of hours of heating setback per week (``TotalSetbackHoursperWeekHeating``)
+- ``SetbackTempHeatingSeason``: Temperature during heating setback
+- ``extension/SetbackStartHourHeating``: The start hour of the heating setback where 0=midnight and 12=noon
+- ``TotalSetbackHoursperWeekHeating``: The number of hours of heating setback per week
 
 If there is a cooling setup, it is defined with:
 
-- Temperature during cooling setup (``SetupTempCoolingSeason``)
-- The start hour of the cooling setup where 0=midnight and 12=noon (``extension/SetupStartHourCooling``)
-- The number of hours of cooling setup per week (``TotalSetupHoursperWeekCooling``)
+- ``SetupTempCoolingSeason``: Temperature during cooling setup
+- ``extension/SetupStartHourCooling``: The start hour of the cooling setup where 0=midnight and 12=noon
+- ``TotalSetupHoursperWeekCooling``: The number of hours of cooling setup per week
 
 Finally, if there are sufficient ceiling fans present that result in a reduced cooling setpoint, this offset can be specified with ``extension/CeilingFanSetpointTempCoolingSeasonOffset``.
 
@@ -429,7 +425,7 @@ For each duct, ``DuctInsulationRValue``, ``DuctLocation``, and ``DuctSurfaceArea
 
 .. warning::
 
-  Specifying a DSE for the HVAC distribution system will NOT be reflected in the EnergyPlus simulation outputs.
+  Specifying a DSE for the HVAC distribution system will NOT be reflected in the raw EnergyPlus simulation outputs, but IS reflected by the SimulationOutputReport reporting measure.
 
 Mechanical Ventilation
 **********************
@@ -460,35 +456,33 @@ Kitchen Fan
 
 A kitchen range fan may be specified as a ``Systems/MechanicalVentilation/VentilationFans/VentilationFan`` with ``FanLocation='kitchen'`` and ``UsedForLocalVentilation='true'``.
 
-Additional fields may be provided per the table below. If not provided, default values will be assumed.
-The default values are based on the `Building America House Simulation Protocols <https://www1.eere.energy.gov/buildings/publications/pdfs/building_america/house_simulation.pdf>`_.
+Additional fields may be provided per the table below. If not provided, default values will be assumed based on the `Building America House Simulation Protocols <https://www1.eere.energy.gov/buildings/publications/pdfs/building_america/house_simulation.pdf>`_.
 
-====================== ========================
-Element Name           Default Value
-====================== ========================
-RatedFlowRate          100 [cfm]
-HoursInOperation       1 [hrs/day]
-FanPower               0.3 * RatedFlowRate [W]
-extension/StartHour    18 [6pm]
-====================== ========================
+=========================== ========================
+Element Name                Default Value
+=========================== ========================
+RatedFlowRate [cfm]         100
+HoursInOperation [hrs/day]  1
+FanPower [W]                0.3 * RatedFlowRate
+extension/StartHour [0-23]  18
+=========================== ========================
 
 Bathroom Fans
 *************
 
 Bathroom fans may be specified as a ``Systems/MechanicalVentilation/VentilationFans/VentilationFan`` with ``FanLocation='bath'`` and ``UsedForLocalVentilation='true'``.
 
-Additional fields may be provided per the table below. If not provided, default values will be assumed.
-The default values are based on the `Building America House Simulation Protocols <https://www1.eere.energy.gov/buildings/publications/pdfs/building_america/house_simulation.pdf>`_.
+Additional fields may be provided per the table below. If not provided, default values will be assumed based on the `Building America House Simulation Protocols <https://www1.eere.energy.gov/buildings/publications/pdfs/building_america/house_simulation.pdf>`_.
 
-====================== ========================
-Element Name           Default Value
-====================== ========================
-Quantity               NumberofBathrooms [#]
-RatedFlowRate          50 [cfm]
-HoursInOperation       1 [hrs/day]
-FanPower               0.3 * RatedFlowRate [W]
-extension/StartHour    7 [7am]
-====================== ========================
+=========================== ========================
+Element Name                Default Value
+=========================== ========================
+Quantity [#]                NumberofBathrooms
+RatedFlowRate [cfm]         50
+HoursInOperation [hrs/day]  1
+FanPower [W]                0.3 * RatedFlowRate
+extension/StartHour [0-23]  7
+=========================== ========================
 
 Whole House Fan
 ***************
@@ -504,7 +498,7 @@ Water Heaters
 
 Each water heater should be entered as a ``Systems/WaterHeating/WaterHeatingSystem``.
 Inputs including ``WaterHeaterType`` and ``FractionDHWLoadServed`` must be provided.
-The water heater ``Location`` can be optionally entered; if not provided, a default water heater location will be assumed based on the IECC climate zone. 
+The water heater ``Location`` can be optionally entered; if not provided, a default water heater location will be assumed based on IECC climate zone. 
 
 +--------------------+--------------------------------------------------------------------------------------------+
 | IECC Climate Zone  | Default Water Heater Location                                                              |
@@ -518,21 +512,32 @@ The setpoint temperature may be provided as ``HotWaterTemperature``; if not prov
 
 Depending on the type of water heater specified, additional elements are required/available:
 
-========================================  ===================================  ===========  ==========  ===============  ========================  =================  =================  =========================================
-WaterHeaterType                           UniformEnergyFactor or EnergyFactor  FuelType     TankVolume  HeatingCapacity  RecoveryEfficiency        RelatedHVACSystem  UsesDesuperheater  WaterHeaterInsulation/Jacket/JacketRValue
-========================================  ===================================  ===========  ==========  ===============  ========================  =================  =================  =========================================
-storage water heater                      required                             <any>        required    <optional>       required if non-electric                     <optional>         <optional>
-instantaneous water heater                required                             <any>                                                                                  <optional>
-heat pump water heater                    required                             electricity  required                                                                                     <optional>
-space-heating boiler with storage tank                                                      required                                               required                              <optional>
-space-heating boiler with tankless coil                                                                                                            required           
-========================================  ===================================  ===========  ==========  ===============  ========================  =================  =================  =========================================
+========================================  ===================================  ===========  ==========  ===============  ==================  =================  =================  =========================================
+WaterHeaterType                           UniformEnergyFactor or EnergyFactor  FuelType     TankVolume  HeatingCapacity  RecoveryEfficiency  RelatedHVACSystem  UsesDesuperheater  WaterHeaterInsulation/Jacket/JacketRValue
+========================================  ===================================  ===========  ==========  ===============  ==================  =================  =================  =========================================
+storage water heater                      required                             <any>        <optional>  <optional>       <optional>          <optional>         <optional>
+instantaneous water heater                required                             <any>                                                                            <optional>
+heat pump water heater                    required                             electricity  required                                                                               <optional>
+space-heating boiler with storage tank                                                      required                                         required                              <optional>
+space-heating boiler with tankless coil                                                                                                      required           
+========================================  ===================================  ===========  ==========  ===============  ==================  =================  =================  =========================================
+
+For storage water heaters, the tank volume in gallons, heating capacity in Btuh, and recovery efficiency can be optionally provided. If not provided, default values for the tank volume and heating capacity will be assumed based on Table 8 in the `2014 Building America House Simulation Protocols <https://www.energy.gov/sites/prod/files/2014/03/f13/house_simulation_protocols_2014.pdf#page=22&zoom=100,93,333>`_ 
+and a default recovery efficiency will be assumed depending on the fuel type, as shown in the table below. The equations for non-electric storage water heaters are based on the regression analysis of `AHRI certified water heaters <https://www.ahridirectory.org/NewSearch?programId=24&searchTypeId=3>`_.
+
+========================  ======================================
+FuelType                  RecoveryEfficiency
+========================  ======================================
+Electric                  0.98
+Non-electric, EF >= 0.75  .. math:: 0.778114 \cdot EF + 0.276679
+Non-electric, EF < 0.75   .. math:: 0.252117 \cdot EF + 0.607997
+========================  ======================================
 
 For tankless water heaters, an annual energy derate due to cycling inefficiencies can be provided.
 If not provided, a value of 0.08 (8%) will be assumed.
 
 For combi boiler systems, the ``RelatedHVACSystem`` must point to a ``HeatingSystem`` of type "Boiler".
-For combi boiler systems with a storage tank, the storage tank losses (deg-F/hr) can be entered as ``StandbyLoss``; if not provided, an average value will be used.
+For combi boiler systems with a storage tank, the storage tank losses (deg-F/hr) can be entered as ``StandbyLoss``; if not provided, a default value based on the `AHRI Directory of Certified Product Performance <https://www.ahridirectory.org>`_ will be calculated.
 
 For water heaters that are connected to a desuperheater, the ``RelatedHVACSystem`` must either point to a ``HeatPump`` or a ``CoolingSystem``.
 
@@ -542,28 +547,33 @@ Hot Water Distribution
 A ``Systems/WaterHeating/HotWaterDistribution`` must be provided if any water heating systems are specified.
 Inputs including ``SystemType`` and ``PipeInsulation/PipeRValue`` must be provided.
 
-For a ``SystemType/Standard`` (non-recirculating) system, the following element can be optionally entered:
+For a ``SystemType/Standard`` (non-recirculating) system, the following element are used:
 
-- ``PipingLength``: Measured length of hot water piping from the hot water heater to the farthest hot water fixture, measured longitudinally from plans, assuming the hot water piping does not run diagonally, plus 10 feet of piping for each floor level, plus 5 feet of piping for unconditioned basements (if any)
+- ``PipingLength``: Optional. Measured length of hot water piping from the hot water heater to the farthest hot water fixture, measured longitudinally from plans, assuming the hot water piping does not run diagonally, plus 10 feet of piping for each floor level, plus 5 feet of piping for unconditioned basements (if any)
+  If not provided, a default ``PipingLength`` will be calculated using the following equation from `ANSI/RESNET/ICC 301-2019 <https://codes.iccsafe.org/content/RESNETICC3012019>`_.
 
-If ``PipingLength`` is not provided, a default ``PipingLength`` will be assumed.
-The default ``PipingLength`` will be calculated using the following equation.
-This equation is based on `ANSI/RESNET/ICC 301-2019 <https://codes.iccsafe.org/content/RESNETICC3012019>`_.
+  .. math:: PipeL = 2.0 \cdot (\frac{CFA}{NCfl})^{0.5} + 10.0 \cdot NCfl + 5.0 \cdot bsmnt
 
-.. math:: PipeL = 2.0 \cdot (\frac{CFA}{NCfl})^{0.5} + 10.0 \cdot NCfl + 5.0 \cdot bsmnt
-  
-Where, 
-PipeL = piping length [ft], 
-CFA = conditioned floor area [ft²],
-NCfl = number of conditioned floor levels number of conditioned floor levels in the residence, including conditioned basements, 
-bsmnt = presence = 1.0 or absence = 0.0 of an unconditioned basement in the residence.
+  Where, 
+  PipeL = piping length [ft], 
+  CFA = conditioned floor area [ft²],
+  NCfl = number of conditioned floor levels number of conditioned floor levels in the residence including conditioned basements, 
+  bsmnt = presence = 1.0 or absence = 0.0 of an unconditioned basement in the residence.
 
-For a ``SystemType/Recirculation`` system, the following elements are required:
+For a ``SystemType/Recirculation`` system, the following elements are used:
 
 - ``ControlType``
-- ``RecirculationPipingLoopLength``: Measured recirculation loop length including both supply and return sides, measured longitudinally from plans, assuming the hot water piping does not run diagonally, plus 20 feet of piping for each floor level greater than one plus 10 feet of piping for unconditioned basements
-- ``BranchPipingLoopLength``: Measured length of the branch hot water piping from the recirculation loop to the farthest hot water fixture from the recirculation loop, measured longitudinally from plans, assuming the branch hot water piping does not run diagonally
-- ``PumpPower``
+- ``RecirculationPipingLoopLength``: Optional. If not provided, the default value will be calculated by using the equation shown in the table below. Measured recirculation loop length including both supply and return sides, measured longitudinally from plans, assuming the hot water piping does not run diagonally, plus 20 feet of piping for each floor level greater than one plus 10 feet of piping for unconditioned basements.
+- ``BranchPipingLoopLength``: Optional. If not provided, the default value will be assumed as shown in the table below. Measured length of the branch hot water piping from the recirculation loop to the farthest hot water fixture from the recirculation loop, measured longitudinally from plans, assuming the branch hot water piping does not run diagonally.
+- ``PumpPower``: Optional. If not provided, the default value will be assumed as shown in the table below. 
+
+  ==================================  ====================================================================================================
+  Element Name                        Default Value
+  ==================================  ====================================================================================================
+  RecirculationPipingLoopLength [ft]  .. math:: 2.0 \cdot (2.0 \cdot (\frac{CFA}{NCfl})^{0.5} + 10.0 \cdot NCfl + 5.0 \cdot bsmnt) - 20.0
+  BranchPipingLoopLength [ft]         10 
+  Pump Power [W]                      50 
+  ==================================  ====================================================================================================
 
 In addition, a ``HotWaterDistribution/DrainWaterHeatRecovery`` (DWHR) may be specified.
 The DWHR system is defined by:
@@ -596,14 +606,17 @@ If using simple inputs, the following elements are used:
 
 If using detailed inputs, the following elements are used:
 
-- ``CollectorArea``
+- ``CollectorArea``: in units of ft²
 - ``CollectorLoopType``: 'liquid indirect' or 'liquid direct' or 'passive thermosyphon'
 - ``CollectorType``: 'single glazing black' or 'double glazing black' or 'evacuated tube' or 'integrated collector storage'
 - ``CollectorAzimuth``
 - ``CollectorTilt``
 - ``CollectorRatedOpticalEfficiency``: FRTA (y-intercept); see Directory of SRCC OG-100 Certified Solar Collector Ratings
-- ``CollectorRatedThermalLosses``: FRUL (slope, in units of Btu/hr-ft^2-R); see Directory of SRCC OG-100 Certified Solar Collector Ratings
-- ``StorageVolume``
+- ``CollectorRatedThermalLosses``: FRUL (slope, in units of Btu/hr-ft²-R); see Directory of SRCC OG-100 Certified Solar Collector Ratings
+- ``StorageVolume``: Optional. If not provided, the default value in gallons will be calculated using the following equation
+  
+  .. math:: StorageVolume = 1.5 \cdot CollectorArea
+
 - ``ConnectedTo``: Must point to a ``WaterHeatingSystem``. The connected water heater cannot be of type space-heating boiler or attached to a desuperheater.
 
 Photovoltaics
@@ -642,20 +655,19 @@ The ``Location`` can be optionally provided; if not provided, it is assumed to b
 Several EnergyGuide label inputs describing the efficiency of the appliance can be provided.
 If the complete set of efficiency inputs is not provided, the following default values representing a standard clothes washer from 2006 will be used.
 
-==================================  ==================
-Element Name                        Default Value
-==================================  ==================
-IntegratedModifiedEnergyFactor      1.0 [ft3/kWh-cyc]
-RatedAnnualkWh                      400 [kWh/yr]
-LabelElectricRate                   0.12 [$/kWh]
-LabelGasRate                        1.09 [$/therm]
-LabelAnnualGasCost                  27.0 [$]
-Capacity                            3.0 [ft³]
-LabelUsage                          6 [cyc/week]
-==================================  ==================
+=============================================  ==============
+Element Name                                   Default Value
+=============================================  ==============
+IntegratedModifiedEnergyFactor [ft³/kWh-cyc]   1.0  
+RatedAnnualkWh [kWh/yr]                        400  
+LabelElectricRate [$/kWh]                      0.12  
+LabelGasRate [$/therm]                         1.09  
+LabelAnnualGasCost [$]                         27.0  
+Capacity [ft³]                                 3.0  
+LabelUsage [cyc/week]                          6  
+=============================================  ==============
 
-If ``ModifiedEnergyFactor`` is provided instead of ``IntegratedModifiedEnergyFactor``, it will be converted using the following equation.
-This equation is based on the `Interpretation on ANSI/RESNET 301-2014 Clothes Washer IMEF <https://www.resnet.us/wp-content/uploads/No.-301-2014-08-sECTION-4.2.2.5.2.8-Clothes-Washers-Eq-4.2-6.pdf>`_.
+If ``ModifiedEnergyFactor`` is provided instead of ``IntegratedModifiedEnergyFactor``, it will be converted using the following equation based on the `Interpretation on ANSI/RESNET 301-2014 Clothes Washer IMEF <https://www.resnet.us/wp-content/uploads/No.-301-2014-08-sECTION-4.2.2.5.2.8-Clothes-Washers-Eq-4.2-6.pdf>`_.
 
 .. math:: IntegratedModifiedEnergyFactor = \frac{ModifiedEnergyFactor - 0.503}{0.95}
 
@@ -671,15 +683,14 @@ The ``Location`` can be optionally provided; if not provided, it is assumed to b
 Several EnergyGuide label inputs describing the efficiency of the appliance can be provided.
 If the complete set of efficiency inputs is not provided, the following default values representing a standard clothes dryer from 2006 will be used.
 
-=======================  ==============
-Element Name             Default Value
-=======================  ==============
-CombinedEnergyFactor     3.01 [lb/kWh]
-ControlType              timer
-=======================  ==============
+==============================  ==============
+Element Name                    Default Value
+==============================  ==============
+CombinedEnergyFactor [lb/kWh]   3.01  
+ControlType                     timer
+==============================  ==============
 
-If ``EnergyFactor`` is provided instead of ``CombinedEnergyFactor``, it will be converted into ``CombinedEnergyFactor`` using the following equation.
-This equation is based on the `Interpretation on ANSI/RESNET/ICC 301-2014 Clothes Dryer CEF <https://www.resnet.us/wp-content/uploads/No.-301-2014-10-Section-4.2.2.5.2.8-Clothes-Dryer-CEF-Rating.pdf>`_.
+If ``EnergyFactor`` is provided instead of ``CombinedEnergyFactor``, it will be converted into ``CombinedEnergyFactor`` using the following equation based on the `Interpretation on ANSI/RESNET/ICC 301-2014 Clothes Dryer CEF <https://www.resnet.us/wp-content/uploads/No.-301-2014-10-Section-4.2.2.5.2.8-Clothes-Dryer-CEF-Rating.pdf>`_.
 
 .. math:: CombinedEnergyFactor = \frac{EnergyFactor}{1.15}
 
@@ -694,19 +705,18 @@ The dishwasher is assumed to be in the living space.
 Several EnergyGuide label inputs describing the efficiency of the appliance can be provided.
 If the complete set of efficiency inputs is not provided, the following default values representing a standard dishwasher from 2006 will be used.
 
-=======================  =================
-Element Name             Default Value
-=======================  =================
-RatedAnnualkWh           467 [kwh/yr]
-LabelElectricRate        0.12 [$/kWh]
-LabelGasRate             1.09 [$/therm]
-LabelAnnualGasCost       33.12 [$]
-PlaceSettingCapacity     12 [standard]
-LabelUsage               4 [cyc/week]
-=======================  =================
+===============================  =================
+Element Name                     Default Value
+===============================  =================
+RatedAnnualkWh [kwh/yr]          467  
+LabelElectricRate [$/kWh]        0.12  
+LabelGasRate [$/therm]           1.09  
+LabelAnnualGasCost [$]           33.12  
+PlaceSettingCapacity [#]         12  
+LabelUsage [cyc/week]            4  
+===============================  =================
 
-If ``EnergyFactor`` is provided instead of ``RatedAnnualkWh``, it will be converted into ``RatedAnnualkWh`` using the following equation.
-This equation is based on `ANSI/RESNET/ICC 301-2014 <https://codes.iccsafe.org/content/document/843>`_.
+If ``EnergyFactor`` is provided instead of ``RatedAnnualkWh``, it will be converted into ``RatedAnnualkWh`` using the following equation based on `ANSI/RESNET/ICC 301-2014 <https://codes.iccsafe.org/content/document/843>`_.
 
 .. math:: RatedAnnualkWh = \frac{215.0}{EnergyFactor}
 
@@ -719,10 +729,9 @@ An ``Appliances/Refrigerator`` element can be specified; if not provided, a refr
 The ``Location`` can be optionally provided; if not provided, it is assumed to be in the living space.
 
 The efficiency of the refrigerator can be optionally entered as ``RatedAnnualkWh`` or ``extension/AdjustedAnnualkWh``.
-If neither are provided, ``RatedAnnualkWh`` will be defaulted to represent a standard refrigerator from 2006 based on the following equation.
-This equation is based on `ANSI/RESNET/ICC 301-2019 <https://codes.iccsafe.org/content/RESNETICC3012019>`_.
+If neither are provided, ``RatedAnnualkWh`` will be defaulted to represent a standard refrigerator from 2006 using the following equation based on `ANSI/RESNET/ICC 301-2019 <https://codes.iccsafe.org/content/RESNETICC3012019>`_.
 
-.. math:: RatedAnnualkWh = 637.0 + 18.0 \cdot Number of bedrooms
+.. math:: RatedAnnualkWh = 637.0 + 18.0 \cdot NumberofBedrooms
 
 An ``extension/UsageMultiplier`` can also be optionally provided that scales energy usage; if not provided, it is assumed to be 1.0.
 
@@ -773,7 +782,14 @@ Ceiling Fans
 ~~~~~~~~~~~~
 
 Each ceiling fan (or set of identical ceiling fans) should be entered as a ``Lighting/CeilingFan``.
-The ``Airflow/Efficiency`` (at medium speed) and ``Quantity`` can be provided, otherwise default assumptions are used.
+The ``Airflow/Efficiency`` (at medium speed) and ``Quantity`` can be provided, otherwise the following default assumptions are used from `ANSI/RESNET/ICC 301-2019 <https://codes.iccsafe.org/content/RESNETICC3012019>`_.
+
+==========================  ==================
+Element Name                Default Value
+==========================  ==================
+Airflow/Efficiency [cfm/W]  3000/42.6
+Quantity [#]                NumberofBedrooms+1
+==========================  ==================
 
 In addition, a reduced cooling setpoint can be specified for summer months when ceiling fans are operating.
 See the Thermostat section for more information.
@@ -783,7 +799,10 @@ Plug Loads
 
 Plug loads can be provided by entering ``MiscLoads/PlugLoad`` elements; if not provided, plug loads will not be modeled.
 Currently only plug loads specified with ``PlugLoadType='other'`` and ``PlugLoadType='TV other'`` are recognized.
-The annual energy consumption (``Load[Units='kWh/year']/Value``) can be provided, otherwise default assumptions based on the plug load type are used.
+The annual energy consumption (``Load[Units='kWh/year']/Value``) can be provided, otherwise they will be calculated using the following equations from `ANSI/RESNET/ICC 301-2019 <https://codes.iccsafe.org/content/RESNETICC3012019>`_.
+
+.. math:: TelevisionkWhs = 413.0 + 69.0 \cdot NumberofBedrooms
+.. math:: OtherkWhs = 0.91 \cdot ConditionedFloorArea
 
 An ``extension/UsageMultiplier`` can also be optionally provided that scales energy usage; if not provided, it is assumed to be 1.0.
 

--- a/hpxml-measures/tasks.rb
+++ b/hpxml-measures/tasks.rb
@@ -224,6 +224,7 @@ def create_hpxmls
     'base-mechvent-bath-kitchen-fans.xml' => 'base.xml',
     'base-misc-ceiling-fans.xml' => 'base.xml',
     'base-misc-defaults.xml' => 'base.xml',
+    'base-misc-defaults2.xml' => 'base-dhw-recirc-demand.xml',
     'base-misc-lighting-none.xml' => 'base.xml',
     'base-misc-timestep-10-mins.xml' => 'base.xml',
     'base-misc-runperiod-1-month.xml' => 'base.xml',
@@ -2565,7 +2566,7 @@ def set_hpxml_water_heating_systems(hpxml_file, hpxml)
                                     fraction_dhw_load_served: 1,
                                     heating_capacity: 18767,
                                     energy_factor: 0.95,
-                                    temperature: 125)
+                                    temperature: Waterheater.get_default_hot_water_temperature(Constants.ERIVersions[-1]))
   elsif ['base-dhw-multiple.xml'].include? hpxml_file
     hpxml.water_heating_systems[0].fraction_dhw_load_served = 0.2
     hpxml.water_heating_systems.add(id: 'WaterHeater2',
@@ -2577,7 +2578,7 @@ def set_hpxml_water_heating_systems(hpxml_file, hpxml)
                                     heating_capacity: 40000,
                                     energy_factor: 0.59,
                                     recovery_efficiency: 0.76,
-                                    temperature: 125)
+                                    temperature: Waterheater.get_default_hot_water_temperature(Constants.ERIVersions[-1]))
     hpxml.water_heating_systems.add(id: 'WaterHeater3',
                                     fuel_type: HPXML::FuelTypeElectricity,
                                     water_heater_type: HPXML::WaterHeaterTypeHeatPump,
@@ -2585,28 +2586,28 @@ def set_hpxml_water_heating_systems(hpxml_file, hpxml)
                                     tank_volume: 80,
                                     fraction_dhw_load_served: 0.2,
                                     energy_factor: 2.3,
-                                    temperature: 125)
+                                    temperature: Waterheater.get_default_hot_water_temperature(Constants.ERIVersions[-1]))
     hpxml.water_heating_systems.add(id: 'WaterHeater4',
                                     fuel_type: HPXML::FuelTypeElectricity,
                                     water_heater_type: HPXML::WaterHeaterTypeTankless,
                                     location: HPXML::LocationLivingSpace,
                                     fraction_dhw_load_served: 0.2,
                                     energy_factor: 0.99,
-                                    temperature: 125)
+                                    temperature: Waterheater.get_default_hot_water_temperature(Constants.ERIVersions[-1]))
     hpxml.water_heating_systems.add(id: 'WaterHeater5',
                                     fuel_type: HPXML::FuelTypeNaturalGas,
                                     water_heater_type: HPXML::WaterHeaterTypeTankless,
                                     location: HPXML::LocationLivingSpace,
                                     fraction_dhw_load_served: 0.1,
                                     energy_factor: 0.82,
-                                    temperature: 125)
+                                    temperature: Waterheater.get_default_hot_water_temperature(Constants.ERIVersions[-1]))
     hpxml.water_heating_systems.add(id: 'WaterHeater6',
                                     water_heater_type: HPXML::WaterHeaterTypeCombiStorage,
                                     location: HPXML::LocationLivingSpace,
                                     tank_volume: 50,
                                     fraction_dhw_load_served: 0.1,
                                     related_hvac_idref: 'HeatingSystem',
-                                    temperature: 125)
+                                    temperature: Waterheater.get_default_hot_water_temperature(Constants.ERIVersions[-1]))
   elsif ['invalid_files/dhw-frac-load-served.xml'].include? hpxml_file
     hpxml.water_heating_systems[0].fraction_dhw_load_served += 0.15
   elsif ['base-dhw-tank-gas.xml',
@@ -2761,13 +2762,16 @@ def set_hpxml_water_heating_systems(hpxml_file, hpxml)
     hpxml.water_heating_systems[0].location = HPXML::LocationGarage
   elsif ['base-dhw-none.xml'].include? hpxml_file
     hpxml.water_heating_systems.clear()
-  end
-  hpxml.water_heating_systems.each do |water_heating_system|
-    if ['base-misc-defaults.xml'].include? hpxml_file
-      water_heating_system.temperature = nil
-      water_heating_system.location = nil
-    else
-      water_heating_system.temperature = Waterheater.get_default_hot_water_temperature(Constants.ERIVersions[-1])
+  elsif ['base-misc-defaults.xml',
+         'base-misc-defaults2.xml'].include? hpxml_file
+    hpxml.water_heating_systems[0].temperature = nil
+    hpxml.water_heating_systems[0].location = nil
+    hpxml.water_heating_systems[0].heating_capacity = nil
+    hpxml.water_heating_systems[0].tank_volume = nil
+    hpxml.water_heating_systems[0].recovery_efficiency = nil
+    if hpxml_file == 'base-misc-defaults2.xml'
+      hpxml.water_heating_systems[0].energy_factor = nil
+      hpxml.water_heating_systems[0].uniform_energy_factor = 0.93
     end
   end
 end
@@ -2818,6 +2822,10 @@ def set_hpxml_hot_water_distribution(hpxml_file, hpxml)
     hpxml.hot_water_distributions.clear()
   elsif ['base-misc-defaults.xml'].include? hpxml_file
     hpxml.hot_water_distributions[0].standard_piping_length = nil
+  elsif ['base-misc-defaults2.xml'].include? hpxml_file
+    hpxml.hot_water_distributions[0].recirculation_piping_length = nil
+    hpxml.hot_water_distributions[0].recirculation_branch_piping_length = nil
+    hpxml.hot_water_distributions[0].recirculation_pump_power = nil
   end
 end
 
@@ -2857,6 +2865,7 @@ def set_hpxml_solar_thermal_system(hpxml_file, hpxml)
          'base-dhw-solar-thermosyphon-flat-plate.xml',
          'base-dhw-tank-heat-pump-with-solar.xml',
          'base-dhw-tankless-gas-with-solar.xml',
+         'base-misc-defaults.xml',
          'invalid_files/solar-thermal-system-with-combi-tankless.xml',
          'invalid_files/solar-thermal-system-with-desuperheater.xml',
          'invalid_files/solar-thermal-system-with-dhw-indirect.xml'].include? hpxml_file
@@ -2874,6 +2883,9 @@ def set_hpxml_solar_thermal_system(hpxml_file, hpxml)
       hpxml.solar_thermal_systems[0].collector_loop_type = HPXML::SolarThermalLoopTypeDirect
     elsif hpxml_file == 'base-dhw-solar-thermosyphon-flat-plate.xml'
       hpxml.solar_thermal_systems[0].collector_loop_type = HPXML::SolarThermalLoopTypeThermosyphon
+    elsif hpxml_file == 'base-misc-defaults.xml'
+      hpxml.solar_thermal_systems[0].collector_loop_type = HPXML::SolarThermalLoopTypeDirect
+      hpxml.solar_thermal_systems[0].storage_volume = nil
     else
       hpxml.solar_thermal_systems[0].collector_loop_type = HPXML::SolarThermalLoopTypeIndirect
     end

--- a/hpxml-measures/workflow/run_simulation.rb
+++ b/hpxml-measures/workflow/run_simulation.rb
@@ -144,7 +144,7 @@ OptionParser.new do |opts|
   end
 
   options[:hourly_outputs] = []
-  opts.on('--hourly TYPE', hourly_types, "Request hourly output type (#{hourly_types[0..3].join(', ')}", "#{hourly_types[4..-1].join(', ')}); can be called multiple times") do |t|
+  opts.on('--hourly TYPE', hourly_types, "Request hourly output type (#{hourly_types[0..3].join(', ')},", "#{hourly_types[4..-1].join(', ')}); can be called multiple times") do |t|
     options[:hourly_outputs] << t
   end
 

--- a/hpxml-measures/workflow/run_simulation.rb
+++ b/hpxml-measures/workflow/run_simulation.rb
@@ -46,6 +46,7 @@ def run_workflow(basedir, rundir, hpxml, debug, hourly_outputs)
   args['include_timeseries_zone_temperatures'] = hourly_outputs.include? 'temperatures'
   args['include_timeseries_fuel_consumptions'] = hourly_outputs.include? 'fuels'
   args['include_timeseries_end_use_consumptions'] = hourly_outputs.include? 'enduses'
+  args['include_timeseries_hot_water_uses'] = hourly_outputs.include? 'hotwater'
   args['include_timeseries_total_loads'] = hourly_outputs.include? 'loads'
   args['include_timeseries_component_loads'] = hourly_outputs.include? 'componentloads'
   update_args_hash(measures, measure_subdir, args)
@@ -128,7 +129,7 @@ def report_ft_errors_warnings(forward_translator, designdir)
   end
 end
 
-hourly_types = ['ALL', 'fuels', 'enduses', 'loads', 'componentloads', 'temperatures']
+hourly_types = ['ALL', 'fuels', 'enduses', 'hotwater', 'loads', 'componentloads', 'temperatures']
 
 options = {}
 OptionParser.new do |opts|

--- a/hpxml-measures/workflow/sample_files/base-misc-defaults2.xml
+++ b/hpxml-measures/workflow/sample_files/base-misc-defaults2.xml
@@ -6,7 +6,13 @@
     <CreatedDateAndTime>2000-01-01T00:00:00-07:00</CreatedDateAndTime>
     <Transaction>create</Transaction>
   </XMLTransactionHeaderInformation>
-  <SoftwareInfo/>
+  <SoftwareInfo>
+    <extension>
+      <SimulationControl>
+        <Timestep>60</Timestep>
+      </SimulationControl>
+    </extension>
+  </SoftwareInfo>
   <Building>
     <BuildingID id='MyBuilding'/>
     <ProjectStatus>
@@ -20,13 +26,16 @@
             <Fuel>natural gas</Fuel>
           </FuelTypesAvailable>
         </Site>
+        <BuildingOccupancy>
+          <NumberofResidents>3.0</NumberofResidents>
+        </BuildingOccupancy>
         <BuildingConstruction>
           <ResidentialFacilityType>single-family detached</ResidentialFacilityType>
           <NumberofConditionedFloors>2</NumberofConditionedFloors>
           <NumberofConditionedFloorsAboveGrade>1</NumberofConditionedFloorsAboveGrade>
-          <AverageCeilingHeight>8.0</AverageCeilingHeight>
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>2700.0</ConditionedFloorArea>
+          <ConditionedBuildingVolume>21600.0</ConditionedBuildingVolume>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>
@@ -49,8 +58,30 @@
               <UnitofMeasure>ACH</UnitofMeasure>
               <AirLeakage>3.0</AirLeakage>
             </BuildingAirLeakage>
+            <InfiltrationVolume>21600.0</InfiltrationVolume>
           </AirInfiltrationMeasurement>
         </AirInfiltration>
+        <Attics>
+          <Attic>
+            <SystemIdentifier id='UnventedAttic'/>
+            <AtticType>
+              <Attic>
+                <Vented>false</Vented>
+              </Attic>
+            </AtticType>
+            <WithinInfiltrationVolume>false</WithinInfiltrationVolume>
+          </Attic>
+        </Attics>
+        <Foundations>
+          <Foundation>
+            <SystemIdentifier id='ConditionedBasement'/>
+            <FoundationType>
+              <Basement>
+                <Conditioned>true</Conditioned>
+              </Basement>
+            </FoundationType>
+          </Foundation>
+        </Foundations>
         <Roofs>
           <Roof>
             <SystemIdentifier id='Roof'/>
@@ -190,6 +221,12 @@
             <Azimuth>0</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
+            <InteriorShading>
+              <SystemIdentifier id='WindowNorthInteriorShading'/>
+              <SummerShadingCoefficient>0.7</SummerShadingCoefficient>
+              <WinterShadingCoefficient>0.85</WinterShadingCoefficient>
+            </InteriorShading>
+            <FractionOperable>0.67</FractionOperable>
             <AttachedToWall idref='Wall'/>
           </Window>
           <Window>
@@ -198,6 +235,12 @@
             <Azimuth>180</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
+            <InteriorShading>
+              <SystemIdentifier id='WindowSouthInteriorShading'/>
+              <SummerShadingCoefficient>0.7</SummerShadingCoefficient>
+              <WinterShadingCoefficient>0.85</WinterShadingCoefficient>
+            </InteriorShading>
+            <FractionOperable>0.67</FractionOperable>
             <AttachedToWall idref='Wall'/>
           </Window>
           <Window>
@@ -206,6 +249,12 @@
             <Azimuth>90</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
+            <InteriorShading>
+              <SystemIdentifier id='WindowEastInteriorShading'/>
+              <SummerShadingCoefficient>0.7</SummerShadingCoefficient>
+              <WinterShadingCoefficient>0.85</WinterShadingCoefficient>
+            </InteriorShading>
+            <FractionOperable>0.67</FractionOperable>
             <AttachedToWall idref='Wall'/>
           </Window>
           <Window>
@@ -214,6 +263,12 @@
             <Azimuth>270</Azimuth>
             <UFactor>0.33</UFactor>
             <SHGC>0.45</SHGC>
+            <InteriorShading>
+              <SystemIdentifier id='WindowWestInteriorShading'/>
+              <SummerShadingCoefficient>0.7</SummerShadingCoefficient>
+              <WinterShadingCoefficient>0.85</WinterShadingCoefficient>
+            </InteriorShading>
+            <FractionOperable>0.67</FractionOperable>
             <AttachedToWall idref='Wall'/>
           </Window>
         </Windows>
@@ -257,11 +312,13 @@
               <CoolingSystemType>central air conditioner</CoolingSystemType>
               <CoolingSystemFuel>electricity</CoolingSystemFuel>
               <CoolingCapacity>48000.0</CoolingCapacity>
+              <CompressorType>single stage</CompressorType>
               <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
               <AnnualCoolingEfficiency>
                 <Units>SEER</Units>
                 <Value>13.0</Value>
               </AnnualCoolingEfficiency>
+              <SensibleHeatFraction>0.73</SensibleHeatFraction>
             </CoolingSystem>
           </HVACPlant>
           <HVACControl>
@@ -306,35 +363,23 @@
             </DistributionSystemType>
           </HVACDistribution>
         </HVAC>
-        <MechanicalVentilation>
-          <VentilationFans>
-            <VentilationFan>
-              <SystemIdentifier id='KitchenRangeFan'/>
-              <FanLocation>kitchen</FanLocation>
-              <UsedForLocalVentilation>true</UsedForLocalVentilation>
-            </VentilationFan>
-            <VentilationFan>
-              <SystemIdentifier id='BathFans'/>
-              <FanLocation>bath</FanLocation>
-              <UsedForLocalVentilation>true</UsedForLocalVentilation>
-            </VentilationFan>
-          </VentilationFans>
-        </MechanicalVentilation>
         <WaterHeating>
           <WaterHeatingSystem>
             <SystemIdentifier id='WaterHeater'/>
             <FuelType>electricity</FuelType>
             <WaterHeaterType>storage water heater</WaterHeaterType>
             <FractionDHWLoadServed>1.0</FractionDHWLoadServed>
-            <EnergyFactor>0.95</EnergyFactor>
+            <UniformEnergyFactor>0.93</UniformEnergyFactor>
           </WaterHeatingSystem>
           <HotWaterDistribution>
             <SystemIdentifier id='HotWaterDstribution'/>
             <SystemType>
-              <Standard/>
+              <Recirculation>
+                <ControlType>presence sensor demand control</ControlType>
+              </Recirculation>
             </SystemType>
             <PipeInsulation>
-              <PipeRValue>0.0</PipeRValue>
+              <PipeRValue>3.0</PipeRValue>
             </PipeInsulation>
           </HotWaterDistribution>
           <WaterFixture>
@@ -348,53 +393,48 @@
             <LowFlow>false</LowFlow>
           </WaterFixture>
         </WaterHeating>
-        <SolarThermal>
-          <SolarThermalSystem>
-            <SystemIdentifier id='SolarThermalSystem'/>
-            <SystemType>hot water</SystemType>
-            <CollectorArea>40.0</CollectorArea>
-            <CollectorLoopType>liquid direct</CollectorLoopType>
-            <CollectorType>single glazing black</CollectorType>
-            <CollectorAzimuth>180</CollectorAzimuth>
-            <CollectorTilt>20.0</CollectorTilt>
-            <CollectorRatedOpticalEfficiency>0.77</CollectorRatedOpticalEfficiency>
-            <CollectorRatedThermalLosses>0.793</CollectorRatedThermalLosses>
-            <ConnectedTo idref='WaterHeater'/>
-          </SolarThermalSystem>
-        </SolarThermal>
-        <Photovoltaics>
-          <PVSystem>
-            <SystemIdentifier id='PVSystem'/>
-            <Location>roof</Location>
-            <ModuleType>standard</ModuleType>
-            <Tracking>fixed</Tracking>
-            <ArrayAzimuth>180</ArrayAzimuth>
-            <ArrayTilt>20.0</ArrayTilt>
-            <MaxPowerOutput>4000.0</MaxPowerOutput>
-            <YearModulesManufactured>2015</YearModulesManufactured>
-          </PVSystem>
-        </Photovoltaics>
       </Systems>
       <Appliances>
         <ClothesWasher>
           <SystemIdentifier id='ClothesWasher'/>
+          <Location>living space</Location>
+          <IntegratedModifiedEnergyFactor>1.21</IntegratedModifiedEnergyFactor>
+          <RatedAnnualkWh>380.0</RatedAnnualkWh>
+          <LabelElectricRate>0.12</LabelElectricRate>
+          <LabelGasRate>1.09</LabelGasRate>
+          <LabelAnnualGasCost>27.0</LabelAnnualGasCost>
+          <LabelUsage>6.0</LabelUsage>
+          <Capacity>3.2</Capacity>
         </ClothesWasher>
         <ClothesDryer>
           <SystemIdentifier id='ClothesDryer'/>
+          <Location>living space</Location>
           <FuelType>electricity</FuelType>
+          <CombinedEnergyFactor>3.73</CombinedEnergyFactor>
+          <ControlType>timer</ControlType>
         </ClothesDryer>
         <Dishwasher>
           <SystemIdentifier id='Dishwasher'/>
+          <RatedAnnualkWh>307.0</RatedAnnualkWh>
+          <PlaceSettingCapacity>12</PlaceSettingCapacity>
+          <LabelElectricRate>0.12</LabelElectricRate>
+          <LabelGasRate>1.09</LabelGasRate>
+          <LabelAnnualGasCost>22.32</LabelAnnualGasCost>
+          <LabelUsage>4.0</LabelUsage>
         </Dishwasher>
         <Refrigerator>
           <SystemIdentifier id='Refrigerator'/>
+          <Location>living space</Location>
+          <RatedAnnualkWh>650.0</RatedAnnualkWh>
         </Refrigerator>
         <CookingRange>
           <SystemIdentifier id='Range'/>
           <FuelType>electricity</FuelType>
+          <IsInduction>false</IsInduction>
         </CookingRange>
         <Oven>
           <SystemIdentifier id='Oven'/>
+          <IsConvection>false</IsConvection>
         </Oven>
       </Appliances>
       <Lighting>
@@ -434,19 +474,37 @@
           <FractionofUnitsInLocation>0.25</FractionofUnitsInLocation>
           <ThirdPartyCertification>ERI Tier II</ThirdPartyCertification>
         </LightingGroup>
-        <CeilingFan>
-          <SystemIdentifier id='CeilingFan'/>
-        </CeilingFan>
       </Lighting>
       <MiscLoads>
         <PlugLoad>
           <SystemIdentifier id='PlugLoadMisc'/>
           <PlugLoadType>other</PlugLoadType>
+          <Load>
+            <Units>kWh/year</Units>
+            <Value>2457.0</Value>
+          </Load>
+          <extension>
+            <FracSensible>0.855</FracSensible>
+            <FracLatent>0.045</FracLatent>
+          </extension>
         </PlugLoad>
         <PlugLoad>
           <SystemIdentifier id='PlugLoadMisc2'/>
           <PlugLoadType>TV other</PlugLoadType>
+          <Load>
+            <Units>kWh/year</Units>
+            <Value>620.0</Value>
+          </Load>
+          <extension>
+            <FracSensible>1.0</FracSensible>
+            <FracLatent>0.0</FracLatent>
+          </extension>
         </PlugLoad>
+        <extension>
+          <WeekdayScheduleFractions>0.04, 0.037, 0.037, 0.036, 0.033, 0.036, 0.043, 0.047, 0.034, 0.023, 0.024, 0.025, 0.024, 0.028, 0.031, 0.032, 0.039, 0.053, 0.063, 0.067, 0.071, 0.069, 0.059, 0.05</WeekdayScheduleFractions>
+          <WeekendScheduleFractions>0.04, 0.037, 0.037, 0.036, 0.033, 0.036, 0.043, 0.047, 0.034, 0.023, 0.024, 0.025, 0.024, 0.028, 0.031, 0.032, 0.039, 0.053, 0.063, 0.067, 0.071, 0.069, 0.059, 0.05</WeekendScheduleFractions>
+          <MonthlyScheduleMultipliers>1.248, 1.257, 0.993, 0.989, 0.993, 0.827, 0.821, 0.821, 0.827, 0.99, 0.987, 1.248</MonthlyScheduleMultipliers>
+        </extension>
       </MiscLoads>
     </BuildingDetails>
   </Building>

--- a/hpxml-measures/workflow/template.osw
+++ b/hpxml-measures/workflow/template.osw
@@ -18,6 +18,7 @@
         "include_timeseries_zone_temperatures": false,
         "include_timeseries_fuel_consumptions": false,
         "include_timeseries_end_use_consumptions": false,
+        "include_timeseries_hot_water_uses": false,
         "include_timeseries_total_loads": false,
         "include_timeseries_component_loads": false
       },

--- a/hpxml-measures/workflow/tests/hpxml_translator_test.rb
+++ b/hpxml-measures/workflow/tests/hpxml_translator_test.rb
@@ -1542,7 +1542,7 @@ class HPXMLTest < MiniTest::Test
     results_base.keys.each do |k|
       next if [@@simulation_runtime_key, @@workflow_runtime_key].include? k
 
-      assert_in_epsilon(results_base[k].to_f, results_collapsed[k].to_f, 0.001)
+      assert_in_epsilon(results_base[k].to_f, results_collapsed[k].to_f, 0.01)
     end
   end
 

--- a/hpxml-measures/workflow/tests/hpxml_translator_test.rb
+++ b/hpxml-measures/workflow/tests/hpxml_translator_test.rb
@@ -466,6 +466,7 @@ class HPXMLTest < MiniTest::Test
     args['include_timeseries_zone_temperatures'] = true
     args['include_timeseries_fuel_consumptions'] = true
     args['include_timeseries_end_use_consumptions'] = true
+    args['include_timeseries_hot_water_uses'] = true
     args['include_timeseries_total_loads'] = true
     args['include_timeseries_component_loads'] = true
     update_args_hash(measures, measure_subdir, args)

--- a/rulesets/301EnergyRatingIndexRuleset/measure.xml
+++ b/rulesets/301EnergyRatingIndexRuleset/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>energy_rating_index_301_measure</name>
   <uid>02a31992-9a16-4945-bb51-e99209f7193b</uid>
-  <version_id>cd015321-99ce-4570-9c06-041dec083789</version_id>
-  <version_modified>20200423T154308Z</version_modified>
+  <version_id>84e1ace8-756f-47f3-b3ab-1f99aac2f85b</version_id>
+  <version_modified>20200424T183042Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>EnergyRatingIndex301Measure</class_name>
   <display_name>Apply Energy Rating Index Ruleset</display_name>
@@ -144,7 +144,7 @@
       <filename>301.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>D539D72A</checksum>
+      <checksum>B64BF692</checksum>
     </file>
   </files>
 </measure>

--- a/rulesets/301EnergyRatingIndexRuleset/resources/301.rb
+++ b/rulesets/301EnergyRatingIndexRuleset/resources/301.rb
@@ -1540,7 +1540,7 @@ class EnergyRatingIndex301Ruleset
 
       energy_factor, recovery_efficiency = get_water_heater_ef_and_re(fuel_type, tank_volume)
 
-      heating_capacity = Waterheater.calc_water_heater_capacity(fuel_type, @nbeds, orig_hpxml.water_heating_systems.size) * 1000.0 # Btuh
+      heating_capacity = Waterheater.get_default_heating_capacity(fuel_type, @nbeds, orig_hpxml.water_heating_systems.size) * 1000.0 # Btuh
 
       location = orig_water_heater.location
       if [Constants.CalcTypeERIIndexAdjustmentDesign, Constants.CalcTypeERIIndexAdjustmentReferenceHome].include? @calc_type
@@ -1583,7 +1583,7 @@ class EnergyRatingIndex301Ruleset
 
       heating_capacity = orig_water_heater.heating_capacity
       if (orig_water_heater.water_heater_type == HPXML::WaterHeaterTypeStorage) && heating_capacity.nil?
-        heating_capacity = Waterheater.calc_water_heater_capacity(orig_water_heater.fuel_type, @nbeds, orig_hpxml.water_heating_systems.size) * 1000.0 # Btuh
+        heating_capacity = Waterheater.get_default_heating_capacity(orig_water_heater.fuel_type, @nbeds, orig_hpxml.water_heating_systems.size) * 1000.0 # Btuh
       end
 
       if orig_water_heater.water_heater_type == HPXML::WaterHeaterTypeTankless
@@ -2296,7 +2296,7 @@ class EnergyRatingIndex301Ruleset
     wh_tank_vol = 40.0
 
     wh_ef, wh_re = get_water_heater_ef_and_re(wh_fuel_type, wh_tank_vol)
-    wh_cap = Waterheater.calc_water_heater_capacity(wh_fuel_type, @nbeds, 1) * 1000.0 # Btuh
+    wh_cap = Waterheater.get_default_heating_capacity(wh_fuel_type, @nbeds, 1) * 1000.0 # Btuh
 
     new_hpxml.water_heating_systems.add(id: 'WaterHeatingSystem',
                                         fuel_type: wh_fuel_type,

--- a/tasks.rb
+++ b/tasks.rb
@@ -2328,6 +2328,7 @@ def create_sample_hpxmls
                   'base-mechvent-cfis-evap-cooler-only-ducted.xml',
                   'base-mechvent-exhaust-rated-flow-rate.xml',
                   'base-misc-defaults.xml',
+                  'base-misc-defaults2.xml',
                   'base-misc-lighting-none.xml',
                   'base-misc-neighbor-shading.xml',
                   'base-misc-runperiod-1-month.xml',

--- a/workflow/design.rb
+++ b/workflow/design.rb
@@ -105,6 +105,7 @@ def get_measures_to_run(run, hpxml, output_hpxml, hourly_outputs, debug, basedir
   args['include_timeseries_zone_temperatures'] = hourly_outputs.include? 'temperatures'
   args['include_timeseries_fuel_consumptions'] = hourly_outputs.include? 'fuels'
   args['include_timeseries_end_use_consumptions'] = hourly_outputs.include? 'enduses'
+  args['include_timeseries_hot_water_uses'] = hourly_outputs.include? 'hotwater'
   args['include_timeseries_total_loads'] = hourly_outputs.include? 'loads'
   args['include_timeseries_component_loads'] = hourly_outputs.include? 'componentloads'
   update_args_hash(measures, measure_subdir, args)

--- a/workflow/energy_rating_index.rb
+++ b/workflow/energy_rating_index.rb
@@ -553,7 +553,7 @@ def calculate_eri(design_outputs, resultsdir)
   return results
 end
 
-hourly_types = ['ALL', 'fuels', 'enduses', 'loads', 'componentloads', 'temperatures']
+hourly_types = ['ALL', 'fuels', 'enduses', 'hotwater', 'loads', 'componentloads', 'temperatures']
 
 options = {}
 OptionParser.new do |opts|
@@ -568,7 +568,7 @@ OptionParser.new do |opts|
   end
 
   options[:hourly_outputs] = []
-  opts.on('--hourly TYPE', hourly_types, "Request hourly output type (#{hourly_types[0..3].join(', ')}", "#{hourly_types[4..-1].join(', ')}); can be called multiple times") do |t|
+  opts.on('--hourly TYPE', hourly_types, "Request hourly output type (#{hourly_types[0..3].join(', ')},", "#{hourly_types[4..-1].join(', ')}); can be called multiple times") do |t|
     options[:hourly_outputs] << t
   end
 

--- a/workflow/tests/energy_rating_index_test.rb
+++ b/workflow/tests/energy_rating_index_test.rb
@@ -1642,7 +1642,7 @@ class EnergyRatingIndexTest < Minitest::Test
     s += "#{xml_appl_sens} #{xml_appl_lat}\n"
 
     # Water Use
-    xml_water_sens, xml_water_lat = HotWaterAndAppliances.get_fixtures_gains_sens_lat(nbeds)
+    xml_water_sens, xml_water_lat = HotWaterAndAppliances.get_water_gains_sens_lat(nbeds)
     s += "#{xml_water_sens} #{xml_water_lat}\n"
 
     # Occupants

--- a/workflow/tests/energy_rating_index_test.rb
+++ b/workflow/tests/energy_rating_index_test.rb
@@ -785,6 +785,7 @@ class EnergyRatingIndexTest < Minitest::Test
     args['include_timeseries_zone_temperatures'] = false
     args['include_timeseries_fuel_consumptions'] = false
     args['include_timeseries_end_use_consumptions'] = false
+    args['include_timeseries_hot_water_uses'] = false
     args['include_timeseries_total_loads'] = false
     args['include_timeseries_component_loads'] = false
     update_args_hash(measures, measure_subdir, args)

--- a/workflow/tests/energy_rating_index_test.rb
+++ b/workflow/tests/energy_rating_index_test.rb
@@ -552,22 +552,22 @@ class EnergyRatingIndexTest < Minitest::Test
 
       base_val = nil
       if [2, 3].include? test_num
-        base_val = all_results['L100AD-HW-01.xml'].inject(:+)
+        base_val = all_results['L100AD-HW-01.xml'][0..1].inject(:+)
         fail 'Missing value' if base_val.nil?
       elsif [4, 5, 6, 7].include? test_num
-        base_val = all_results['L100AD-HW-02.xml'].inject(:+)
+        base_val = all_results['L100AD-HW-02.xml'][0..1].inject(:+)
         fail 'Missing value' if base_val.nil?
       elsif [9, 10].include? test_num
-        base_val = all_results['L100AM-HW-01.xml'].inject(:+)
+        base_val = all_results['L100AM-HW-01.xml'][0..1].inject(:+)
         fail 'Missing value' if base_val.nil?
       elsif [11, 12, 13, 14].include? test_num
-        base_val = all_results['L100AM-HW-02.xml'].inject(:+)
+        base_val = all_results['L100AM-HW-02.xml'][0..1].inject(:+)
         fail 'Missing value' if base_val.nil?
       end
 
       mn_val = nil
       if test_num >= 8
-        mn_val = all_results[xml.gsub('AM', 'AD')].inject(:+)
+        mn_val = all_results[xml.gsub('AM', 'AD')][0..1].inject(:+)
         fail 'Missing value' if mn_val.nil?
       end
 
@@ -610,16 +610,16 @@ class EnergyRatingIndexTest < Minitest::Test
 
       base_val = nil
       if [2, 3].include? test_num
-        base_val = all_results['L100AD-HW-01.xml'].inject(:+)
+        base_val = all_results['L100AD-HW-01.xml'][0..1].inject(:+)
         fail 'Missing value' if base_val.nil?
       elsif [5, 6].include? test_num
-        base_val = all_results['L100AM-HW-01.xml'].inject(:+)
+        base_val = all_results['L100AM-HW-01.xml'][0..1].inject(:+)
         fail 'Missing value' if base_val.nil?
       end
 
       mn_val = nil
       if test_num >= 4
-        mn_val = all_results[xml.gsub('AM', 'AD')].inject(:+)
+        mn_val = all_results[xml.gsub('AM', 'AD')][0..1].inject(:+)
         fail 'Missing value' if mn_val.nil?
       end
 
@@ -1952,12 +1952,12 @@ class EnergyRatingIndexTest < Minitest::Test
     rated_recirc = nil
     rated_gpd = 0
     CSV.foreach(results_csv) do |row|
-      next if row.nil? or row[0].nil?
+      next if row.nil? || row[0].nil?
       if ['Electricity: Hot Water (MBtu)', 'Natural Gas: Hot Water (MBtu)'].include? row[0]
         rated_dhw = Float(row[1])
       elsif row[0] == 'Electricity: Hot Water Recirc Pump (MBtu)'
         rated_recirc = Float(row[1])
-      elsif row[0].start_with? "Hot Water:" and row[0].include? "(gal)"
+      elsif row[0].start_with?('Hot Water:') && row[0].include?('(gal)')
         rated_gpd += (Float(row[1]) / 365.0)
       end
     end


### PR DESCRIPTION
## Pull Request Description

Adds hot water outputs (gallons), disaggregated by end use, to annual output. Also available for timeseries outputs. GPD values added to DHW test results.

## Checklist

Not all may apply:

- [x] OS-HPXML git subtree has been pulled
- [x] Workflow tests have been updated
- [x] Documentation has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
