### PR TITLE
Latest OS-HPXML

### DIFF
--- a/docs/source/software_connection.rst
+++ b/docs/source/software_connection.rst
@@ -184,6 +184,7 @@ Frame Floors
 ************
 
 Any horizontal floor/ceiling surface that is not in contact with the ground (Slab) nor adjacent to ambient conditions above (Roof) should be specified as an ``Enclosure/FrameFloors/FrameFloor``.
+Frame floors in an attached/multifamily building that are adjacent to "other housing unit", "other heated space", "other multifamily buffer space", or "other non-freezing space" must have the ``extension/OtherSpaceAboveOrBelow`` property set to signify whether the other space is "above" or "below".
 
 Frame floors are primarily defined by their ``Insulation/AssemblyEffectiveRValue``.
 

--- a/hpxml-measures/HPXMLtoOpenStudio/measure.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/measure.rb
@@ -1,29 +1,33 @@
 # frozen_string_literal: true
 
-# see the URL below for information on how to write OpenStudio measures
-# http://nrel.github.io/OpenStudio-user-documentation/reference/measure_writing_guide/
-
+# Require all gems up front; this is much faster than multiple resource
+# files lazy loading as needed, as it prevents multiple lookups for the
+# same gem.
 require 'openstudio'
 require 'pathname'
 require 'csv'
-require_relative 'resources/EPvalidator'
+require 'oga'
 require_relative 'resources/airflow'
 require_relative 'resources/constants'
 require_relative 'resources/constructions'
+require_relative 'resources/EPvalidator'
 require_relative 'resources/geometry'
 require_relative 'resources/hotwater_appliances'
+require_relative 'resources/hpxml'
 require_relative 'resources/hvac'
 require_relative 'resources/hvac_sizing'
 require_relative 'resources/lighting'
 require_relative 'resources/location'
+require_relative 'resources/materials'
 require_relative 'resources/misc_loads'
+require_relative 'resources/psychrometrics'
 require_relative 'resources/pv'
+require_relative 'resources/schedules'
 require_relative 'resources/unit_conversions'
 require_relative 'resources/util'
 require_relative 'resources/waterheater'
 require_relative 'resources/weather'
 require_relative 'resources/xmlhelper'
-require_relative 'resources/hpxml'
 
 # start the measure
 class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
@@ -411,6 +415,7 @@ class OSModel
     @hpxml.header.begin_day_of_month = 1 if @hpxml.header.begin_day_of_month.nil?
     @hpxml.header.end_month = 12 if @hpxml.header.end_month.nil?
     @hpxml.header.end_day_of_month = 31 if @hpxml.header.end_day_of_month.nil?
+    @hpxml.site.site_type = HPXML::SiteTypeSuburban if @hpxml.site.site_type.nil?
     @hpxml.site.shelter_coefficient = Airflow.get_default_shelter_coefficient() if @hpxml.site.shelter_coefficient.nil?
     @hpxml.building_occupancy.number_of_residents = Geometry.get_occupancy_default_num(@nbeds) if @hpxml.building_occupancy.number_of_residents.nil?
     if @hpxml.building_construction.conditioned_building_volume.nil?
@@ -461,9 +466,9 @@ class OSModel
     measurements = []
     infilvolume = nil
     @hpxml.air_infiltration_measurements.each do |measurement|
-      is_ach50 = ((measurement.house_pressure == 50) && (measurement.unit_of_measure == HPXML::UnitsACH))
-      is_cfm50 = ((measurement.house_pressure == 50) && (measurement.unit_of_measure == HPXML::UnitsCFM))
-      is_nach = (measurement.house_pressure.nil? && (measurement.unit_of_measure == HPXML::UnitsACHNatural))
+      is_ach50 = ((measurement.unit_of_measure == HPXML::UnitsACH) && (measurement.house_pressure == 50))
+      is_cfm50 = ((measurement.unit_of_measure == HPXML::UnitsCFM) && (measurement.house_pressure == 50))
+      is_nach = (measurement.unit_of_measure == HPXML::UnitsACHNatural)
       next unless (is_ach50 || is_cfm50 || is_nach)
 
       measurements << measurement
@@ -884,7 +889,7 @@ class OSModel
   end
 
   def self.set_zone_volumes(runner, model)
-    # TODO: Use HPXML values not Model values
+    # FUTURE: Use HPXML values not Model values
     thermal_zones = model.getThermalZones
 
     # Init
@@ -953,7 +958,7 @@ class OSModel
 
   def self.explode_surfaces(runner, model)
     # Re-position surfaces so as to not shade each other and to make it easier to visualize the building.
-    # FUTURE: Might be able to use the new self-shading options in E+ 8.9 ShadowCalculation object?
+    # FUTURE: Might be able to use the new self-shading options in E+ 8.9 ShadowCalculation object instead?
 
     gap_distance = UnitConversions.convert(10.0, 'ft', 'm') # distance between surfaces of the same azimuth
     rad90 = UnitConversions.convert(90, 'deg', 'rad')
@@ -2730,7 +2735,7 @@ class OSModel
 
     # Base heating setpoint
     htg_setpoint = hvac_control.heating_setpoint_temp
-    @htg_weekday_setpoints = [[htg_setpoint] * 24] * 12
+    htg_weekday_setpoints = [[htg_setpoint] * 24] * 12
 
     # Apply heating setback?
     htg_setback = hvac_control.heating_setback_temp
@@ -2739,15 +2744,15 @@ class OSModel
       htg_setback_start_hr = hvac_control.heating_setback_start_hour
       for m in 1..12
         for hr in htg_setback_start_hr..htg_setback_start_hr + Integer(htg_setback_hrs_per_week / 7.0) - 1
-          @htg_weekday_setpoints[m - 1][hr % 24] = htg_setback
+          htg_weekday_setpoints[m - 1][hr % 24] = htg_setback
         end
       end
     end
-    @htg_weekend_setpoints = @htg_weekday_setpoints
+    htg_weekend_setpoints = htg_weekday_setpoints
 
     # Base cooling setpoint
     clg_setpoint = hvac_control.cooling_setpoint_temp
-    @clg_weekday_setpoints = [[clg_setpoint] * 24] * 12
+    clg_weekday_setpoints = [[clg_setpoint] * 24] * 12
 
     # Apply cooling setup?
     clg_setup = hvac_control.cooling_setup_temp
@@ -2756,7 +2761,7 @@ class OSModel
       clg_setup_start_hr = hvac_control.cooling_setup_start_hour
       for m in 1..12
         for hr in clg_setup_start_hr..clg_setup_start_hr + Integer(clg_setup_hrs_per_week / 7.0) - 1
-          @clg_weekday_setpoints[m - 1][hr % 24] = clg_setup
+          clg_weekday_setpoints[m - 1][hr % 24] = clg_setup
         end
       end
     end
@@ -2767,14 +2772,14 @@ class OSModel
       HVAC.get_default_ceiling_fan_months(weather).each_with_index do |operation, m|
         next unless operation == 1
 
-        @clg_weekday_setpoints[m] = [@clg_weekday_setpoints[m], Array.new(24, clg_ceiling_fan_offset)].transpose.map { |i| i.reduce(:+) }
+        clg_weekday_setpoints[m] = [clg_weekday_setpoints[m], Array.new(24, clg_ceiling_fan_offset)].transpose.map { |i| i.reduce(:+) }
       end
     end
-    @clg_weekend_setpoints = @clg_weekday_setpoints
+    clg_weekend_setpoints = clg_weekday_setpoints
 
     HVAC.apply_setpoints(model, runner, weather, @living_zone,
-                         @htg_weekday_setpoints, @htg_weekend_setpoints, 1, 12,
-                         @clg_weekday_setpoints, @clg_weekend_setpoints, 1, 12)
+                         htg_weekday_setpoints, htg_weekend_setpoints, 1, 12,
+                         clg_weekday_setpoints, clg_weekend_setpoints, 1, 12)
   end
 
   def self.add_ceiling_fans(runner, model, weather)
@@ -2881,75 +2886,19 @@ class OSModel
   end
 
   def self.add_airflow(runner, model, weather, spaces)
-    # Infiltration
-    infil_height = Airflow.calc_inferred_infiltration_height(@cfa, @ncfl, @ncfl_ag, @infil_volume, @hpxml)
-    infil_ach50 = nil
-    infil_const_ach = nil
-    @hpxml.air_infiltration_measurements.each do |measurement|
-      if (measurement.house_pressure == 50) && (measurement.unit_of_measure == HPXML::UnitsACH)
-        infil_ach50 = measurement.air_leakage
-      elsif (measurement.house_pressure == 50) && (measurement.unit_of_measure == HPXML::UnitsCFM)
-        infil_ach50 = measurement.air_leakage * 60.0 / @infil_volume # Convert CFM50 to ACH50
-      elsif measurement.house_pressure.nil? && (measurement.unit_of_measure == HPXML::UnitsACHNatural)
-        if @apply_ashrae140_assumptions
-          infil_const_ach = measurement.air_leakage
-        else
-          sla = Airflow.get_infiltration_SLA_from_ACH(measurement.air_leakage, infil_height, weather)
-          infil_ach50 = Airflow.get_infiltration_ACH50_from_SLA(sla, 0.65, @cfa, @infil_volume)
-        end
-      end
+    # Vented Attic
+    vented_attic = nil
+    @hpxml.attics.each do |attic|
+      next unless attic.attic_type == HPXML::AtticTypeVented
+      vented_attic = attic
     end
 
-    vented_attic_sla = nil
-    vented_attic_const_ach = nil
-    if @hpxml.has_space_type(HPXML::LocationAtticVented)
-      @hpxml.attics.each do |attic|
-        next unless attic.attic_type == HPXML::AtticTypeVented
-
-        if not attic.vented_attic_sla.nil?
-          vented_attic_sla = attic.vented_attic_sla
-        elsif not attic.vented_attic_ach.nil?
-          if @apply_ashrae140_assumptions
-            vented_attic_const_ach = attic.vented_attic_ach
-          else
-            vented_attic_sla = Airflow.get_infiltration_SLA_from_ACH(attic.vented_attic_ach, 8.202, weather)
-          end
-        end
-      end
-    else
-      vented_attic_sla = 0.0
+    # Vented Crawlspace
+    vented_crawl = nil
+    @hpxml.foundations.each do |foundation|
+      next unless foundation.foundation_type == HPXML::FoundationTypeCrawlspaceVented
+      vented_crawl = foundation
     end
-
-    vented_crawl_sla = nil
-    if @hpxml.has_space_type(HPXML::LocationCrawlspaceVented)
-      @hpxml.foundations.each do |foundation|
-        next unless foundation.foundation_type == HPXML::FoundationTypeCrawlspaceVented
-
-        vented_crawl_sla = foundation.vented_crawlspace_sla
-      end
-    else
-      vented_crawl_sla = 0.0
-    end
-
-    shelter_coef = @hpxml.site.shelter_coefficient
-    living_ach50 = infil_ach50
-    living_constant_ach = infil_const_ach
-    garage_ach50 = infil_ach50
-    unconditioned_basement_ach = 0.1
-    unvented_crawl_sla = 0
-    unvented_attic_sla = 0
-    has_flue_chimney = false
-    terrain = Constants.TerrainSuburban
-    infil = Infiltration.new(living_ach50, living_constant_ach, shelter_coef, garage_ach50, vented_crawl_sla, unvented_crawl_sla,
-                             vented_attic_sla, unvented_attic_sla, vented_attic_const_ach, unconditioned_basement_ach, has_flue_chimney, terrain)
-
-    # Natural Ventilation
-    nv_frac_window_area_open = @frac_windows_operable * 0.5 * 0.2 # Assume A) 50% of the area of an operable window can be open, and B) 20% of openable window area is actually open
-    nv_num_days_per_week = 7
-    nv_max_oa_hr = 0.0115
-    nv_max_oa_rh = 0.7
-    nat_vent = NaturalVentilation.new(nv_frac_window_area_open, nv_max_oa_hr, nv_max_oa_rh, nv_num_days_per_week,
-                                      @htg_weekday_setpoints, @htg_weekend_setpoints, @clg_weekday_setpoints, @clg_weekend_setpoints, @clg_ssn_sensor)
 
     # Ducts
     duct_systems = {}
@@ -2975,111 +2924,37 @@ class OSModel
       end
     end
 
-    # Mechanical Ventilation
-    mech_vent_id = nil
-    mech_vent_type = nil
-    mech_vent_total_eff = 0.0
-    mech_vent_total_eff_adj = 0.0
-    mech_vent_sens_eff = 0.0
-    mech_vent_sens_eff_adj = 0.0
-    mech_vent_fan_w = 0.0
-    mech_vent_cfm = 0.0
-    mech_vent_attached_dist_system = nil
-    cfis_open_time = 0.0
+    # Ventilation fans
+    vent_mech = nil
+    vent_kitchen = nil
+    vent_bath = nil
+    vent_whf = nil
     @hpxml.ventilation_fans.each do |vent_fan|
-      next unless vent_fan.used_for_whole_building_ventilation
-
-      mech_vent_id = vent_fan.id
-      mech_vent_type = vent_fan.fan_type
-      if (mech_vent_type == HPXML::MechVentTypeERV) || (mech_vent_type == HPXML::MechVentTypeHRV)
-        if vent_fan.sensible_recovery_efficiency_adjusted.nil?
-          mech_vent_sens_eff = vent_fan.sensible_recovery_efficiency
-        else
-          mech_vent_sens_eff_adj = vent_fan.sensible_recovery_efficiency_adjusted
-        end
-      end
-      if mech_vent_type == HPXML::MechVentTypeERV
-        if vent_fan.total_recovery_efficiency_adjusted.nil?
-          mech_vent_total_eff = vent_fan.total_recovery_efficiency
-        else
-          mech_vent_total_eff_adj = vent_fan.total_recovery_efficiency_adjusted
-        end
-      end
-      mech_vent_cfm = vent_fan.tested_flow_rate
-      if mech_vent_cfm.nil?
-        mech_vent_cfm = vent_fan.rated_flow_rate
-      end
-      mech_vent_fan_w = vent_fan.fan_power
-      if mech_vent_type == HPXML::MechVentTypeCFIS
-        # CFIS: Specify minimum open time in minutes
-        cfis_open_time = [vent_fan.hours_in_operation / 24.0 * 60.0, 59.999].min
-      else
-        # Other: Adjust constant CFM/power based on hours per day of operation
-        mech_vent_cfm *= (vent_fan.hours_in_operation / 24.0)
-        mech_vent_fan_w *= (vent_fan.hours_in_operation / 24.0)
-      end
-      mech_vent_attached_dist_system = vent_fan.distribution_system
-    end
-    cfis_airflow_frac = 1.0
-    clothes_dryer_exhaust = 0.0
-
-    # Kitchen range fan
-    vent_fan_kitchen = nil
-    @hpxml.ventilation_fans.each do |vent_fan|
-      next unless (vent_fan.used_for_local_ventilation && (vent_fan.fan_location == HPXML::VentilationFanLocationKitchen))
-
-      vent_fan_kitchen = vent_fan
-    end
-
-    # Bath fans
-    vent_fan_bath = nil
-    @hpxml.ventilation_fans.each do |vent_fan|
-      next unless (vent_fan.used_for_local_ventilation && (vent_fan.fan_location == HPXML::VentilationFanLocationBath))
-
-      vent_fan_bath = vent_fan
-    end
-
-    # Whole house fan
-    whole_house_fan_w = 0.0
-    whole_house_fan_cfm = 0.0
-    whf_num_days_per_week = 0
-    @hpxml.ventilation_fans.each do |vent_fan|
-      next unless vent_fan.used_for_seasonal_cooling_load_reduction
-
-      whole_house_fan_w = vent_fan.fan_power
-      whole_house_fan_cfm = vent_fan.rated_flow_rate
-      whf_num_days_per_week = 7
-    end
-    whf = WholeHouseFan.new(whole_house_fan_cfm, whole_house_fan_w, whf_num_days_per_week)
-
-    # Get AirLoop associated with CFIS
-    cfis_airloop = nil
-    if mech_vent_type == HPXML::MechVentTypeCFIS
-      cfis_sys_ids = mech_vent_attached_dist_system.hvac_systems.map { |system| system.id }
-
-      # Get AirLoopHVACs associated with these HVAC systems
-      @hvac_map.each do |sys_id, hvacs|
-        next unless cfis_sys_ids.include? sys_id
-
-        hvacs.each do |loop|
-          next unless loop.is_a? OpenStudio::Model::AirLoopHVAC
-          next if cfis_airloop == loop # already assigned
-
-          fail 'Two airloops found for CFIS. Aborting...' unless cfis_airloop.nil?
-
-          cfis_airloop = loop
+      if vent_fan.used_for_whole_building_ventilation
+        vent_mech = vent_fan
+      elsif vent_fan.used_for_seasonal_cooling_load_reduction
+        vent_whf = vent_fan
+      elsif vent_fan.used_for_local_ventilation
+        if vent_fan.fan_location == HPXML::VentilationFanLocationKitchen
+          vent_kitchen = vent_fan
+        elsif vent_fan.fan_location == HPXML::VentilationFanLocationBath
+          vent_bath = vent_fan
         end
       end
     end
 
-    mech_vent = MechanicalVentilation.new(mech_vent_type, mech_vent_total_eff, mech_vent_total_eff_adj, mech_vent_cfm,
-                                          mech_vent_fan_w, mech_vent_sens_eff, mech_vent_sens_eff_adj, clothes_dryer_exhaust,
-                                          cfis_open_time, cfis_airflow_frac, cfis_airloop)
-
+    air_infils = @hpxml.air_infiltration_measurements
     window_area = @hpxml.windows.map { |w| w.area }.inject(0, :+)
-    Airflow.apply(model, runner, weather, infil, mech_vent, nat_vent, whf, duct_systems,
-                  @cfa, @infil_volume, infil_height, @nbeds, @nbaths, @ncfl_ag, window_area,
-                  @min_neighbor_distance, vent_fan_kitchen, vent_fan_bath)
+    open_window_area = window_area * @frac_windows_operable * 0.5 * 0.2 # Assume A) 50% of the area of an operable window can be open, and B) 20% of openable window area is actually open
+    site_type = @hpxml.site.site_type
+    shelter_coef = @hpxml.site.shelter_coefficient
+    has_flue_chimney = false # FUTURE: Expose as HPXML input
+    infil_height = Airflow.calc_inferred_infiltration_height(@cfa, @ncfl, @ncfl_ag, @infil_volume, @hpxml)
+    Airflow.apply(model, runner, weather, spaces, air_infils, vent_mech, vent_whf,
+                  duct_systems, @infil_volume, infil_height, open_window_area,
+                  @clg_ssn_sensor, @min_neighbor_distance, vent_kitchen, vent_bath,
+                  vented_attic, vented_crawl, site_type, shelter_coef,
+                  has_flue_chimney, @hvac_map, @apply_ashrae140_assumptions)
   end
 
   def self.create_ducts(hvac_distribution, model, spaces)
@@ -4125,10 +4000,8 @@ class OSModel
     elsif [HPXML::LocationBasementConditioned].include? exterior_adjacent_to
       surface.createAdjacentSurface(create_or_get_space(model, spaces, HPXML::LocationLivingSpace))
       @cond_bsmnt_surfaces << surface
-    elsif [HPXML::LocationOtherHousingUnit, HPXML::LocationOtherHousingUnitAbove, HPXML::LocationOtherHousingUnitBelow].include? exterior_adjacent_to
-      # collapse into one
-      set_surface_otherside_coefficients(surface, HPXML::LocationOtherHousingUnit, model, spaces)
-    elsif [HPXML::LocationOtherHeatedSpace, HPXML::LocationOtherMultifamilyBufferSpace, HPXML::LocationOtherNonFreezingSpace].include? exterior_adjacent_to
+      set_surface_otherside_coefficients(surface, exterior_adjacent_to, model, spaces)
+    elsif [HPXML::LocationOtherHousingUnit, HPXML::LocationOtherHeatedSpace, HPXML::LocationOtherMultifamilyBufferSpace, HPXML::LocationOtherNonFreezingSpace].include? exterior_adjacent_to
       set_surface_otherside_coefficients(surface, exterior_adjacent_to, model, spaces)
     else
       surface.createAdjacentSurface(create_or_get_space(model, spaces, exterior_adjacent_to))

--- a/hpxml-measures/HPXMLtoOpenStudio/measure.xml
+++ b/hpxml-measures/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>65c4a746-e3a0-442f-8b14-97e038076841</version_id>
-  <version_modified>20200512T142707Z</version_modified>
+  <version_id>13323397-0155-4b62-a629-71694df7719a</version_id>
+  <version_modified>20200513T194127Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -331,34 +331,10 @@
       <checksum>CE0F105B</checksum>
     </file>
     <file>
-      <filename>psychrometrics.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>8844E6F4</checksum>
-    </file>
-    <file>
       <filename>meta_measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>5FA33833</checksum>
-    </file>
-    <file>
-      <filename>schedules.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>E6285CCB</checksum>
-    </file>
-    <file>
-      <filename>materials.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>A83541A4</checksum>
-    </file>
-    <file>
-      <filename>weather.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>F1170EBB</checksum>
     </file>
     <file>
       <filename>minitest_helper.rb</filename>
@@ -367,40 +343,10 @@
       <checksum>8FA46782</checksum>
     </file>
     <file>
-      <filename>util.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>2FFA6469</checksum>
-    </file>
-    <file>
-      <filename>unit_conversions.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>2B988139</checksum>
-    </file>
-    <file>
       <filename>pv.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>54B83C91</checksum>
-    </file>
-    <file>
-      <filename>location.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>18E6B63D</checksum>
-    </file>
-    <file>
-      <filename>misc_loads.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>1FBD8519</checksum>
-    </file>
-    <file>
-      <filename>constructions.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>75ED1225</checksum>
     </file>
     <file>
       <filename>test_hvac.rb</filename>
@@ -409,64 +355,118 @@
       <checksum>72183EEA</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>4A4B437E</checksum>
+    </file>
+    <file>
+      <filename>test_airflow.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>3204784B</checksum>
+    </file>
+    <file>
+      <filename>psychrometrics.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>38ED685E</checksum>
+    </file>
+    <file>
+      <filename>schedules.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>845F2FA5</checksum>
+    </file>
+    <file>
+      <filename>materials.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>99AD368E</checksum>
+    </file>
+    <file>
+      <filename>weather.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C2A8BC34</checksum>
+    </file>
+    <file>
+      <filename>util.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>5FDF5AFA</checksum>
+    </file>
+    <file>
+      <filename>unit_conversions.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>7EC7A818</checksum>
+    </file>
+    <file>
+      <filename>location.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>9AE7D3AC</checksum>
+    </file>
+    <file>
+      <filename>misc_loads.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>9726CA6F</checksum>
+    </file>
+    <file>
+      <filename>constructions.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>305F7EFC</checksum>
+    </file>
+    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>DFBA9690</checksum>
+      <checksum>86AD17CB</checksum>
     </file>
     <file>
       <filename>lighting.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>3F5031E7</checksum>
+      <checksum>ADBC5AED</checksum>
     </file>
     <file>
       <filename>xmlhelper.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>C5E10D06</checksum>
+      <checksum>9CAB5244</checksum>
     </file>
     <file>
       <filename>geometry.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>F9E6A41F</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>94C25DD3</checksum>
-    </file>
-    <file>
-      <filename>hvac_sizing.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>AB99DF79</checksum>
-    </file>
-    <file>
-      <filename>EPvalidator.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>37C6B651</checksum>
-    </file>
-    <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>313741EE</checksum>
+      <checksum>3426AF5E</checksum>
     </file>
     <file>
       <filename>waterheater.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>7AFECC12</checksum>
+      <checksum>BDCFB48D</checksum>
+    </file>
+    <file>
+      <filename>hotwater_appliances.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>DFBC59C4</checksum>
     </file>
     <file>
       <filename>airflow.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>2CD57596</checksum>
+      <checksum>1F3EE1AE</checksum>
+    </file>
+    <file>
+      <filename>hvac_sizing.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>AA162D27</checksum>
     </file>
     <file>
       <version>
@@ -477,13 +477,19 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>3DEC18F9</checksum>
+      <checksum>FA27B272</checksum>
     </file>
     <file>
-      <filename>hotwater_appliances.rb</filename>
+      <filename>EPvalidator.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>5858302E</checksum>
+      <checksum>AE89A124</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>61D6CFEC</checksum>
     </file>
   </files>
 </measure>

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/EPvalidator.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/EPvalidator.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'oga'
-
 class EnergyPlusValidator
   def self.run_validator(hpxml_doc)
     # A hash of hashes that defines the XML elements used by the EnergyPlus HPXML Use Case.
@@ -49,10 +47,11 @@ class EnergyPlusValidator
         '/HPXML/Building/BuildingID' => one, # Required by HPXML schema
         '/HPXML/Building/ProjectStatus/EventType' => one, # Required by HPXML schema
 
-        '/HPXML/Building/BuildingDetails/BuildingSummary/Site/extension/ShelterCoefficient' => zero_or_one, # Uses ERI assumption if not provided
-        '/HPXML/Building/BuildingDetails/BuildingSummary/BuildingOccupancy/NumberofResidents' => zero_or_one, # Uses ERI assumption if not provided
-        '/HPXML/Building/BuildingDetails/BuildingSummary/BuildingConstruction' => one, # See [BuildingConstruction]
+        '/HPXML/Building/BuildingDetails/BuildingSummary/Site/SiteType[text()="urban" or text()="suburban" or text()="rural"]' => zero_or_one,
+        '/HPXML/Building/BuildingDetails/BuildingSummary/Site/extension/ShelterCoefficient' => zero_or_one,
         '/HPXML/Building/BuildingDetails/BuildingSummary/Site/extension/Neighbors' => zero_or_one, # See [Neighbors]
+        '/HPXML/Building/BuildingDetails/BuildingSummary/BuildingOccupancy/NumberofResidents' => zero_or_one,
+        '/HPXML/Building/BuildingDetails/BuildingSummary/BuildingConstruction' => one, # See [BuildingConstruction]
 
         '/HPXML/Building/BuildingDetails/ClimateandRiskZones/ClimateZoneIECC' => zero_or_one, # See [ClimateZone]
         '/HPXML/Building/BuildingDetails/ClimateandRiskZones/WeatherStation' => one, # See [WeatherStation]
@@ -225,11 +224,16 @@ class EnergyPlusValidator
       # [FrameFloor]
       '/HPXML/Building/BuildingDetails/Enclosure/FrameFloors/FrameFloor' => {
         'SystemIdentifier' => one, # Required by HPXML schema
-        'ExteriorAdjacentTo[text()="outside" or text()="attic - vented" or text()="attic - unvented" or text()="basement - conditioned" or text()="basement - unconditioned" or text()="crawlspace - vented" or text()="crawlspace - unvented" or text()="garage" or text()="other housing unit above" or text()="other housing unit below" or text()="other heated space" or text()="other multifamily buffer space" or text()="other non-freezing space"]' => one,
+        'ExteriorAdjacentTo[text()="outside" or text()="attic - vented" or text()="attic - unvented" or text()="basement - conditioned" or text()="basement - unconditioned" or text()="crawlspace - vented" or text()="crawlspace - unvented" or text()="garage" or text()="other housing unit" or text()="other heated space" or text()="other multifamily buffer space" or text()="other non-freezing space"]' => one, # See [FrameFloorAdjacentToOther]
         'InteriorAdjacentTo[text()="living space" or text()="attic - vented" or text()="attic - unvented" or text()="basement - conditioned" or text()="basement - unconditioned" or text()="crawlspace - vented" or text()="crawlspace - unvented" or text()="garage"]' => one,
         'Area' => one,
         'Insulation/SystemIdentifier' => one, # Required by HPXML schema
         'Insulation/AssemblyEffectiveRValue' => one,
+      },
+
+      # [FrameFloorAdjacentToOther]
+      '/HPXML/Building/BuildingDetails/Enclosure/FrameFloors/FrameFloor[ExteriorAdjacentTo[text()="other housing unit" or text()="other heated space" or text()="other multifamily buffer space" or text()="other non-freezing space"]]' => {
+        'extension/OtherSpaceAboveOrBelow[text()="above" or text()="below"]' => one,
       },
 
       # [Slab]

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/airflow.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/airflow.rb
@@ -1,155 +1,70 @@
 # frozen_string_literal: true
 
-require_relative 'constants'
-require_relative 'unit_conversions'
-require_relative 'schedules'
-require_relative 'util'
-require_relative 'psychrometrics'
-require_relative 'hvac'
-
 class Airflow
-  def self.apply(model, runner, weather, infil, mech_vent, nat_vent, whf, duct_systems,
-                 cfa, infil_volume, infil_height, nbeds, nbaths, ncfl_ag, window_area,
-                 min_neighbor_distance, vent_fan_kitchen, vent_fan_bath)
+  def self.apply(model, runner, weather, spaces, air_infils, vent_mech, vent_whf,
+                 duct_systems, infil_volume, infil_height, open_window_area,
+                 nv_clg_ssn_sensor, min_neighbor_distance, vent_kitchen, vent_bath,
+                 vented_attic, vented_crawl, site_type, shelter_coef,
+                 has_flue_chimney, hvac_map, apply_ashrae140_assumptions)
+
+    # Global variables
 
     @runner = runner
-    @infMethodConstantCFM = 'CONSTANT_CFM'
-    @infMethodAIM2 = 'AIM2' # aka ASHRAE Enhanced
-    @infMethodELA = 'ELA'
-
-    model_spaces = model.getSpaces
-
-    # Populate building object
-    building = Building.new
-    building.height = Geometry.get_max_z_of_spaces(model_spaces)
-    model.getThermalZones.each do |thermal_zone|
-      if Geometry.is_living(thermal_zone)
-        building.living = ZoneInfo.new(thermal_zone, Geometry.get_height_of_spaces(thermal_zone.spaces), UnitConversions.convert(thermal_zone.floorArea, 'm^2', 'ft^2'), Geometry.get_zone_volume(thermal_zone), Geometry.get_z_origin_for_zone(thermal_zone), nil, nil)
-      elsif Geometry.is_garage(thermal_zone)
-        building.garage = ZoneInfo.new(thermal_zone, Geometry.get_height_of_spaces(thermal_zone.spaces), UnitConversions.convert(thermal_zone.floorArea, 'm^2', 'ft^2'), Geometry.get_zone_volume(thermal_zone), Geometry.get_z_origin_for_zone(thermal_zone), nil, nil)
-      elsif Geometry.is_unconditioned_basement(thermal_zone)
-        building.unconditioned_basement = ZoneInfo.new(thermal_zone, Geometry.get_height_of_spaces(thermal_zone.spaces), UnitConversions.convert(thermal_zone.floorArea, 'm^2', 'ft^2'), Geometry.get_zone_volume(thermal_zone), Geometry.get_z_origin_for_zone(thermal_zone), infil.unconditioned_basement_ach, nil)
-      elsif Geometry.is_vented_crawl(thermal_zone)
-        building.vented_crawlspace = ZoneInfo.new(thermal_zone, Geometry.get_height_of_spaces(thermal_zone.spaces), UnitConversions.convert(thermal_zone.floorArea, 'm^2', 'ft^2'), Geometry.get_zone_volume(thermal_zone), Geometry.get_z_origin_for_zone(thermal_zone), nil, infil.vented_crawl_sla)
-      elsif Geometry.is_unvented_crawl(thermal_zone)
-        building.unvented_crawlspace = ZoneInfo.new(thermal_zone, Geometry.get_height_of_spaces(thermal_zone.spaces), UnitConversions.convert(thermal_zone.floorArea, 'm^2', 'ft^2'), Geometry.get_zone_volume(thermal_zone), Geometry.get_z_origin_for_zone(thermal_zone), nil, infil.unvented_crawl_sla)
-      elsif Geometry.is_vented_attic(thermal_zone)
-        building.vented_attic = ZoneInfo.new(thermal_zone, Geometry.get_height_of_spaces(thermal_zone.spaces), UnitConversions.convert(thermal_zone.floorArea, 'm^2', 'ft^2'), Geometry.get_zone_volume(thermal_zone), Geometry.get_z_origin_for_zone(thermal_zone), infil.vented_attic_const_ach, infil.vented_attic_sla)
-      elsif Geometry.is_unvented_attic(thermal_zone)
-        building.unvented_attic = ZoneInfo.new(thermal_zone, Geometry.get_height_of_spaces(thermal_zone.spaces), UnitConversions.convert(thermal_zone.floorArea, 'm^2', 'ft^2'), Geometry.get_zone_volume(thermal_zone), Geometry.get_z_origin_for_zone(thermal_zone), nil, infil.unvented_attic_sla)
-      end
-    end
-    building.cfa = cfa
-    building.infilvolume = infil_volume
-    building.infilheight = infil_height
-    building.living.volume = building.infilvolume
-    building.living.height = building.infilheight
-    building.nbeds = nbeds
-    building.nbaths = nbaths
-    building.ncfl_ag = ncfl_ag
-    building.window_area = window_area
-
-    wind_speed = process_wind_speed_correction(infil.terrain, infil.shelter_coef, min_neighbor_distance, building.height)
-    process_infiltration(model, infil, wind_speed, building, weather)
+    @spaces = spaces
+    @building_height = Geometry.get_max_z_of_spaces(model.getSpaces)
+    @infil_volume = infil_volume
+    @infil_height = infil_height
+    @living_space = spaces[HPXML::LocationLivingSpace]
+    @living_zone = @living_space.thermalZone.get
+    @apply_ashrae140_assumptions = apply_ashrae140_assumptions
+    @cfa = UnitConversions.convert(@living_space.floorArea, 'm^2', 'ft^2')
 
     # Global sensors
 
-    pbar_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Site Outdoor Air Barometric Pressure')
-    pbar_sensor.setName('out pb s')
+    @pbar_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Site Outdoor Air Barometric Pressure')
+    @pbar_sensor.setName('out pb s')
 
-    wout_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Site Outdoor Air Humidity Ratio')
-    wout_sensor.setName('out wt s')
+    @wout_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Site Outdoor Air Humidity Ratio')
+    @wout_sensor.setName('out wt s')
 
-    vwind_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Site Wind Speed')
-    vwind_sensor.setName('site vw s')
+    @vwind_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Site Wind Speed')
+    @vwind_sensor.setName('site vw s')
 
-    # Adiabatic construction for ducts
+    @tin_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Zone Mean Air Temperature')
+    @tin_sensor.setName("#{Constants.ObjectNameAirflow} tin s")
+    @tin_sensor.setKeyName(@living_zone.name.to_s)
+
+    @tout_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Zone Outdoor Air Drybulb Temperature')
+    @tout_sensor.setName("#{Constants.ObjectNameAirflow} tt s")
+    @tout_sensor.setKeyName(@living_zone.name.to_s)
+
+    # Adiabatic construction for duct plenum
 
     adiabatic_mat = OpenStudio::Model::MasslessOpaqueMaterial.new(model, 'Rough', 176.1)
     adiabatic_mat.setName('Adiabatic')
-    adiabatic_const = OpenStudio::Model::Construction.new(model)
-    adiabatic_const.setName('AdiabaticConst')
-    adiabatic_const.insertLayer(0, adiabatic_mat)
+    @adiabatic_const = OpenStudio::Model::Construction.new(model)
+    @adiabatic_const.setName('AdiabaticConst')
+    @adiabatic_const.insertLayer(0, adiabatic_mat)
 
-    # Common sensors
+    # Initialization
 
-    tin_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Zone Mean Air Temperature')
-    tin_sensor.setName("#{Constants.ObjectNameAirflow} tin s")
-    tin_sensor.setKeyName(building.living.zone.name.to_s)
-
-    tout_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Zone Outdoor Air Drybulb Temperature')
-    tout_sensor.setName("#{Constants.ObjectNameAirflow} tt s")
-    tout_sensor.setKeyName(building.living.zone.name.to_s)
-
-    # Update model
-
-    air_loop_objects = create_air_loop_objects(model, model.getAirLoopHVACs, mech_vent, building)
-    process_infiltration_for_conditioned_zones(model, infil, wind_speed, building, weather)
-    process_mech_vent(model, mech_vent, building, weather, infil)
-
-    if mech_vent.type == HPXML::MechVentTypeCFIS
-      cfis_program = create_cfis_objects(model, building, mech_vent)
-    end
-
-    nv_and_whf_program = process_nat_vent_and_whole_house_fan(model, nat_vent, whf, tin_sensor, tout_sensor, pbar_sensor, vwind_sensor, wind_speed, infil, building, weather, wout_sensor)
-
-    duct_programs = {}
-    duct_lks = {}
-    duct_systems.each do |ducts, air_loop|
-      process_ducts(model, ducts, building, air_loop)
-      create_ducts_objects(model, building, ducts, mech_vent, tin_sensor, pbar_sensor, adiabatic_const, air_loop, duct_programs, duct_lks, air_loop_objects)
-    end
-
-    infil_program = create_infil_mech_vent_objects(model, building, infil, mech_vent, vent_fan_kitchen, vent_fan_bath, wind_speed, tin_sensor, tout_sensor, vwind_sensor, duct_lks, wout_sensor, pbar_sensor)
-
-    create_ems_program_managers(model, infil_program, nv_and_whf_program, cfis_program, duct_programs)
-
-    # Store info for HVAC Sizing measure
-    if not building.living.ELA.nil?
-      building.living.zone.additionalProperties.setFeature(Constants.SizingInfoZoneInfiltrationELA, building.living.ELA.to_f)
-      building.living.zone.additionalProperties.setFeature(Constants.SizingInfoZoneInfiltrationCFM, building.living.inf_flow.to_f)
-      building.living.zone.additionalProperties.setFeature(Constants.SizingInfoZoneInfiltrationACH, building.living.ACH.to_f)
-    else
-      building.living.zone.additionalProperties.setFeature(Constants.SizingInfoZoneInfiltrationELA, 0.0)
-      building.living.zone.additionalProperties.setFeature(Constants.SizingInfoZoneInfiltrationCFM, 0.0)
-      building.living.zone.additionalProperties.setFeature(Constants.SizingInfoZoneInfiltrationACH, 0.0)
-    end
-
-    # Store info for HVAC Sizing measure
-    unless building.vented_crawlspace.nil?
-      building.vented_crawlspace.zone.additionalProperties.setFeature(Constants.SizingInfoZoneInfiltrationCFM, building.vented_crawlspace.inf_flow.to_f)
-    end
-    unless building.unvented_crawlspace.nil?
-      building.unvented_crawlspace.zone.additionalProperties.setFeature(Constants.SizingInfoZoneInfiltrationCFM, building.unvented_crawlspace.inf_flow.to_f)
-    end
-    unless building.unconditioned_basement.nil?
-      building.unconditioned_basement.zone.additionalProperties.setFeature(Constants.SizingInfoZoneInfiltrationCFM, building.unconditioned_basement.inf_flow.to_f)
-    end
-    unless building.vented_attic.nil?
-      building.vented_attic.zone.additionalProperties.setFeature(Constants.SizingInfoZoneInfiltrationCFM, building.vented_attic.inf_flow)
-    end
-    unless building.unvented_attic.nil?
-      building.unvented_attic.zone.additionalProperties.setFeature(Constants.SizingInfoZoneInfiltrationCFM, building.unvented_attic.inf_flow)
-    end
+    initialize_cfis(model, vent_mech, hvac_map)
     model.getAirLoopHVACs.each do |air_loop|
-      has_ducts = air_loop.additionalProperties.getFeatureAsBoolean(Constants.SizingInfoDuctExist)
-      next if has_ducts.is_initialized
-
-      air_loop.additionalProperties.setFeature(Constants.SizingInfoDuctExist, false)
+      initialize_air_loop_objects(model, air_loop)
     end
 
-    terrain = { Constants.TerrainOcean => 'Ocean',      # Ocean, Bayou flat country
-                Constants.TerrainPlains => 'Country',   # Flat, open country
-                Constants.TerrainRural => 'Country',    # Flat, open country
-                Constants.TerrainSuburban => 'Suburbs', # Rough, wooded country, suburbs
-                Constants.TerrainCity => 'City' }       # Towns, city outskirts, center of large cities
-    model.getSite.setTerrain(terrain[infil.terrain])
+    # Apply ducts
 
-    model.getScheduleDays.each do |obj| # remove any orphaned day schedules
-      next if obj.directUseCount > 0
-
-      obj.remove
+    duct_lks = []
+    duct_systems.each do |ducts, air_loop|
+      apply_ducts(model, ducts, vent_mech, air_loop, duct_lks)
     end
+
+    # Apply infiltration/ventilation
+
+    @wind_speed = set_wind_speed_correction(model, site_type, shelter_coef, min_neighbor_distance)
+    apply_natural_ventilation_and_whole_house_fan(model, weather, vent_whf, open_window_area, nv_clg_ssn_sensor)
+    apply_infiltration_and_ventilation_fans(model, weather, vent_mech, vent_kitchen, vent_bath, duct_lks, has_flue_chimney, air_infils, vented_attic, vented_crawl)
   end
 
   def self.get_default_shelter_coefficient()
@@ -190,39 +105,34 @@ class Airflow
 
   private
 
-  def self.process_wind_speed_correction(terrain, shelter_coef, min_neighbor_distance, building_height)
+  def self.set_wind_speed_correction(model, site_type, shelter_coef, min_neighbor_distance)
+    site_map = { HPXML::SiteTypeRural => 'Country',    # Flat, open country
+                 HPXML::SiteTypeSuburban => 'Suburbs', # Rough, wooded country, suburbs
+                 HPXML::SiteTypeUrban => 'City' }      # Towns, city outskirts, center of large cities
+    model.getSite.setTerrain(site_map[site_type])
+
     wind_speed = WindSpeed.new
     wind_speed.height = 32.8 # ft (Standard weather station height)
 
     # Open, Unrestricted at Weather Station
-    wind_speed.terrain_multiplier = 1.0 # Used for DOE-2's correlation
-    wind_speed.terrain_exponent = 0.15 # Used for DOE-2's correlation
+    wind_speed.terrain_multiplier = 1.0
+    wind_speed.terrain_exponent = 0.15
     wind_speed.ashrae_terrain_thickness = 270
     wind_speed.ashrae_terrain_exponent = 0.14
 
-    if terrain == Constants.TerrainOcean
-      wind_speed.site_terrain_multiplier = 1.30 # Used for DOE-2's correlation
-      wind_speed.site_terrain_exponent = 0.10 # Used for DOE-2's correlation
-      wind_speed.ashrae_site_terrain_thickness = 210 # Ocean, Bayou flat country
-      wind_speed.ashrae_site_terrain_exponent = 0.10 # Ocean, Bayou flat country
-    elsif terrain == Constants.TerrainPlains
-      wind_speed.site_terrain_multiplier = 1.00 # Used for DOE-2's correlation
-      wind_speed.site_terrain_exponent = 0.15 # Used for DOE-2's correlation
+    if site_type == HPXML::SiteTypeRural
+      wind_speed.site_terrain_multiplier = 0.85
+      wind_speed.site_terrain_exponent = 0.20
       wind_speed.ashrae_site_terrain_thickness = 270 # Flat, open country
       wind_speed.ashrae_site_terrain_exponent = 0.14 # Flat, open country
-    elsif terrain == Constants.TerrainRural
-      wind_speed.site_terrain_multiplier = 0.85 # Used for DOE-2's correlation
-      wind_speed.site_terrain_exponent = 0.20 # Used for DOE-2's correlation
-      wind_speed.ashrae_site_terrain_thickness = 270 # Flat, open country
-      wind_speed.ashrae_site_terrain_exponent = 0.14 # Flat, open country
-    elsif terrain == Constants.TerrainSuburban
-      wind_speed.site_terrain_multiplier = 0.67 # Used for DOE-2's correlation
-      wind_speed.site_terrain_exponent = 0.25 # Used for DOE-2's correlation
+    elsif site_type == HPXML::SiteTypeSuburban
+      wind_speed.site_terrain_multiplier = 0.67
+      wind_speed.site_terrain_exponent = 0.25
       wind_speed.ashrae_site_terrain_thickness = 370 # Rough, wooded country, suburbs
       wind_speed.ashrae_site_terrain_exponent = 0.22 # Rough, wooded country, suburbs
-    elsif terrain == Constants.TerrainCity
-      wind_speed.site_terrain_multiplier = 0.47 # Used for DOE-2's correlation
-      wind_speed.site_terrain_exponent = 0.35 # Used for DOE-2's correlation
+    elsif site_type == HPXML::SiteTypeUrban
+      wind_speed.site_terrain_multiplier = 0.47
+      wind_speed.site_terrain_exponent = 0.35
       wind_speed.ashrae_site_terrain_thickness = 460 # Towns, city outskirts, center of large cities
       wind_speed.ashrae_site_terrain_exponent = 0.33 # Towns, city outskirts, center of large cities
     end
@@ -232,13 +142,12 @@ class Airflow
       if min_neighbor_distance.nil?
         # Typical shelter for isolated rural house
         wind_speed.S_wo = 0.90
-      elsif min_neighbor_distance > building_height
+      elsif min_neighbor_distance > @building_height
         # Typical shelter caused by other building across the street
         wind_speed.S_wo = 0.70
       else
         # Typical shelter for urban buildings where sheltering obstacles
         # are less than one building height away.
-        # Recommended by C.Christensen.
         wind_speed.S_wo = 0.50
       end
     else
@@ -251,453 +160,343 @@ class Airflow
     return wind_speed
   end
 
-  def self.process_infiltration(model, infil, wind_speed, building, weather)
-    spaces = []
-    spaces << building.garage if not building.garage.nil?
-    spaces << building.unconditioned_basement if not building.unconditioned_basement.nil?
-    spaces << building.vented_crawlspace if not building.vented_crawlspace.nil?
-    spaces << building.unvented_crawlspace if not building.unvented_crawlspace.nil?
-    spaces << building.vented_attic if not building.vented_attic.nil?
-    spaces << building.unvented_attic if not building.unvented_attic.nil?
-
-    unless building.garage.nil?
-      building.garage.inf_method = @infMethodELA
-      building.garage.hor_lk_frac = 0.4
-      building.garage.neutral_level = 0.5
-      building.garage.SLA = Airflow.get_infiltration_SLA_from_ACH50(infil.garage_ach50, 0.65, building.garage.area, building.garage.volume)
-      building.garage.ACH = Airflow.get_infiltration_ACH_from_SLA(building.garage.SLA, 8.202, weather)
-      building.garage.inf_flow = building.garage.ACH / UnitConversions.convert(1.0, 'hr', 'min') * building.garage.volume # cfm
-    end
-
-    unless building.unconditioned_basement.nil?
-      building.unconditioned_basement.inf_method = @infMethodConstantCFM # Used for constant ACH
-      building.unconditioned_basement.inf_flow = building.unconditioned_basement.ACH / UnitConversions.convert(1.0, 'hr', 'min') * building.unconditioned_basement.volume
-    end
-
-    unless building.vented_crawlspace.nil?
-      building.vented_crawlspace.inf_method = @infMethodConstantCFM
-      building.vented_crawlspace.ACH = Airflow.get_infiltration_ACH_from_SLA(building.vented_crawlspace.SLA, 8.202, weather)
-      building.vented_crawlspace.inf_flow = building.vented_crawlspace.ACH / UnitConversions.convert(1.0, 'hr', 'min') * building.vented_crawlspace.volume
-    end
-
-    unless building.unvented_crawlspace.nil?
-      building.unvented_crawlspace.inf_method = @infMethodConstantCFM
-      building.unvented_crawlspace.ACH = Airflow.get_infiltration_ACH_from_SLA(building.unvented_crawlspace.SLA, 8.202, weather)
-      building.unvented_crawlspace.inf_flow = building.unvented_crawlspace.ACH / UnitConversions.convert(1.0, 'hr', 'min') * building.unvented_crawlspace.volume
-    end
-
-    unless building.vented_attic.nil?
-      if not building.vented_attic.SLA.nil?
-        building.vented_attic.inf_method = @infMethodELA
-        building.vented_attic.hor_lk_frac = 1.0
-        building.vented_attic.neutral_level = 0.5
-        building.vented_attic.ACH = Airflow.get_infiltration_ACH_from_SLA(building.vented_attic.SLA, 8.202, weather)
-      elsif not building.vented_attic.ACH.nil?
-        building.vented_attic.inf_method = @infMethodConstantCFM
-      end
-      building.vented_attic.inf_flow = building.vented_attic.ACH / UnitConversions.convert(1.0, 'hr', 'min') * building.vented_attic.volume
-    end
-
-    unless building.unvented_attic.nil?
-      if not building.unvented_attic.SLA.nil?
-        building.unvented_attic.inf_method = @infMethodELA
-        building.unvented_attic.hor_lk_frac = 1.0
-        building.unvented_attic.neutral_level = 0.5 # DOE-2 Default
-        building.unvented_attic.ACH = Airflow.get_infiltration_ACH_from_SLA(building.unvented_attic.SLA, 8.202, weather)
-      elsif not building.unvented_attic.ACH.nil?
-        building.unvented_attic.inf_method = @infMethodConstantCFM
-      end
-      building.unvented_attic.inf_flow = building.unvented_attic.ACH / UnitConversions.convert(1.0, 'hr', 'min') * building.unvented_attic.volume
-    end
-
-    process_infiltration_for_spaces(model, spaces, wind_speed)
-  end
-
-  def self.create_air_loop_objects(model, air_loops, mech_vent, building)
-    # Obtain data across all air loops (needed for ducts, CFIS w/ separate heating and cooling air loops)
-    air_loop_objects = {}
-    air_loops.each_with_index do |air_loop, air_loop_index|
-      next unless building.living.zone.airLoopHVACs.include? air_loop # next if airloop doesn't serve this
-
-      system = HVAC.get_unitary_system_from_air_loop_hvac(air_loop)
-      if system.nil? # Evap cooler system stored information in airloopHVAC
-        system = air_loop
-      end
-      next if system.nil?
-
-      # Get the supply fan
-      supply_fan = nil
-      if air_loop.to_AirLoopHVAC.is_initialized
-        supply_fan = system.supplyFan.get
-      end
-
-      # Supply fan runtime fraction
-      fan_rtf_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{air_loop.name} Fan RTF".gsub(' ', '_'))
-      if supply_fan.to_FanOnOff.is_initialized
-        fan_rtf_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Fan Runtime Fraction')
-        fan_rtf_sensor.setName("#{fan_rtf_var.name} s")
-        fan_rtf_sensor.setKeyName(supply_fan.name.to_s)
-      elsif supply_fan.to_FanVariableVolume.is_initialized
-        fan_mfr_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Fan Air Mass Flow Rate')
-        fan_mfr_sensor.setName("#{supply_fan.name} air MFR")
-        fan_mfr_sensor.setKeyName("#{supply_fan.name}")
-        fan_rtf_sensor = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{fan_rtf_var.name}_s")
-      else
-        fail "Unexpected fan: #{supply_fan.name}"
-      end
-
-      # Supply fan maximum mass flow rate
-      fan_mfr_max_var = OpenStudio::Model::EnergyManagementSystemInternalVariable.new(model, 'Fan Maximum Mass Flow Rate')
-      fan_mfr_max_var.setName("#{air_loop.name} max sup fan mfr")
-      fan_mfr_max_var.setInternalDataIndexKeyName(supply_fan.name.to_s)
-
-      air_loop_objects[air_loop] = { fan_rtf_var: fan_rtf_var,
-                                     fan_rtf_sensor: fan_rtf_sensor,
-                                     fan_mfr_max_var: fan_mfr_max_var,
-                                     fan_mfr_sensor: fan_mfr_sensor }
-
-      if (mech_vent.type == HPXML::MechVentTypeCFIS) && (air_loop == mech_vent.cfis_air_loop)
-        mech_vent.cfis_fan_rtf_sensor = fan_rtf_sensor.name
-        mech_vent.cfis_fan_mfr_max_var = fan_mfr_max_var.name
-      end
-    end
-
-    return air_loop_objects
-  end
-
-  def self.process_infiltration_for_conditioned_zones(model, infil, wind_speed, building, weather)
-    spaces = []
-    spaces << building.living
-
-    outside_air_density = UnitConversions.convert(weather.header.LocalPressure, 'atm', 'Btu/ft^3') / (Gas.Air.r * (weather.data.AnnualAvgDrybulb + 460.0))
-    inf_conv_factor = 776.25 # [ft/min]/[inH2O^(1/2)*ft^(3/2)/lbm^(1/2)]
-    delta_pref = 0.016 # inH2O
-
-    # Living Space Infiltration
-    if not infil.living_ach50.nil?
-      building.living.inf_method = @infMethodAIM2
-
-      # Based on "Field Validation of Algebraic Equations for Stack and
-      # Wind Driven Air Infiltration Calculations" by Walker and Wilson (1998)
-
-      # Pressure Exponent
-      n_i = 0.65
-
-      # Calculate SLA
-      building.living.SLA = Airflow.get_infiltration_SLA_from_ACH50(infil.living_ach50, n_i, building.cfa, building.infilvolume)
-
-      # Effective Leakage Area (ft^2)
-      a_o = building.living.SLA * building.cfa
-
-      # Flow Coefficient (cfm/inH2O^n) (based on ASHRAE HoF)
-      c_i = a_o * (2.0 / outside_air_density)**0.5 * delta_pref**(0.5 - n_i) * inf_conv_factor
-
-      if infil.has_flue_chimney
-        y_i = 0.2 # Fraction of leakage through the flue; 0.2 is a "typical" value according to THE ALBERTA AIR INFIL1RATION MODEL, Walker and Wilson, 1990
-        flue_height = building.height + 2.0 # ft
-        s_wflue = 1.0 # Flue Shelter Coefficient
-      else
-        y_i = 0.0 # Fraction of leakage through the flu
-        flue_height = 0.0 # ft
-        s_wflue = 0.0 # Flue Shelter Coefficient
-      end
-
-      vented_crawl = false
-      if not building.vented_crawlspace.nil?
-        vented_crawl = true
-      end
-
-      # Leakage distributions per Iain Walker (LBL) recommendations
-      if vented_crawl
-        # 15% ceiling, 35% walls, 50% floor leakage distribution for vented crawl
-        leakkage_ceiling = 0.15
-        leakage_walls = 0.35
-        leakage_floor = 0.50
-      else
-        # 25% ceiling, 50% walls, 25% floor leakage distribution for slab/basement/unvented crawl
-        leakkage_ceiling = 0.25
-        leakage_walls = 0.50
-        leakage_floor = 0.25
-      end
-      if leakkage_ceiling + leakage_walls + leakage_floor != 1
-        fail "Invalid air leakage distribution specified (#{leakkage_ceiling}, #{leakage_walls}, #{leakage_floor}); does not add up to 1."
-      end
-
-      r_i = (leakkage_ceiling + leakage_floor)
-      x_i = (leakkage_ceiling - leakage_floor)
-      r_i *= (1 - y_i)
-      x_i *= (1 - y_i)
-
-      building.living.hor_lk_frac = r_i
-      z_f = flue_height / (building.infilheight + building.living.coord_z)
-
-      # Calculate Stack Coefficient
-      m_o = (x_i + (2.0 * n_i + 1.0) * y_i)**2.0 / (2 - r_i)
-
-      if m_o <=  1.0
-        m_i = m_o # eq. 10
-      else
-        m_i = 1.0 # eq. 11
-      end
-
-      if infil.has_flue_chimney
-        # Eq. 13
-        x_c = r_i + (2.0 * (1.0 - r_i - y_i)) / (n_i + 1.0) - 2.0 * y_i * (z_f - 1.0)**n_i
-        # Additive flue function, Eq. 12
-        f_i = n_i * y_i * (z_f - 1.0)**((3.0 * n_i - 1.0) / 3.0) * (1.0 - (3.0 * (x_c - x_i)**2.0 * r_i**(1 - n_i)) / (2.0 * (z_f + 1.0)))
-      else
-        # Critical value of ceiling-floor leakage difference where the
-        # neutral level is located at the ceiling (eq. 13)
-        x_c = r_i + (2.0 * (1.0 - r_i - y_i)) / (n_i + 1.0)
-        # Additive flue function (eq. 12)
-        f_i = 0.0
-      end
-
-      f_s = ((1.0 + n_i * r_i) / (n_i + 1.0)) * (0.5 - 0.5 * m_i**1.2)**(n_i + 1.0) + f_i
-
-      stack_coef = f_s * (UnitConversions.convert(outside_air_density * Constants.g * building.infilheight, 'lbm/(ft*s^2)', 'inH2O') / (Constants.AssumedInsideTemp + 460.0))**n_i # inH2O^n/R^n
-
-      # Calculate wind coefficient
-      if vented_crawl
-
-        if x_i > 1.0 - 2.0 * y_i
-          # Critical floor to ceiling difference above which f_w does not change (eq. 25)
-          x_i = 1.0 - 2.0 * y_i
-        end
-
-        # Redefined R for wind calculations for houses with crawlspaces (eq. 21)
-        r_x = 1.0 - r_i * (n_i / 2.0 + 0.2)
-        # Redefined Y for wind calculations for houses with crawlspaces (eq. 22)
-        y_x = 1.0 - y_i / 4.0
-        # Used to calculate X_x (eq.24)
-        x_s = (1.0 - r_i) / 5.0 - 1.5 * y_i
-        # Redefined X for wind calculations for houses with crawlspaces (eq. 23)
-        x_x = 1.0 - (((x_i - x_s) / (2.0 - r_i))**2.0)**0.75
-        # Wind factor (eq. 20)
-        f_w = 0.19 * (2.0 - n_i) * x_x * r_x * y_x
-
-      else
-
-        j_i = (x_i + r_i + 2.0 * y_i) / 2.0
-        f_w = 0.19 * (2.0 - n_i) * (1.0 - ((x_i + r_i) / 2.0)**(1.5 - y_i)) - y_i / 4.0 * (j_i - 2.0 * y_i * j_i**4.0)
-
-      end
-
-      wind_coef = f_w * UnitConversions.convert(outside_air_density / 2.0, 'lbm/ft^3', 'inH2O/mph^2')**n_i # inH2O^n/mph^2n
-
-      building.living.ACH = Airflow.get_infiltration_ACH_from_SLA(building.living.SLA, building.infilheight, weather)
-
-      # Convert living space ACH to cfm:
-      building.living.inf_flow = building.living.ACH / UnitConversions.convert(1.0, 'hr', 'min') * building.infilvolume # cfm
-
-    elsif not infil.living_constant_ach.nil?
-
-      building.living.inf_method = @infMethodConstantCFM
-
-      building.living.ACH = infil.living_constant_ach
-      building.living.inf_flow = building.living.ACH / UnitConversions.convert(1.0, 'hr', 'min') * building.infilvolume # cfm
-
-    end
-
-    process_infiltration_for_spaces(model, spaces, wind_speed)
-
-    infil.a_o = a_o
-    infil.c_i = c_i
-    infil.n_i = n_i
-    infil.stack_coef = stack_coef
-    infil.wind_coef = wind_coef
-    infil.y_i = y_i
-    infil.s_wflue = s_wflue
-  end
-
-  def self.process_infiltration_for_spaces(model, spaces, wind_speed)
-    spaces.each do |space|
-      space.f_t_SG = wind_speed.site_terrain_multiplier * ((space.height + space.coord_z) / 32.8)**wind_speed.site_terrain_exponent / (wind_speed.terrain_multiplier * (wind_speed.height / 32.8)**wind_speed.terrain_exponent)
-
-      if space.inf_method == @infMethodELA
-        space.f_s_SG = 2.0 / 3.0 * (1 + space.hor_lk_frac / 2.0) * (2.0 * space.neutral_level * (1.0 - space.neutral_level))**0.5 / (space.neutral_level**0.5 + (1.0 - space.neutral_level)**0.5)
-        space.f_w_SG = wind_speed.shielding_coef * (1.0 - space.hor_lk_frac)**(1.0 / 3.0) * space.f_t_SG
-        space.C_s_SG = space.f_s_SG**2.0 * Constants.g * space.height / (Constants.AssumedInsideTemp + 460.0)
-        space.C_w_SG = space.f_w_SG**2.0
-        space.ELA = space.SLA * space.area # ft^2
-      elsif space.inf_method == @infMethodAIM2
-        space.ELA = space.SLA * space.area # ft^2
-      end
-
-      space.zone.spaces.each do |s|
-        next if Geometry.is_living(s)
-
-        obj_name = "#{Constants.ObjectNameInfiltration}|#{s.name}"
-        if (space.inf_method == @infMethodConstantCFM) && (space.ACH.to_f > 0)
-          flow_rate = OpenStudio::Model::SpaceInfiltrationDesignFlowRate.new(model)
-          flow_rate.setName(obj_name)
-          flow_rate.setSchedule(model.alwaysOnDiscreteSchedule)
-          flow_rate.setAirChangesperHour(space.ACH)
-          flow_rate.setSpace(s)
-          flow_rate.setConstantTermCoefficient(1)
-          flow_rate.setTemperatureTermCoefficient(0)
-          flow_rate.setVelocityTermCoefficient(0)
-          flow_rate.setVelocitySquaredTermCoefficient(0)
-        elsif (space.inf_method == @infMethodELA) && (space.ELA.to_f > 0)
-          leakage_area = OpenStudio::Model::SpaceInfiltrationEffectiveLeakageArea.new(model)
-          leakage_area.setName(obj_name)
-          leakage_area.setSchedule(model.alwaysOnDiscreteSchedule)
-          leakage_area.setEffectiveAirLeakageArea(UnitConversions.convert(space.ELA, 'ft^2', 'cm^2'))
-          leakage_area.setStackCoefficient(UnitConversions.convert(space.C_s_SG, 'ft^2/(s^2*R)', 'L^2/(s^2*cm^4*K)'))
-          leakage_area.setWindCoefficient(space.C_w_SG * 0.01)
-          leakage_area.setSpace(s)
-        elsif space.inf_method == @infMethodAIM2
-          # nop
-        end
-      end
+  def self.apply_infiltration_to_unconditioned_space(model, space, ach = nil, ela = nil, c_w_SG = nil, c_s_SG = nil)
+    if ach.to_f > 0
+      # Model ACH as constant infiltration/ventilation
+      # This is typically used for below-grade spaces where wind is zero
+      flow_rate = OpenStudio::Model::SpaceInfiltrationDesignFlowRate.new(model)
+      flow_rate.setName("#{Constants.ObjectNameInfiltration}|#{space.name}")
+      flow_rate.setSchedule(model.alwaysOnDiscreteSchedule)
+      flow_rate.setAirChangesperHour(ach)
+      flow_rate.setSpace(space)
+      flow_rate.setConstantTermCoefficient(1)
+      flow_rate.setTemperatureTermCoefficient(0)
+      flow_rate.setVelocityTermCoefficient(0)
+      flow_rate.setVelocitySquaredTermCoefficient(0)
+    elsif ela.to_f > 0
+      # Model ELA with stack/wind coefficients
+      leakage_area = OpenStudio::Model::SpaceInfiltrationEffectiveLeakageArea.new(model)
+      leakage_area.setName("#{Constants.ObjectNameInfiltration}|#{space.name}")
+      leakage_area.setSchedule(model.alwaysOnDiscreteSchedule)
+      leakage_area.setEffectiveAirLeakageArea(UnitConversions.convert(ela, 'ft^2', 'cm^2'))
+      leakage_area.setStackCoefficient(UnitConversions.convert(c_s_SG, 'ft^2/(s^2*R)', 'L^2/(s^2*cm^4*K)'))
+      leakage_area.setWindCoefficient(c_w_SG * 0.01)
+      leakage_area.setSpace(space)
     end
   end
 
-  def self.process_mech_vent(model, mech_vent, building, weather, infil)
-    if mech_vent.type == HPXML::MechVentTypeCFIS
-      if not HVAC.has_ducted_equipment(model, mech_vent.cfis_air_loop)
-        fail 'A CFIS ventilation system has been specified but the building does not have central, forced air equipment.'
-      end
+  def self.apply_natural_ventilation_and_whole_house_fan(model, weather, vent_whf, open_window_area, nv_clg_ssn_sensor)
+    if @living_zone.thermostatSetpointDualSetpoint.is_initialized
+      thermostat = @living_zone.thermostatSetpointDualSetpoint.get
+      htg_sch = thermostat.heatingSetpointTemperatureSchedule.get
+      clg_sch = thermostat.coolingSetpointTemperatureSchedule.get
     end
 
-    # Fraction of fan heat that goes to the space
-    if [HPXML::MechVentTypeExhaust].include? mech_vent.type
-      frac_fan_heat = 0.0 # Fan heat does not enter space
-    elsif [HPXML::MechVentTypeSupply, HPXML::MechVentTypeCFIS].include? mech_vent.type
-      frac_fan_heat = 1.0 # Fan heat does enter space
-    elsif [HPXML::MechVentTypeBalanced, HPXML::MechVentTypeERV, HPXML::MechVentTypeHRV].include? mech_vent.type
-      frac_fan_heat = 0.5 # Assumes supply fan heat enters space
+    nv_num_days_per_week = 7 # FUTURE: Expose via HPXML?
+    if vent_whf.nil?
+      whf_num_days_per_week = 0
+      whf_cfm = 0.0
+      whf_fan_w = 0.0
     else
-      frac_fan_heat = 0.0
+      whf_num_days_per_week = 7 # FUTURE: Expose via HPXML?
+      whf_cfm = vent_whf.rated_flow_rate
+      whf_fan_w = vent_whf.fan_power
     end
 
-    # Get the clothes washer so we can use the day shift for the clothes dryer
-    if mech_vent.dryer_exhaust > 0
-      cw_day_shift = 0.0
-      model.getElectricEquipments.each do |ee|
-        next if ee.name.to_s != Constants.ObjectNameClothesWasher
-
-        cw_day_shift = ee.additionalProperties.getFeatureAsDouble(Constants.ClothesWasherDayShift).get
-        break
+    # Availability Schedule
+    aval_schs = {}
+    { Constants.ObjectNameNaturalVentilation => nv_num_days_per_week,
+      Constants.ObjectNameWholeHouseFan => whf_num_days_per_week }.each do |obj_name, num_days_per_week|
+      aval_schs[obj_name] = OpenStudio::Model::ScheduleRuleset.new(model)
+      aval_schs[obj_name].setName("#{obj_name} avail schedule")
+      Schedule.set_schedule_type_limits(model, aval_schs[obj_name], Constants.ScheduleTypeLimitsOnOff)
+      on_rule = OpenStudio::Model::ScheduleRule.new(aval_schs[obj_name])
+      on_rule.setName("#{obj_name} avail schedule rule")
+      on_rule_day = on_rule.daySchedule
+      on_rule_day.setName("#{obj_name} avail schedule day")
+      on_rule_day.addValue(OpenStudio::Time.new(0, 24, 0, 0), 1)
+      if num_days_per_week >= 1
+        on_rule.setApplyMonday(true)
       end
-      dryer_exhaust_day_shift = cw_day_shift + 1.0 / 24.0
+      if num_days_per_week >= 2
+        on_rule.setApplyWednesday(true)
+      end
+      if num_days_per_week >= 3
+        on_rule.setApplyFriday(true)
+      end
+      if num_days_per_week >= 4
+        on_rule.setApplySaturday(true)
+      end
+      if num_days_per_week >= 5
+        on_rule.setApplyTuesday(true)
+      end
+      if num_days_per_week >= 6
+        on_rule.setApplyThursday(true)
+      end
+      if num_days_per_week >= 7
+        on_rule.setApplySunday(true)
+      end
+      on_rule.setStartDate(OpenStudio::Date::fromDayOfYear(1))
+      on_rule.setEndDate(OpenStudio::Date::fromDayOfYear(365))
     end
 
-    # Search for clothes dryer
-    has_dryer = false
-    (model.getElectricEquipments + model.getOtherEquipments).each do |equip|
-      next unless equip.name.to_s == Constants.ObjectNameClothesDryer
-
-      has_dryer = true
-      break
+    # Sensors
+    if not htg_sch.nil?
+      htg_sp_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Schedule Value')
+      htg_sp_sensor.setName('htg sp s')
+      htg_sp_sensor.setKeyName(htg_sch.name.to_s)
     end
 
-    if (not has_dryer) && (mech_vent.dryer_exhaust > 0)
-      @runner.registerWarning('No clothes dryer object was found but the clothes dryer exhaust specified is non-zero. Overriding clothes dryer exhaust to be zero.')
+    if not clg_sch.nil?
+      clg_sp_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Schedule Value')
+      clg_sp_sensor.setName('clg sp s')
+      clg_sp_sensor.setKeyName(clg_sch.name.to_s)
     end
 
-    #--- Calculate HRV/ERV effectiveness values. Calculated here for use in sizing routines.
+    nv_avail_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Schedule Value')
+    nv_avail_sensor.setName("#{Constants.ObjectNameNaturalVentilation} nva s")
+    nv_avail_sensor.setKeyName(aval_schs[Constants.ObjectNameNaturalVentilation].name.to_s)
 
-    apparent_sensible_effectiveness = 0.0
-    sensible_effectiveness = 0.0
-    latent_effectiveness = 0.0
+    whf_avail_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Schedule Value')
+    whf_avail_sensor.setName("#{Constants.ObjectNameWholeHouseFan} nva s")
+    whf_avail_sensor.setKeyName(aval_schs[Constants.ObjectNameWholeHouseFan].name.to_s)
 
-    if [HPXML::MechVentTypeERV, HPXML::MechVentTypeHRV].include?(mech_vent.type) && (mech_vent.cfm > 0)
-      # Must assume an operating condition (HVI seems to use CSA 439)
-      t_sup_in = 0.0
-      w_sup_in = 0.0028
-      t_exh_in = 22.0
-      w_exh_in = 0.0065
-      cp_a = 1006.0
-      p_fan = mech_vent.fan_power_w # Watts
+    # Actuators
+    nv_flow = OpenStudio::Model::SpaceInfiltrationDesignFlowRate.new(model)
+    nv_flow.setName(Constants.ObjectNameNaturalVentilation + ' flow')
+    nv_flow.setSchedule(model.alwaysOnDiscreteSchedule)
+    nv_flow.setSpace(@living_space)
+    nv_flow_actuator = OpenStudio::Model::EnergyManagementSystemActuator.new(nv_flow, 'Zone Infiltration', 'Air Exchange Flow Rate')
+    nv_flow_actuator.setName("#{nv_flow.name} act")
 
-      m_fan = UnitConversions.convert(mech_vent.cfm, 'cfm', 'm^3/s') * 16.02 * Psychrometrics.rhoD_fT_w_P(UnitConversions.convert(t_sup_in, 'C', 'F'), w_sup_in, 14.7) # kg/s
+    whf_flow = OpenStudio::Model::SpaceInfiltrationDesignFlowRate.new(model)
+    whf_flow.setName(Constants.ObjectNameWholeHouseFan + ' flow')
+    whf_flow.setSchedule(model.alwaysOnDiscreteSchedule)
+    whf_flow.setSpace(@living_space)
+    whf_flow_actuator = OpenStudio::Model::EnergyManagementSystemActuator.new(whf_flow, 'Zone Infiltration', 'Air Exchange Flow Rate')
+    whf_flow_actuator.setName("#{whf_flow.name} act")
 
-      if mech_vent.sensible_efficiency > 0
-        # The following is derived from CSA 439, Clause 9.3.3.1, Eq. 12:
-        #    E_SHR = (m_sup,fan * Cp * (Tsup,out - Tsup,in) - P_sup,fan) / (m_exh,fan * Cp * (Texh,in - Tsup,in) + P_exh,fan)
-        t_sup_out = t_sup_in + (mech_vent.sensible_efficiency * (m_fan * cp_a * (t_exh_in - t_sup_in) + p_fan) + p_fan) / (m_fan * cp_a)
+    # Assume located in attic floor if attic zone exists; otherwise assume it's through roof/wall.
+    whf_zone = nil
+    if not @spaces[HPXML::LocationAtticVented].nil?
+      whf_zone = @spaces[HPXML::LocationAtticVented].thermalZone.get
+    elsif not @spaces[HPXML::LocationAtticUnvented].nil?
+      whf_zone = @spaces[HPXML::LocationAtticUnvented].thermalZone.get
+    end
+    if not whf_zone.nil?
+      # Air from living to WHF zone (attic)
+      zone_mixing = OpenStudio::Model::ZoneMixing.new(whf_zone)
+      zone_mixing.setName("#{Constants.ObjectNameWholeHouseFan} mix")
+      zone_mixing.setSourceZone(@living_zone)
+      liv_to_zone_flow_rate_actuator = OpenStudio::Model::EnergyManagementSystemActuator.new(zone_mixing, 'ZoneMixing', 'Air Exchange Flow Rate')
+      liv_to_zone_flow_rate_actuator.setName("#{zone_mixing.name} act")
+    end
 
-        # Calculate the apparent sensible effectiveness
-        apparent_sensible_effectiveness = (t_sup_out - t_sup_in) / (t_exh_in - t_sup_in)
+    # Electric Equipment (for whole house fan electricity consumption)
 
-      else
-        # The following is derived from (taken from CSA 439, Clause 9.2.1, Eq. 7):
-        t_sup_out = t_sup_in + (mech_vent.sensible_efficiency_adjusted * (t_exh_in - t_sup_in))
+    whf_equip_def = OpenStudio::Model::ElectricEquipmentDefinition.new(model)
+    whf_equip_def.setName(Constants.ObjectNameWholeHouseFan)
+    whf_equip = OpenStudio::Model::ElectricEquipment.new(whf_equip_def)
+    whf_equip.setName(Constants.ObjectNameWholeHouseFan)
+    whf_equip.setSpace(@living_space)
+    whf_equip_def.setFractionRadiant(0)
+    whf_equip_def.setFractionLatent(0)
+    whf_equip_def.setFractionLost(1)
+    whf_equip.setSchedule(model.alwaysOnDiscreteSchedule)
+    whf_equip.setEndUseSubcategory(Constants.ObjectNameWholeHouseFan)
+    whf_elec_actuator = OpenStudio::Model::EnergyManagementSystemActuator.new(whf_equip, 'ElectricEquipment', 'Electric Power Level')
+    whf_elec_actuator.setName("#{whf_equip.name} act")
 
-        apparent_sensible_effectiveness = mech_vent.sensible_efficiency_adjusted
+    area = 0.6 * open_window_area # ft^2, for Sherman-Grimsrud
+    max_rate = 20.0 # Air Changes per hour
+    max_flow_rate = max_rate * @infil_volume / UnitConversions.convert(1.0, 'hr', 'min')
+    neutral_level = 0.5
+    hor_lk_frac = 0.0
+    c_w, c_s = calc_wind_stack_coeffs(hor_lk_frac, neutral_level, @living_space, @infil_height)
+    max_oa_hr = 0.0115 # From BA HSP
+    max_oa_rh = 0.7 # From BA HSP
 
-      end
-
-      # Calculate the supply temperature before the fan
-      t_sup_out_gross = t_sup_out - p_fan / (m_fan * cp_a)
-
-      # Sensible effectiveness of the HX only
-      sensible_effectiveness = (t_sup_out_gross - t_sup_in) / (t_exh_in - t_sup_in)
-
-      if (sensible_effectiveness < 0.0) || (sensible_effectiveness > 1.0)
-        fail "The calculated ERV/HRV sensible effectiveness is #{sensible_effectiveness} but should be between 0 and 1. Please revise ERV/HRV efficiency values."
-      end
-
-      # Use summer test condition to determine the latent effectiveness since TRE is generally specified under the summer condition
-      if ((mech_vent.total_efficiency > 0) || (mech_vent.total_efficiency_adjusted > 0))
-
-        t_sup_in = 35.0
-        w_sup_in = 0.0178
-        t_exh_in = 24.0
-        w_exh_in = 0.0092
-
-        m_fan = UnitConversions.convert(mech_vent.cfm, 'cfm', 'm^3/s') * UnitConversions.convert(Psychrometrics.rhoD_fT_w_P(UnitConversions.convert(t_sup_in, 'C', 'F'), w_sup_in, 14.7), 'lbm/ft^3', 'kg/m^3') # kg/s
-
-        t_sup_out_gross = t_sup_in - sensible_effectiveness * (t_sup_in - t_exh_in)
-        t_sup_out = t_sup_out_gross + p_fan / (m_fan * cp_a)
-
-        h_sup_in = Psychrometrics.h_fT_w_SI(t_sup_in, w_sup_in)
-        h_exh_in = Psychrometrics.h_fT_w_SI(t_exh_in, w_exh_in)
-
-        if mech_vent.total_efficiency > 0
-          # The following is derived from CSA 439, Clause 9.3.3.2, Eq. 13:
-          #    E_THR = (m_sup,fan * Cp * (h_sup,out - h_sup,in) - P_sup,fan) / (m_exh,fan * Cp * (h_exh,in - h_sup,in) + P_exh,fan)
-          h_sup_out = h_sup_in - (mech_vent.total_efficiency * (m_fan * (h_sup_in - h_exh_in) + p_fan) + p_fan) / m_fan
-        else
-          # The following is derived from (taken from CSA 439, Clause 9.2.1, Eq. 7):
-          h_sup_out = h_sup_in - (mech_vent.total_efficiency_adjusted * (h_sup_in - h_exh_in))
-        end
-
-        w_sup_out = Psychrometrics.w_fT_h_SI(t_sup_out, h_sup_out)
-        latent_effectiveness = [0.0, (w_sup_out - w_sup_in) / (w_exh_in - w_sup_in)].max
-
-        if (latent_effectiveness < 0.0) || (latent_effectiveness > 1.0)
-          fail "The calculated ERV/HRV latent effectiveness is #{latent_effectiveness} but should be between 0 and 1. Please revise ERV/HRV efficiency values."
-        end
-
-      else
-        latent_effectiveness = 0.0
-      end
+    # Program
+    vent_program = OpenStudio::Model::EnergyManagementSystemProgram.new(model)
+    vent_program.setName(Constants.ObjectNameNaturalVentilation + ' program')
+    vent_program.addLine("Set Tin = #{@tin_sensor.name}")
+    vent_program.addLine("Set Tout = #{@tout_sensor.name}")
+    vent_program.addLine("Set Wout = #{@wout_sensor.name}")
+    vent_program.addLine("Set Pbar = #{@pbar_sensor.name}")
+    vent_program.addLine('Set Phiout = (@RhFnTdbWPb Tout Wout Pbar)')
+    vent_program.addLine("Set MaxHR = #{max_oa_hr}")
+    vent_program.addLine("Set MaxRH = #{max_oa_rh}")
+    if (not htg_sp_sensor.nil?) && (not clg_sp_sensor.nil?)
+      vent_program.addLine("Set Tnvsp = (#{htg_sp_sensor.name} + #{clg_sp_sensor.name}) / 2") # Average of heating/cooling setpoints to minimize incurring additional heating energy
     else
-      if mech_vent.total_efficiency > 0
-        apparent_sensible_effectiveness = mech_vent.total_efficiency
-        sensible_effectiveness = mech_vent.total_efficiency
-        latent_effectiveness = mech_vent.total_efficiency
-      end
+      vent_program.addLine("Set Tnvsp = #{UnitConversions.convert(73.0, 'F', 'C')}") # Assumption when no HVAC system
     end
+    vent_program.addLine("Set NVavail = #{nv_avail_sensor.name}")
+    vent_program.addLine("Set WHFavail = #{whf_avail_sensor.name}")
+    vent_program.addLine("Set ClgSsnAvail = #{nv_clg_ssn_sensor.name}")
+    vent_program.addLine('If (Wout < MaxHR) && (Phiout < MaxRH) && (Tin > Tout) && (Tin > Tnvsp) && (ClgSsnAvail > 0)')
+    vent_program.addLine("  Set WHF_Flow = #{UnitConversions.convert(whf_cfm, 'cfm', 'm^3/s')}")
+    vent_program.addLine('  Set Adj = (Tin-Tnvsp)/(Tin-Tout)')
+    vent_program.addLine('  Set Adj = (@Min Adj 1)')
+    vent_program.addLine('  Set Adj = (@Max Adj 0)')
+    vent_program.addLine('  If (WHFavail > 0) && (WHF_Flow > 0)') # If available, prioritize whole house fan
+    vent_program.addLine("    Set #{nv_flow_actuator.name} = 0")
+    vent_program.addLine("    Set #{whf_flow_actuator.name} = WHF_Flow*Adj")
+    vent_program.addLine("    Set #{liv_to_zone_flow_rate_actuator.name} = WHF_Flow*Adj") unless whf_zone.nil?
+    vent_program.addLine("    Set #{whf_elec_actuator.name} = #{whf_fan_w}*Adj")
+    vent_program.addLine('  ElseIf (NVavail > 0)') # Natural ventilation
+    vent_program.addLine("    Set NVArea = #{UnitConversions.convert(area, 'ft^2', 'cm^2')}")
+    vent_program.addLine("    Set Cs = #{UnitConversions.convert(c_s, 'ft^2/(s^2*R)', 'L^2/(s^2*cm^4*K)')}")
+    vent_program.addLine("    Set Cw = #{c_w * 0.01}")
+    vent_program.addLine('    Set Tdiff = Tin-Tout')
+    vent_program.addLine('    Set dT = (@Abs Tdiff)')
+    vent_program.addLine("    Set Vwind = #{@vwind_sensor.name}")
+    vent_program.addLine('    Set SGNV = NVArea*Adj*((((Cs*dT)+(Cw*(Vwind^2)))^0.5)/1000)')
+    vent_program.addLine("    Set MaxNV = #{UnitConversions.convert(max_flow_rate, 'cfm', 'm^3/s')}")
+    vent_program.addLine("    Set #{nv_flow_actuator.name} = (@Min SGNV MaxNV)")
+    vent_program.addLine("    Set #{whf_flow_actuator.name} = 0")
+    vent_program.addLine("    Set #{liv_to_zone_flow_rate_actuator.name} = 0") unless whf_zone.nil?
+    vent_program.addLine("    Set #{whf_elec_actuator.name} = 0")
+    vent_program.addLine('  EndIf')
+    vent_program.addLine('Else')
+    vent_program.addLine("  Set #{nv_flow_actuator.name} = 0")
+    vent_program.addLine("  Set #{whf_flow_actuator.name} = 0")
+    vent_program.addLine("  Set #{liv_to_zone_flow_rate_actuator.name} = 0") unless whf_zone.nil?
+    vent_program.addLine("  Set #{whf_elec_actuator.name} = 0")
+    vent_program.addLine('EndIf')
 
-    # Store info for HVAC Sizing measure
-    model.getBuilding.additionalProperties.setFeature(Constants.SizingInfoMechVentType, mech_vent.type.to_s)
-    model.getBuilding.additionalProperties.setFeature(Constants.SizingInfoMechVentTotalEfficiency, mech_vent.total_efficiency.to_f)
-    model.getBuilding.additionalProperties.setFeature(Constants.SizingInfoMechVentLatentEffectiveness, latent_effectiveness.to_f)
-    model.getBuilding.additionalProperties.setFeature(Constants.SizingInfoMechVentApparentSensibleEffectiveness, apparent_sensible_effectiveness.to_f)
-    model.getBuilding.additionalProperties.setFeature(Constants.SizingInfoMechVentWholeHouseRate, mech_vent.cfm.to_f)
-
-    mech_vent.frac_fan_heat = frac_fan_heat
-    mech_vent.latent_effectiveness = latent_effectiveness
-    mech_vent.sensible_effectiveness = sensible_effectiveness
-    mech_vent.dryer_exhaust_day_shift = dryer_exhaust_day_shift
-    mech_vent.has_dryer = has_dryer
+    manager = OpenStudio::Model::EnergyManagementSystemProgramCallingManager.new(model)
+    manager.setName("#{vent_program.name} calling manager")
+    manager.setCallingPoint('BeginTimestepBeforePredictor')
+    manager.addProgram(vent_program)
   end
 
-  def self.process_ducts(model, ducts, building, air_loop)
-    # Validate Inputs
+  def self.create_return_air_duct_zone(model, air_loop_name)
+    # Create the return air plenum zone, space
+    ra_duct_zone = OpenStudio::Model::ThermalZone.new(model)
+    ra_duct_zone.setName(air_loop_name + ' ret air zone')
+    ra_duct_zone.setVolume(1.0)
+
+    ra_duct_polygon = OpenStudio::Point3dVector.new
+    ra_duct_polygon << OpenStudio::Point3d.new(0, 0, 0)
+    ra_duct_polygon << OpenStudio::Point3d.new(0, 1.0, 0)
+    ra_duct_polygon << OpenStudio::Point3d.new(1.0, 1.0, 0)
+    ra_duct_polygon << OpenStudio::Point3d.new(1.0, 0, 0)
+
+    ra_space = OpenStudio::Model::Space::fromFloorPrint(ra_duct_polygon, 1, model)
+    ra_space = ra_space.get
+    ra_space.setName(air_loop_name + ' ret air space')
+    ra_space.setThermalZone(ra_duct_zone)
+
+    ra_space.surfaces.each do |surface|
+      surface.setConstruction(@adiabatic_const)
+      surface.setOutsideBoundaryCondition('Adiabatic')
+      surface.setSunExposure('NoSun')
+      surface.setWindExposure('NoWind')
+      surface_property_convection_coefficients = OpenStudio::Model::SurfacePropertyConvectionCoefficients.new(surface)
+      surface_property_convection_coefficients.setConvectionCoefficient1Location('Inside')
+      surface_property_convection_coefficients.setConvectionCoefficient1Type('Value')
+      surface_property_convection_coefficients.setConvectionCoefficient1(30)
+    end
+
+    return ra_duct_zone
+  end
+
+  def self.create_sens_lat_load_actuator_and_equipment(model, name, space, frac_lat, frac_lost)
+    other_equip_def = OpenStudio::Model::OtherEquipmentDefinition.new(model)
+    other_equip_def.setName("#{name} equip")
+    other_equip = OpenStudio::Model::OtherEquipment.new(other_equip_def)
+    other_equip.setName(other_equip_def.name.to_s)
+    other_equip.setFuelType('None')
+    other_equip.setSchedule(model.alwaysOnDiscreteSchedule)
+    other_equip.setSpace(space)
+    other_equip_def.setFractionLost(frac_lost)
+    other_equip_def.setFractionLatent(frac_lat)
+    other_equip_def.setFractionRadiant(0.0)
+    actuator = OpenStudio::Model::EnergyManagementSystemActuator.new(other_equip, 'OtherEquipment', 'Power Level')
+    actuator.setName("#{other_equip.name} act")
+    return actuator
+  end
+
+  def self.initialize_cfis(model, vent_mech, hvac_map)
+    # Get AirLoop associated with CFIS
+    return if vent_mech.nil? || (vent_mech.fan_type != HPXML::MechVentTypeCFIS)
+
+    cfis_sys_ids = vent_mech.distribution_system.hvac_systems.map { |system| system.id }
+
+    @cfis_airloop = nil
+
+    # Get AirLoopHVACs associated with these HVAC systems
+    hvac_map.each do |sys_id, hvacs|
+      next unless cfis_sys_ids.include? sys_id
+
+      hvacs.each do |loop|
+        next unless loop.is_a? OpenStudio::Model::AirLoopHVAC
+        next if (not @cfis_airloop.nil?) && (@cfis_airloop == loop) # already assigned
+
+        fail 'Two airloops found for CFIS.' unless @cfis_airloop.nil?
+
+        @cfis_airloop = loop
+      end
+    end
+
+    @cfis_t_sum_open_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{Constants.ObjectNameMechanicalVentilation.gsub(' ', '_')}_cfis_t_sum_open") # Sums the time during an hour the CFIS damper has been open
+    @cfis_f_damper_extra_open_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{Constants.ObjectNameMechanicalVentilation.gsub(' ', '_')}_cfis_f_extra_damper_open") # Fraction of timestep the CFIS blower is running while hvac is not operating. Used by infiltration and duct leakage programs
+
+    # CFIS Initialization Program
+    cfis_program = OpenStudio::Model::EnergyManagementSystemProgram.new(model)
+    cfis_program.setName(Constants.ObjectNameMechanicalVentilation + ' cfis init program')
+    cfis_program.addLine("Set #{@cfis_t_sum_open_var.name} = 0")
+    cfis_program.addLine("Set #{@cfis_f_damper_extra_open_var.name} = 0")
+
+    manager = OpenStudio::Model::EnergyManagementSystemProgramCallingManager.new(model)
+    manager.setName("#{cfis_program.name} calling manager")
+    manager.setCallingPoint('BeginNewEnvironment')
+    manager.addProgram(cfis_program)
+
+    manager = OpenStudio::Model::EnergyManagementSystemProgramCallingManager.new(model)
+    manager.setName("#{cfis_program.name} calling manager2")
+    manager.setCallingPoint('AfterNewEnvironmentWarmUpIsComplete')
+    manager.addProgram(cfis_program)
+  end
+
+  def self.initialize_air_loop_objects(model, air_loop)
+    @supply_fans = {} if @supply_fans.nil?
+    @fan_rtf_var = {} if @fan_rtf_var.nil?
+    @fan_mfr_max_var = {} if @fan_mfr_max_var.nil?
+    @fan_rtf_sensor = {} if @fan_rtf_sensor.nil?
+    @fan_mfr_sensor = {} if @fan_mfr_sensor.nil?
+
+    # Get the supply fan
+    system = HVAC.get_unitary_system_from_air_loop_hvac(air_loop)
+    if system.nil? # Evaporative cooler supply fan directly on air loop
+      @supply_fans[air_loop] = air_loop.supplyFan.get
+    else
+      @supply_fans[air_loop] = system.supplyFan.get
+    end
+
+    @fan_rtf_var[air_loop] = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{air_loop.name} Fan RTF".gsub(' ', '_'))
+
+    # Supply fan maximum mass flow rate
+    @fan_mfr_max_var[air_loop] = OpenStudio::Model::EnergyManagementSystemInternalVariable.new(model, 'Fan Maximum Mass Flow Rate')
+    @fan_mfr_max_var[air_loop].setName("#{air_loop.name} max sup fan mfr")
+    @fan_mfr_max_var[air_loop].setInternalDataIndexKeyName(@supply_fans[air_loop].name.to_s)
+
+    if @supply_fans[air_loop].to_FanOnOff.is_initialized
+      @fan_rtf_sensor[air_loop] = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Fan Runtime Fraction')
+      @fan_rtf_sensor[air_loop].setName("#{@fan_rtf_var[air_loop].name} s")
+      @fan_rtf_sensor[air_loop].setKeyName(@supply_fans[air_loop].name.to_s)
+    elsif @supply_fans[air_loop].to_FanVariableVolume.is_initialized # Evaporative cooler
+      @fan_mfr_sensor[air_loop] = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Fan Air Mass Flow Rate')
+      @fan_mfr_sensor[air_loop].setName("#{@supply_fans[air_loop].name} air MFR")
+      @fan_mfr_sensor[air_loop].setKeyName("#{@supply_fans[air_loop].name}")
+      @fan_rtf_sensor[air_loop] = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{@fan_rtf_var[air_loop].name}_s")
+    else
+      fail "Unexpected fan: #{@supply_fans[air_loop].name}"
+    end
+  end
+
+  def self.apply_ducts(model, ducts, vent_mech, air_loop, duct_lks)
     ducts.each do |duct|
       if duct.leakage_frac.nil? == duct.leakage_cfm25.nil?
         fail 'Ducts: Must provide either leakage fraction or cfm25, but not both.'
@@ -738,7 +537,7 @@ class Airflow
       end
     end
 
-    if (ducts.size > 0) && building.living.zone.airLoopHVACs.include?(air_loop)
+    if ducts.size > 0
       # Store info for HVAC Sizing measure
       air_loop.additionalProperties.setFeature(Constants.SizingInfoDuctExist, true)
       air_loop.additionalProperties.setFeature(Constants.SizingInfoDuctSides, ducts.map { |duct| duct.side }.join(','))
@@ -748,230 +547,11 @@ class Airflow
       air_loop.additionalProperties.setFeature(Constants.SizingInfoDuctAreas, ducts.map { |duct| duct.area.to_f }.join(','))
       air_loop.additionalProperties.setFeature(Constants.SizingInfoDuctRvalues, ducts.map { |duct| duct.rvalue.to_f }.join(','))
     end
-  end
 
-  def self.process_nat_vent_and_whole_house_fan(model, nat_vent, whf, tin_sensor, tout_sensor, pbar_sensor, vwind_sensor, wind_speed, infil, building, weather, wout_sensor)
-    # Availability Schedule
-    aval_schs = {}
-    { Constants.ObjectNameNaturalVentilation => nat_vent.nv_num_days_per_week,
-      Constants.ObjectNameWholeHouseFan => whf.whf_num_days_per_week }.each do |obj_name, num_days_per_week|
-      aval_schs[obj_name] = OpenStudio::Model::ScheduleRuleset.new(model)
-      aval_schs[obj_name].setName("#{obj_name} avail schedule")
-      Schedule.set_schedule_type_limits(model, aval_schs[obj_name], Constants.ScheduleTypeLimitsOnOff)
-      on_rule = OpenStudio::Model::ScheduleRule.new(aval_schs[obj_name])
-      on_rule.setName("#{obj_name} avail schedule rule")
-      on_rule_day = on_rule.daySchedule
-      on_rule_day.setName("#{obj_name} avail schedule day")
-      on_rule_day.addValue(OpenStudio::Time.new(0, 24, 0, 0), 1)
-      if num_days_per_week >= 1
-        on_rule.setApplyMonday(true)
-      end
-      if num_days_per_week >= 2
-        on_rule.setApplyWednesday(true)
-      end
-      if num_days_per_week >= 3
-        on_rule.setApplyFriday(true)
-      end
-      if num_days_per_week >= 4
-        on_rule.setApplySaturday(true)
-      end
-      if num_days_per_week >= 5
-        on_rule.setApplyTuesday(true)
-      end
-      if num_days_per_week >= 6
-        on_rule.setApplyThursday(true)
-      end
-      if num_days_per_week >= 7
-        on_rule.setApplySunday(true)
-      end
-      on_rule.setStartDate(OpenStudio::Date::fromDayOfYear(1))
-      on_rule.setEndDate(OpenStudio::Date::fromDayOfYear(365))
-    end
-
-    # Setpoint schedule (average of heating/cooling setpoints to minimize incurring additional heating energy)
-
-    nv_weekday_setpoints = [[nil] * 24] * 12
-    nv_weekend_setpoints = [[nil] * 24] * 12
-    for month in 1..12
-      for hr in 1..24
-        nv_weekday_setpoints[month - 1][hr - 1] = UnitConversions.convert((nat_vent.htg_weekday_setpoints[month - 1][hr - 1] + nat_vent.clg_weekday_setpoints[month - 1][hr - 1]) / 2.0, 'F', 'C')
-        nv_weekend_setpoints[month - 1][hr - 1] = UnitConversions.convert((nat_vent.htg_weekend_setpoints[month - 1][hr - 1] + nat_vent.clg_weekend_setpoints[month - 1][hr - 1]) / 2.0, 'F', 'C')
-      end
-    end
-    temp_sch = HourlyByMonthSchedule.new(model, Constants.ObjectNameNaturalVentilation + ' temp schedule', nv_weekday_setpoints, nv_weekend_setpoints, false, true, Constants.ScheduleTypeLimitsTemperature)
-
-    # Sensors
-    nv_sp_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Schedule Value')
-    nv_sp_sensor.setName('airflow sp s')
-    nv_sp_sensor.setKeyName(temp_sch.schedule.name.to_s)
-
-    nv_avail_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Schedule Value')
-    nv_avail_sensor.setName("#{Constants.ObjectNameNaturalVentilation} nva s")
-    nv_avail_sensor.setKeyName(aval_schs[Constants.ObjectNameNaturalVentilation].name.to_s)
-
-    whf_avail_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Schedule Value')
-    whf_avail_sensor.setName("#{Constants.ObjectNameWholeHouseFan} nva s")
-    whf_avail_sensor.setKeyName(aval_schs[Constants.ObjectNameWholeHouseFan].name.to_s)
-
-    # Actuators
-    living_space = building.living.zone.spaces[0]
-
-    nv_flow = OpenStudio::Model::SpaceInfiltrationDesignFlowRate.new(model)
-    nv_flow.setName(Constants.ObjectNameNaturalVentilation + ' flow')
-    nv_flow.setSchedule(model.alwaysOnDiscreteSchedule)
-    nv_flow.setSpace(living_space)
-    nv_flow_actuator = OpenStudio::Model::EnergyManagementSystemActuator.new(nv_flow, 'Zone Infiltration', 'Air Exchange Flow Rate')
-    nv_flow_actuator.setName("#{nv_flow.name} act")
-
-    whf_flow = OpenStudio::Model::SpaceInfiltrationDesignFlowRate.new(model)
-    whf_flow.setName(Constants.ObjectNameWholeHouseFan + ' flow')
-    whf_flow.setSchedule(model.alwaysOnDiscreteSchedule)
-    whf_flow.setSpace(living_space)
-    whf_flow_actuator = OpenStudio::Model::EnergyManagementSystemActuator.new(whf_flow, 'Zone Infiltration', 'Air Exchange Flow Rate')
-    whf_flow_actuator.setName("#{whf_flow.name} act")
-
-    # Assume located in attic floor if attic zone exists; otherwise assume it's through roof/wall.
-    whf_zone = nil
-    if not building.vented_attic.nil?
-      whf_zone = building.vented_attic.zone
-    elsif not building.unvented_attic.nil?
-      whf_zone = building.unvented_attic.zone
-    end
-    if not whf_zone.nil?
-      # Air from living to WHF zone (attic)
-      zone_mixing = OpenStudio::Model::ZoneMixing.new(whf_zone)
-      zone_mixing.setName("#{Constants.ObjectNameWholeHouseFan} mix")
-      zone_mixing.setSourceZone(building.living.zone)
-      liv_to_zone_flow_rate_actuator = OpenStudio::Model::EnergyManagementSystemActuator.new(zone_mixing, 'ZoneMixing', 'Air Exchange Flow Rate')
-      liv_to_zone_flow_rate_actuator.setName("#{zone_mixing.name} act")
-    end
-
-    # Electric Equipment (for whole house fan electricity consumption)
-
-    whf_equip_def = OpenStudio::Model::ElectricEquipmentDefinition.new(model)
-    whf_equip_def.setName(Constants.ObjectNameWholeHouseFan)
-    whf_equip = OpenStudio::Model::ElectricEquipment.new(whf_equip_def)
-    whf_equip.setName(Constants.ObjectNameWholeHouseFan)
-    whf_equip.setSpace(living_space)
-    whf_equip_def.setFractionRadiant(0)
-    whf_equip_def.setFractionLatent(0)
-    whf_equip_def.setFractionLost(1)
-    whf_equip.setSchedule(model.alwaysOnDiscreteSchedule)
-    whf_equip.setEndUseSubcategory(Constants.ObjectNameWholeHouseFan)
-    whf_elec_actuator = OpenStudio::Model::EnergyManagementSystemActuator.new(whf_equip, 'ElectricEquipment', 'Electric Power Level')
-    whf_elec_actuator.setName("#{whf_equip.name} act")
-
-    area = 0.6 * building.window_area * nat_vent.nv_frac_window_area_open # ft^2, For Sherman-Grimsrud, this is 0.6*(open window area)
-    max_rate = 20.0 # Air Changes per hour
-    max_flow_rate = max_rate * building.infilvolume / UnitConversions.convert(1.0, 'hr', 'min')
-    neutral_level = 0.5
-    hor_vent_frac = 0.0
-    f_s_nv = 2.0 / 3.0 * (1.0 + hor_vent_frac / 2.0) * (2.0 * neutral_level * (1 - neutral_level))**0.5 / (neutral_level**0.5 + (1 - neutral_level)**0.5)
-    f_w_nv = wind_speed.shielding_coef * (1 - hor_vent_frac)**(1.0 / 3.0) * building.living.f_t_SG
-    c_s = f_s_nv**2.0 * Constants.g * building.infilheight / (Constants.AssumedInsideTemp + 460.0)
-    c_w = f_w_nv**2.0
-
-    # Program
-    nv_and_whf_program = OpenStudio::Model::EnergyManagementSystemProgram.new(model)
-    nv_and_whf_program.setName(Constants.ObjectNameNaturalVentilation + ' program')
-    nv_and_whf_program.addLine("Set Tin = #{tin_sensor.name}")
-    nv_and_whf_program.addLine("Set Tout = #{tout_sensor.name}")
-    nv_and_whf_program.addLine("Set Wout = #{wout_sensor.name}")
-    nv_and_whf_program.addLine("Set Pbar = #{pbar_sensor.name}")
-    nv_and_whf_program.addLine('Set Phiout = (@RhFnTdbWPb Tout Wout Pbar)')
-    nv_and_whf_program.addLine("Set MaxHR = #{nat_vent.max_oa_hr}")
-    nv_and_whf_program.addLine("Set MaxRH = #{nat_vent.max_oa_rh}")
-    nv_and_whf_program.addLine("Set Tnvsp = #{nv_sp_sensor.name}")
-    nv_and_whf_program.addLine("Set NVavail = #{nv_avail_sensor.name}")
-    nv_and_whf_program.addLine("Set WHFavail = #{whf_avail_sensor.name}")
-    nv_and_whf_program.addLine("Set ClgSsnAvail = #{nat_vent.clg_ssn_sensor.name}")
-    nv_and_whf_program.addLine('If (Wout < MaxHR) && (Phiout < MaxRH) && (Tin > Tout) && (Tin > Tnvsp) && (ClgSsnAvail > 0)')
-    nv_and_whf_program.addLine("  Set WHF_Flow = #{UnitConversions.convert(whf.cfm, 'cfm', 'm^3/s')}")
-    nv_and_whf_program.addLine('  Set Adj = (Tin-Tnvsp)/(Tin-Tout)')
-    nv_and_whf_program.addLine('  Set Adj = (@Min Adj 1)')
-    nv_and_whf_program.addLine('  Set Adj = (@Max Adj 0)')
-    nv_and_whf_program.addLine('  If (WHFavail > 0) && (WHF_Flow > 0)') # If available, prioritize whole house fan
-    nv_and_whf_program.addLine("    Set #{nv_flow_actuator.name} = 0")
-    nv_and_whf_program.addLine("    Set #{whf_flow_actuator.name} = WHF_Flow*Adj")
-    nv_and_whf_program.addLine("    Set #{liv_to_zone_flow_rate_actuator.name} = WHF_Flow*Adj") unless whf_zone.nil?
-    nv_and_whf_program.addLine("    Set #{whf_elec_actuator.name} = #{whf.fan_power_w}*Adj")
-    nv_and_whf_program.addLine('  ElseIf (NVavail > 0)') # Natural ventilation
-    nv_and_whf_program.addLine("    Set NVArea = #{UnitConversions.convert(area, 'ft^2', 'cm^2')}")
-    nv_and_whf_program.addLine("    Set Cs = #{UnitConversions.convert(c_s, 'ft^2/(s^2*R)', 'L^2/(s^2*cm^4*K)')}")
-    nv_and_whf_program.addLine("    Set Cw = #{c_w * 0.01}")
-    nv_and_whf_program.addLine('    Set Tdiff = Tin-Tout')
-    nv_and_whf_program.addLine('    Set dT = (@Abs Tdiff)')
-    nv_and_whf_program.addLine("    Set Vwind = #{vwind_sensor.name}")
-    nv_and_whf_program.addLine('    Set SGNV = NVArea*Adj*((((Cs*dT)+(Cw*(Vwind^2)))^0.5)/1000)')
-    nv_and_whf_program.addLine("    Set MaxNV = #{UnitConversions.convert(max_flow_rate, 'cfm', 'm^3/s')}")
-    nv_and_whf_program.addLine("    Set #{nv_flow_actuator.name} = (@Min SGNV MaxNV)")
-    nv_and_whf_program.addLine("    Set #{whf_flow_actuator.name} = 0")
-    nv_and_whf_program.addLine("    Set #{liv_to_zone_flow_rate_actuator.name} = 0") unless whf_zone.nil?
-    nv_and_whf_program.addLine("    Set #{whf_elec_actuator.name} = 0")
-    nv_and_whf_program.addLine('  EndIf')
-    nv_and_whf_program.addLine('Else')
-    nv_and_whf_program.addLine("  Set #{nv_flow_actuator.name} = 0")
-    nv_and_whf_program.addLine("  Set #{whf_flow_actuator.name} = 0")
-    nv_and_whf_program.addLine("  Set #{liv_to_zone_flow_rate_actuator.name} = 0") unless whf_zone.nil?
-    nv_and_whf_program.addLine("  Set #{whf_elec_actuator.name} = 0")
-    nv_and_whf_program.addLine('EndIf')
-
-    return nv_and_whf_program
-  end
-
-  def self.create_return_air_duct_zone(model, air_loop_name, adiabatic_const)
-    # Create the return air plenum zone, space
-    ra_duct_zone = OpenStudio::Model::ThermalZone.new(model)
-    ra_duct_zone.setName(air_loop_name + ' ret air zone')
-    ra_duct_zone.setVolume(1.0)
-
-    ra_duct_polygon = OpenStudio::Point3dVector.new
-    ra_duct_polygon << OpenStudio::Point3d.new(0, 0, 0)
-    ra_duct_polygon << OpenStudio::Point3d.new(0, 1.0, 0)
-    ra_duct_polygon << OpenStudio::Point3d.new(1.0, 1.0, 0)
-    ra_duct_polygon << OpenStudio::Point3d.new(1.0, 0, 0)
-
-    ra_space = OpenStudio::Model::Space::fromFloorPrint(ra_duct_polygon, 1, model)
-    ra_space = ra_space.get
-    ra_space.setName(air_loop_name + ' ret air space')
-    ra_space.setThermalZone(ra_duct_zone)
-
-    ra_space.surfaces.each do |surface|
-      surface.setConstruction(adiabatic_const)
-      surface.setOutsideBoundaryCondition('Adiabatic')
-      surface.setSunExposure('NoSun')
-      surface.setWindExposure('NoWind')
-      surface_property_convection_coefficients = OpenStudio::Model::SurfacePropertyConvectionCoefficients.new(surface)
-      surface_property_convection_coefficients.setConvectionCoefficient1Location('Inside')
-      surface_property_convection_coefficients.setConvectionCoefficient1Type('Value')
-      surface_property_convection_coefficients.setConvectionCoefficient1(30)
-    end
-
-    return ra_duct_zone
-  end
-
-  def self.create_sens_lat_load_actuator_and_equipment(model, name, space, frac_lat, frac_lost)
-    other_equip_def = OpenStudio::Model::OtherEquipmentDefinition.new(model)
-    other_equip_def.setName("#{name} equip")
-    other_equip = OpenStudio::Model::OtherEquipment.new(other_equip_def)
-    other_equip.setName(other_equip_def.name.to_s)
-    other_equip.setFuelType('None')
-    other_equip.setSchedule(model.alwaysOnDiscreteSchedule)
-    other_equip.setSpace(space)
-    other_equip_def.setFractionLost(frac_lost)
-    other_equip_def.setFractionLatent(frac_lat)
-    other_equip_def.setFractionRadiant(0.0)
-    actuator = OpenStudio::Model::EnergyManagementSystemActuator.new(other_equip, 'OtherEquipment', 'Power Level')
-    actuator.setName("#{other_equip.name} act")
-    return actuator
-  end
-
-  def self.create_ducts_objects(model, building, ducts, mech_vent, tin_sensor, pbar_sensor, adiabatic_const, air_loop, duct_programs, duct_lks, air_loop_objects)
     return if ducts.size == 0 # No ducts
 
     # get duct located zone or ambient temperature schedule objects
     duct_locations = ducts.map { |duct| if duct.zone.nil? then duct.loc_schedule else duct.zone end }.uniq
-    living_space = building.living.zone.spaces[0]
 
     # All duct zones are in living space?
     all_ducts_conditioned = true
@@ -984,694 +564,939 @@ class Airflow
     end
     return if all_ducts_conditioned
 
-    if building.living.zone.airLoopHVACs.include? air_loop # next if airloop doesn't serve this
+    # Set the return plenum
+    ra_duct_zone = create_return_air_duct_zone(model, air_loop.name.to_s)
+    ra_duct_space = ra_duct_zone.spaces[0]
+    @living_zone.setReturnPlenum(ra_duct_zone, air_loop)
 
-      ra_duct_zone = create_return_air_duct_zone(model, air_loop.name.to_s, adiabatic_const)
-      ra_duct_space = ra_duct_zone.spaces[0]
+    # -- Sensors --
 
-      # Get the air demand inlet node
-      air_demand_inlet_node = nil
-      if air_loop.to_AirLoopHVAC.is_initialized
-        air_demand_inlet_node = air_loop.demandInletNode
-      end
+    # Air handler mass flow rate
+    ah_mfr_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{air_loop.name} AH MFR".gsub(' ', '_'))
+    ah_mfr_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'System Node Mass Flow Rate')
+    ah_mfr_sensor.setName("#{ah_mfr_var.name} s")
+    ah_mfr_sensor.setKeyName(air_loop.demandInletNode.name.to_s)
 
-      # Set the return plenum
-      if air_loop.to_AirLoopHVAC.is_initialized
-        building.living.zone.setReturnPlenum(ra_duct_zone, air_loop)
-        air_loop.demandComponents.each do |demand_component|
-          next unless demand_component.to_AirLoopHVACReturnPlenum.is_initialized
+    # Air handler volume flow rate
+    ah_vfr_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{air_loop.name} AH VFR".gsub(' ', '_'))
+    ah_vfr_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'System Node Current Density Volume Flow Rate')
+    ah_vfr_sensor.setName("#{ah_vfr_var.name} s")
+    ah_vfr_sensor.setKeyName(air_loop.demandInletNode.name.to_s)
 
-          demand_component.setName("#{air_loop.name} return plenum")
-        end
-      end
+    # Air handler outlet temperature
+    ah_tout_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{air_loop.name} AH Tout".gsub(' ', '_'))
+    ah_tout_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'System Node Temperature')
+    ah_tout_sensor.setName("#{ah_tout_var.name} s")
+    ah_tout_sensor.setKeyName(air_loop.demandInletNode.name.to_s)
 
-      living_zone_return_air_node = nil
-      building.living.zone.returnAirModelObjects.each do |return_air_model_obj|
-        next if return_air_model_obj.to_Node.get.airLoopHVAC.get != air_loop
+    # Air handler outlet humidity ratio
+    ah_wout_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{air_loop.name} AH Wout".gsub(' ', '_'))
+    ah_wout_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'System Node Humidity Ratio')
+    ah_wout_sensor.setName("#{ah_wout_var.name} s")
+    ah_wout_sensor.setKeyName(air_loop.demandInletNode.name.to_s)
 
-        living_zone_return_air_node = return_air_model_obj
-      end
+    living_zone_return_air_node = nil
+    @living_zone.returnAirModelObjects.each do |return_air_model_obj|
+      next if return_air_model_obj.to_Node.get.airLoopHVAC.get != air_loop
+
+      living_zone_return_air_node = return_air_model_obj
+    end
+
+    # Return air temperature
+    ra_t_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{air_loop.name} RA T".gsub(' ', '_'))
+    if not living_zone_return_air_node.nil?
+      ra_t_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'System Node Temperature')
+      ra_t_sensor.setName("#{ra_t_var.name} s")
+      ra_t_sensor.setKeyName(living_zone_return_air_node.name.to_s)
+    else
+      ra_t_sensor = @tin_sensor
+    end
+
+    # Return air humidity ratio
+    ra_w_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{air_loop.name} Ra W".gsub(' ', '_'))
+    if not living_zone_return_air_node.nil?
+      ra_w_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'System Node Humidity Ratio')
+      ra_w_sensor.setName("#{ra_w_var.name} s")
+      ra_w_sensor.setKeyName(living_zone_return_air_node.name.to_s)
+    else
+      ra_w_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Zone Mean Air Humidity Ratio')
+      ra_w_sensor.setName("#{ra_w_var.name} s")
+      ra_w_sensor.setKeyName(@living_zone.name.to_s)
+    end
+
+    # Living zone humidity ratio
+    win_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Zone Mean Air Humidity Ratio')
+    win_sensor.setName("#{air_loop.name} win s")
+    win_sensor.setKeyName(@living_zone.name.to_s)
+
+    # Create one duct program for each duct location zone
+    duct_locations.each_with_index do |duct_location, i|
+      next if (not duct_location.nil?) && (duct_location.name.to_s == @living_zone.name.to_s)
+
+      air_loop_name_idx = "#{air_loop.name}_#{i}"
 
       # -- Sensors --
 
-      # Air handler mass flow rate
-      ah_mfr_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{air_loop.name} AH MFR".gsub(' ', '_'))
-      ah_mfr_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'System Node Mass Flow Rate')
-      ah_mfr_sensor.setName("#{ah_mfr_var.name} s")
-      ah_mfr_sensor.setKeyName(air_demand_inlet_node.name.to_s)
-
-      # Air handler volume flow rate
-      ah_vfr_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{air_loop.name} AH VFR".gsub(' ', '_'))
-      ah_vfr_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'System Node Current Density Volume Flow Rate')
-      ah_vfr_sensor.setName("#{ah_vfr_var.name} s")
-      ah_vfr_sensor.setKeyName(air_demand_inlet_node.name.to_s)
-
-      # Air handler outlet temperature
-      ah_tout_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{air_loop.name} AH Tout".gsub(' ', '_'))
-      ah_tout_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'System Node Temperature')
-      ah_tout_sensor.setName("#{ah_tout_var.name} s")
-      ah_tout_sensor.setKeyName(air_demand_inlet_node.name.to_s)
-
-      # Air handler outlet humidity ratio
-      ah_wout_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{air_loop.name} AH Wout".gsub(' ', '_'))
-      ah_wout_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'System Node Humidity Ratio')
-      ah_wout_sensor.setName("#{ah_wout_var.name} s")
-      ah_wout_sensor.setKeyName(air_demand_inlet_node.name.to_s)
-
-      # Return air temperature
-      ra_t_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{air_loop.name} RA T".gsub(' ', '_'))
-      if not living_zone_return_air_node.nil?
-        ra_t_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'System Node Temperature')
-        ra_t_sensor.setName("#{ra_t_var.name} s")
-        ra_t_sensor.setKeyName(living_zone_return_air_node.name.to_s)
-      else
-        ra_t_sensor = tin_sensor
+      # Duct zone temperature
+      dz_t_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{air_loop_name_idx} DZ T".gsub(' ', '_'))
+      if duct_location.is_a? OpenStudio::Model::ThermalZone
+        dz_t_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Zone Air Temperature')
+        dz_t_sensor.setKeyName(duct_location.name.to_s)
+      elsif duct_location.is_a? OpenStudio::Model::ScheduleConstant
+        dz_t_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Schedule Value')
+        dz_t_sensor.setKeyName(duct_location.name.to_s)
+      elsif duct_location.nil? # Outside
+        dz_t_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Site Outdoor Air Drybulb Temperature')
+        dz_t_sensor.setKeyName('Environment')
+      else # shouldn't get here, should only have schedule/thermal zone/nil assigned
+        fail 'Unexpected duct zone type passed'
       end
+      dz_t_sensor.setName("#{dz_t_var.name} s")
 
-      # Return air humidity ratio
-      ra_w_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{air_loop.name} Ra W".gsub(' ', '_'))
-      if not living_zone_return_air_node.nil?
-        ra_w_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'System Node Humidity Ratio')
-        ra_w_sensor.setName("#{ra_w_var.name} s")
-        ra_w_sensor.setKeyName(living_zone_return_air_node.name.to_s)
-      else
-        ra_w_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Zone Mean Air Humidity Ratio')
-        ra_w_sensor.setName("#{ra_w_var.name} s")
-        ra_w_sensor.setKeyName(building.living.zone.name.to_s)
-      end
-
-      # Living zone humidity ratio
-      win_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Zone Mean Air Humidity Ratio')
-      win_sensor.setName("#{air_loop.name} win s")
-      win_sensor.setKeyName(building.living.zone.name.to_s)
-
-      fan_mfr_max_var = air_loop_objects[air_loop][:fan_mfr_max_var]
-      fan_rtf_sensor = air_loop_objects[air_loop][:fan_rtf_sensor]
-      fan_mfr_sensor = air_loop_objects[air_loop][:fan_mfr_sensor]
-      fan_rtf_var = air_loop_objects[air_loop][:fan_rtf_var]
-
-      # Create one duct program for each duct location zone
-
-      duct_locations.each_with_index do |duct_location, i|
-        next if (not duct_location.nil?) && (duct_location.name.to_s == building.living.zone.name.to_s)
-
-        air_loop_name_idx = "#{air_loop.name}_#{i}"
-
-        # -- Sensors --
-
-        # Duct zone temperature
-        dz_t_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{air_loop_name_idx} DZ T".gsub(' ', '_'))
-        if duct_location.is_a? OpenStudio::Model::ThermalZone
-          dz_t_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Zone Air Temperature')
-          dz_t_sensor.setKeyName(duct_location.name.to_s)
-        elsif duct_location.is_a? OpenStudio::Model::ScheduleConstant
-          dz_t_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Schedule Value')
-          dz_t_sensor.setKeyName(duct_location.name.to_s)
-        elsif duct_location.nil? # Outside
-          dz_t_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Site Outdoor Air Drybulb Temperature')
-          dz_t_sensor.setKeyName('Environment')
-        else # shouldn't get here, should only have schedule/thermal zone/nil assigned
-          fail 'Unexpected duct zone type passed'
-        end
-        dz_t_sensor.setName("#{dz_t_var.name} s")
-
-        # Duct zone humidity ratio
-        dz_w_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{air_loop_name_idx} DZ W".gsub(' ', '_'))
-        if duct_location.is_a? OpenStudio::Model::ThermalZone
-          dz_w_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Zone Mean Air Humidity Ratio')
-          dz_w_sensor.setKeyName(duct_location.name.to_s)
-          dz_w_sensor.setName("#{dz_w_var.name} s")
-          dz_w = "#{dz_w_sensor.name}"
-        elsif duct_location.is_a? OpenStudio::Model::ScheduleConstant # Outside or scheduled temperature
-          if duct_location.name.get == HPXML::LocationOtherNonFreezingSpace
-            dz_w_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Site Outdoor Air Humidity Ratio')
-            dz_w_sensor.setName("#{dz_w_var.name} s")
-            dz_w = "#{dz_w_sensor.name}"
-          elsif duct_location.name.get == HPXML::LocationOtherHousingUnit
-            dz_w_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Zone Mean Air Humidity Ratio')
-            dz_w_sensor.setKeyName(building.living.zone.name.to_s)
-            dz_w_sensor.setName("#{dz_w_var.name} s")
-            dz_w = "#{dz_w_sensor.name}"
-          else
-            dz_w_sensor1 = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Site Outdoor Air Humidity Ratio')
-            dz_w_sensor1.setName("#{dz_w_var.name} s 1")
-            dz_w_sensor2 = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Zone Mean Air Humidity Ratio')
-            dz_w_sensor2.setName("#{dz_w_var.name} s 2")
-            dz_w_sensor2.setKeyName(building.living.zone.name.to_s)
-            dz_w = "(#{dz_w_sensor1.name} + #{dz_w_sensor2.name}) / 2"
-          end
-        else
+      # Duct zone humidity ratio
+      dz_w_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{air_loop_name_idx} DZ W".gsub(' ', '_'))
+      if duct_location.is_a? OpenStudio::Model::ThermalZone
+        dz_w_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Zone Mean Air Humidity Ratio')
+        dz_w_sensor.setKeyName(duct_location.name.to_s)
+        dz_w_sensor.setName("#{dz_w_var.name} s")
+        dz_w = "#{dz_w_sensor.name}"
+      elsif duct_location.is_a? OpenStudio::Model::ScheduleConstant # Outside or scheduled temperature
+        if duct_location.name.get == HPXML::LocationOtherNonFreezingSpace
           dz_w_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Site Outdoor Air Humidity Ratio')
           dz_w_sensor.setName("#{dz_w_var.name} s")
           dz_w = "#{dz_w_sensor.name}"
-        end
-
-        # -- Actuators --
-
-        # List of: [Var name, object name, space, frac load latent, frac load outside]
-        equip_act_infos = []
-
-        # Other equipment objects to cancel out the supply air leakage directly into the return plenum
-        equip_act_infos << ['supply_sens_lk_to_liv', 'SupSensLkToLv', living_space, 0.0, 0.0]
-        equip_act_infos << ['supply_lat_lk_to_liv', 'SupLatLkToLv', living_space, 1.0, 0.0]
-
-        # Supply duct conduction load added to the living space
-        equip_act_infos << ['supply_cond_to_liv', 'SupCondToLv', living_space, 0.0, 0.0]
-
-        # Return duct conduction load added to the return plenum zone
-        equip_act_infos << ['return_cond_to_rp', 'RetCondToRP', ra_duct_space, 0.0, 0.0]
-
-        # Return duct sensible leakage impact on the return plenum
-        equip_act_infos << ['return_sens_lk_to_rp', 'RetSensLkToRP', ra_duct_space, 0.0, 0.0]
-
-        # Return duct latent leakage impact on the return plenum
-        equip_act_infos << ['return_lat_lk_to_rp', 'RetLatLkToRP', ra_duct_space, 1.0, 0.0]
-
-        # Supply duct conduction impact on the duct zone
-        if not duct_location.is_a? OpenStudio::Model::ThermalZone # Outside or scheduled temperature
-          equip_act_infos << ['supply_cond_to_dz', 'SupCondToDZ', living_space, 0.0, 1.0]
+        elsif duct_location.name.get == HPXML::LocationOtherHousingUnit
+          dz_w_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Zone Mean Air Humidity Ratio')
+          dz_w_sensor.setKeyName(@living_zone.name.to_s)
+          dz_w_sensor.setName("#{dz_w_var.name} s")
+          dz_w = "#{dz_w_sensor.name}"
         else
-          equip_act_infos << ['supply_cond_to_dz', 'SupCondToDZ', duct_location.spaces[0], 0.0, 0.0]
+          dz_w_sensor1 = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Site Outdoor Air Humidity Ratio')
+          dz_w_sensor1.setName("#{dz_w_var.name} s 1")
+          dz_w_sensor2 = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Zone Mean Air Humidity Ratio')
+          dz_w_sensor2.setName("#{dz_w_var.name} s 2")
+          dz_w_sensor2.setKeyName(@living_zone.name.to_s)
+          dz_w = "(#{dz_w_sensor1.name} + #{dz_w_sensor2.name}) / 2"
         end
+      else
+        dz_w_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Site Outdoor Air Humidity Ratio')
+        dz_w_sensor.setName("#{dz_w_var.name} s")
+        dz_w = "#{dz_w_sensor.name}"
+      end
 
-        # Return duct conduction impact on the duct zone
-        if not duct_location.is_a? OpenStudio::Model::ThermalZone # Outside or scheduled temperature
-          equip_act_infos << ['return_cond_to_dz', 'RetCondToDZ', living_space, 0.0, 1.0]
+      # -- Actuators --
+
+      # List of: [Var name, object name, space, frac load latent, frac load outside]
+      equip_act_infos = []
+
+      # Other equipment objects to cancel out the supply air leakage directly into the return plenum
+      equip_act_infos << ['supply_sens_lk_to_liv', 'SupSensLkToLv', @living_space, 0.0, 0.0]
+      equip_act_infos << ['supply_lat_lk_to_liv', 'SupLatLkToLv', @living_space, 1.0, 0.0]
+
+      # Supply duct conduction load added to the living space
+      equip_act_infos << ['supply_cond_to_liv', 'SupCondToLv', @living_space, 0.0, 0.0]
+
+      # Return duct conduction load added to the return plenum zone
+      equip_act_infos << ['return_cond_to_rp', 'RetCondToRP', ra_duct_space, 0.0, 0.0]
+
+      # Return duct sensible leakage impact on the return plenum
+      equip_act_infos << ['return_sens_lk_to_rp', 'RetSensLkToRP', ra_duct_space, 0.0, 0.0]
+
+      # Return duct latent leakage impact on the return plenum
+      equip_act_infos << ['return_lat_lk_to_rp', 'RetLatLkToRP', ra_duct_space, 1.0, 0.0]
+
+      # Supply duct conduction impact on the duct zone
+      if not duct_location.is_a? OpenStudio::Model::ThermalZone # Outside or scheduled temperature
+        equip_act_infos << ['supply_cond_to_dz', 'SupCondToDZ', @living_space, 0.0, 1.0]
+      else
+        equip_act_infos << ['supply_cond_to_dz', 'SupCondToDZ', duct_location.spaces[0], 0.0, 0.0]
+      end
+
+      # Return duct conduction impact on the duct zone
+      if not duct_location.is_a? OpenStudio::Model::ThermalZone # Outside or scheduled temperature
+        equip_act_infos << ['return_cond_to_dz', 'RetCondToDZ', @living_space, 0.0, 1.0]
+      else
+        equip_act_infos << ['return_cond_to_dz', 'RetCondToDZ', duct_location.spaces[0], 0.0, 0.0]
+      end
+
+      # Supply duct sensible leakage impact on the duct zone
+      if not duct_location.is_a? OpenStudio::Model::ThermalZone # Outside or scheduled temperature
+        equip_act_infos << ['supply_sens_lk_to_dz', 'SupSensLkToDZ', @living_space, 0.0, 1.0]
+      else
+        equip_act_infos << ['supply_sens_lk_to_dz', 'SupSensLkToDZ', duct_location.spaces[0], 0.0, 0.0]
+      end
+
+      # Supply duct latent leakage impact on the duct zone
+      if not duct_location.is_a? OpenStudio::Model::ThermalZone # Outside or scheduled temperature
+        equip_act_infos << ['supply_lat_lk_to_dz', 'SupLatLkToDZ', @living_space, 0.0, 1.0]
+      else
+        equip_act_infos << ['supply_lat_lk_to_dz', 'SupLatLkToDZ', duct_location.spaces[0], 1.0, 0.0]
+      end
+
+      duct_vars = {}
+      duct_actuators = {}
+      [false, true].each do |is_cfis|
+        if is_cfis
+          next unless ((not @cfis_airloop.nil?) && (air_loop == @cfis_airloop))
+
+          prefix = 'cfis_'
         else
-          equip_act_infos << ['return_cond_to_dz', 'RetCondToDZ', duct_location.spaces[0], 0.0, 0.0]
+          prefix = ''
         end
+        equip_act_infos.each do |act_info|
+          var_name = "#{prefix}#{act_info[0]}"
+          object_name = "#{air_loop_name_idx} #{prefix}#{act_info[1]}".gsub(' ', '_')
+          space = act_info[2]
+          if is_cfis && (space == ra_duct_space)
+            # Move all CFIS return duct losses to the conditioned space so as to avoid extreme plenum temperatures
+            # due to mismatch between return plenum duct loads and airloop airflow rate (which does not actually
+            # increase due to the presence of CFIS).
+            space = @living_space
+          end
+          frac_lat = act_info[3]
+          frac_lost = act_info[4]
+          if not is_cfis
+            duct_vars[var_name] = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, object_name)
+          end
+          duct_actuators[var_name] = create_sens_lat_load_actuator_and_equipment(model, object_name, space, frac_lat, frac_lost)
+        end
+      end
 
-        # Supply duct sensible leakage impact on the duct zone
-        if not duct_location.is_a? OpenStudio::Model::ThermalZone # Outside or scheduled temperature
-          equip_act_infos << ['supply_sens_lk_to_dz', 'SupSensLkToDZ', living_space, 0.0, 1.0]
+      # Two objects are required to model the air exchange between the duct zone and the living space since
+      # ZoneMixing objects can not account for direction of air flow (both are controlled by EMS)
+
+      # List of: [Var name, object name, space, frac load latent, frac load outside]
+      mix_act_infos = []
+
+      if duct_location.is_a? OpenStudio::Model::ThermalZone
+        # Accounts for leaks from the duct zone to the living zone
+        mix_act_infos << ['dz_to_liv_flow_rate', 'ZoneMixDZToLv', @living_zone, duct_location]
+        # Accounts for leaks from the living zone to the duct zone
+        mix_act_infos << ['liv_to_dz_flow_rate', 'ZoneMixLvToDZ', duct_location, @living_zone]
+      end
+
+      [false, true].each do |is_cfis|
+        if is_cfis
+          next unless ((not @cfis_airloop.nil?) && (air_loop == @cfis_airloop))
+
+          prefix = 'cfis_'
         else
-          equip_act_infos << ['supply_sens_lk_to_dz', 'SupSensLkToDZ', duct_location.spaces[0], 0.0, 0.0]
+          prefix = ''
         end
+        mix_act_infos.each do |act_info|
+          var_name = "#{prefix}#{act_info[0]}"
+          object_name = "#{air_loop_name_idx} #{prefix}#{act_info[1]}".gsub(' ', '_')
+          dest_zone = act_info[2]
+          source_zone = act_info[3]
 
-        # Supply duct latent leakage impact on the duct zone
-        if not duct_location.is_a? OpenStudio::Model::ThermalZone # Outside or scheduled temperature
-          equip_act_infos << ['supply_lat_lk_to_dz', 'SupLatLkToDZ', living_space, 0.0, 1.0]
-        else
-          equip_act_infos << ['supply_lat_lk_to_dz', 'SupLatLkToDZ', duct_location.spaces[0], 1.0, 0.0]
-        end
-
-        duct_vars = {}
-        duct_actuators = {}
-        [false, true].each do |is_cfis|
-          if is_cfis
-            next unless ((mech_vent.type == HPXML::MechVentTypeCFIS) && (air_loop == mech_vent.cfis_air_loop))
-
-            prefix = 'cfis_'
-          else
-            prefix = ''
+          if not is_cfis
+            duct_vars[var_name] = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, object_name)
           end
-          equip_act_infos.each do |act_info|
-            var_name = "#{prefix}#{act_info[0]}"
-            object_name = "#{air_loop_name_idx} #{prefix}#{act_info[1]}".gsub(' ', '_')
-            space = act_info[2]
-            if is_cfis && (space == ra_duct_space)
-              # Move all CFIS return duct losses to the conditioned space so as to avoid extreme plenum temperatures
-              # due to mismatch between return plenum duct loads and airloop airflow rate (which does not actually
-              # increase due to the presence of CFIS).
-              space = living_space
-            end
-            frac_lat = act_info[3]
-            frac_lost = act_info[4]
-            if not is_cfis
-              duct_vars[var_name] = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, object_name)
-            end
-            duct_actuators[var_name] = create_sens_lat_load_actuator_and_equipment(model, object_name, space, frac_lat, frac_lost)
-          end
+          zone_mixing = OpenStudio::Model::ZoneMixing.new(dest_zone)
+          zone_mixing.setName("#{object_name} mix")
+          zone_mixing.setSourceZone(source_zone)
+          duct_actuators[var_name] = OpenStudio::Model::EnergyManagementSystemActuator.new(zone_mixing, 'ZoneMixing', 'Air Exchange Flow Rate')
+          duct_actuators[var_name].setName("#{zone_mixing.name} act")
         end
+      end
 
-        # Two objects are required to model the air exchange between the duct zone and the living space since
-        # ZoneMixing objects can not account for direction of air flow (both are controlled by EMS)
+      # -- Global Variables --
 
-        # List of: [Var name, object name, space, frac load latent, frac load outside]
-        mix_act_infos = []
+      duct_lk_supply_fan_equiv_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{air_loop_name_idx} LkSupFanEquiv".gsub(' ', '_'))
+      duct_lk_exhaust_fan_equiv_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{air_loop_name_idx} LkExhFanEquiv".gsub(' ', '_'))
+      duct_lks << [duct_lk_supply_fan_equiv_var, duct_lk_exhaust_fan_equiv_var]
 
-        if duct_location.is_a? OpenStudio::Model::ThermalZone
-          # Accounts for leaks from the duct zone to the living zone
-          mix_act_infos << ['dz_to_liv_flow_rate', 'ZoneMixDZToLv', building.living.zone, duct_location]
-          # Accounts for leaks from the living zone to the duct zone
-          mix_act_infos << ['liv_to_dz_flow_rate', 'ZoneMixLvToDZ', duct_location, building.living.zone]
+      # Obtain aggregate values for all ducts in the current duct location
+      leakage_fracs = { HPXML::DuctTypeSupply => nil, HPXML::DuctTypeReturn => nil }
+      leakage_cfm25s = { HPXML::DuctTypeSupply => nil, HPXML::DuctTypeReturn => nil }
+      ua_values = { HPXML::DuctTypeSupply => 0, HPXML::DuctTypeReturn => 0 }
+      ducts.each do |duct|
+        next unless (duct_location.nil? && duct.zone.nil?) ||
+                    (!duct_location.nil? && !duct.zone.nil? && (duct.zone.name.to_s == duct_location.name.to_s)) ||
+                    (!duct_location.nil? && !duct.loc_schedule.nil? && (duct.loc_schedule.name.to_s == duct_location.name.to_s))
+
+        if not duct.leakage_frac.nil?
+          leakage_fracs[duct.side] = 0 if leakage_fracs[duct.side].nil?
+          leakage_fracs[duct.side] += duct.leakage_frac
+        elsif not duct.leakage_cfm25.nil?
+          leakage_cfm25s[duct.side] = 0 if leakage_cfm25s[duct.side].nil?
+          leakage_cfm25s[duct.side] += duct.leakage_cfm25
         end
+        ua_values[duct.side] += duct.area / duct.rvalue
+      end
 
-        [false, true].each do |is_cfis|
-          if is_cfis
-            next unless ((mech_vent.type == HPXML::MechVentTypeCFIS) && (air_loop == mech_vent.cfis_air_loop))
-
-            prefix = 'cfis_'
-          else
-            prefix = ''
-          end
-          mix_act_infos.each do |act_info|
-            var_name = "#{prefix}#{act_info[0]}"
-            object_name = "#{air_loop_name_idx} #{prefix}#{act_info[1]}".gsub(' ', '_')
-            dest_zone = act_info[2]
-            source_zone = act_info[3]
-
-            if not is_cfis
-              duct_vars[var_name] = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, object_name)
-            end
-            zone_mixing = OpenStudio::Model::ZoneMixing.new(dest_zone)
-            zone_mixing.setName("#{object_name} mix")
-            zone_mixing.setSourceZone(source_zone)
-            duct_actuators[var_name] = OpenStudio::Model::EnergyManagementSystemActuator.new(zone_mixing, 'ZoneMixing', 'Air Exchange Flow Rate')
-            duct_actuators[var_name].setName("#{zone_mixing.name} act")
-          end
+      # Calculate fraction of outside air specific to this duct location
+      f_oa = 1.0
+      if duct_location.is_a? OpenStudio::Model::ThermalZone # in a space
+        if (not @spaces[HPXML::LocationBasementUnconditioned].nil?) && (@spaces[HPXML::LocationBasementUnconditioned].thermalZone.get.name.to_s == duct_location.name.to_s)
+          f_oa = 0.0
+        elsif (not @spaces[HPXML::LocationCrawlspaceUnvented].nil?) && (@spaces[HPXML::LocationCrawlspaceUnvented].thermalZone.get.name.to_s == duct_location.name.to_s)
+          f_oa = 0.0
+        elsif (not @spaces[HPXML::LocationAtticUnvented].nil?) && (@spaces[HPXML::LocationAtticUnvented].thermalZone.get.name.to_s == duct_location.name.to_s)
+          f_oa = 0.0
         end
+      end
 
-        # -- Global Variables --
+      # Duct Subroutine
 
-        duct_lk_supply_fan_equiv_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{air_loop_name_idx} LkSupFanEquiv".gsub(' ', '_'))
-        duct_lk_exhaust_fan_equiv_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{air_loop_name_idx} LkExhFanEquiv".gsub(' ', '_'))
-        duct_lks[air_loop_name_idx] = [duct_lk_supply_fan_equiv_var, duct_lk_exhaust_fan_equiv_var]
+      duct_subroutine = OpenStudio::Model::EnergyManagementSystemSubroutine.new(model)
+      duct_subroutine.setName("#{air_loop_name_idx} duct subroutine")
+      duct_subroutine.addLine("Set AH_MFR = #{ah_mfr_var.name}")
+      duct_subroutine.addLine('If AH_MFR>0')
+      duct_subroutine.addLine("  Set AH_Tout = #{ah_tout_var.name}")
+      duct_subroutine.addLine("  Set AH_Wout = #{ah_wout_var.name}")
+      duct_subroutine.addLine("  Set RA_T = #{ra_t_var.name}")
+      duct_subroutine.addLine("  Set RA_W = #{ra_w_var.name}")
+      duct_subroutine.addLine("  Set Fan_RTF = #{@fan_rtf_var[air_loop].name}")
+      duct_subroutine.addLine("  Set DZ_T = #{dz_t_var.name}")
+      duct_subroutine.addLine("  Set DZ_W = #{dz_w_var.name}")
+      duct_subroutine.addLine("  Set AH_VFR = #{ah_vfr_var.name}")
+      duct_subroutine.addLine('  Set h_SA = (@HFnTdbW AH_Tout AH_Wout)') # J/kg
+      duct_subroutine.addLine('  Set h_RA = (@HFnTdbW RA_T RA_W)') # J/kg
+      duct_subroutine.addLine('  Set h_fg = (@HfgAirFnWTdb AH_Wout AH_Tout)') # J/kg
+      duct_subroutine.addLine('  Set h_DZ = (@HFnTdbW DZ_T DZ_W)') # J/kg
+      duct_subroutine.addLine('  Set air_cp = 1006.0') # J/kg-C
 
-        # Obtain aggregate values for all ducts in the current duct location
-        leakage_fracs = { HPXML::DuctTypeSupply => nil, HPXML::DuctTypeReturn => nil }
-        leakage_cfm25s = { HPXML::DuctTypeSupply => nil, HPXML::DuctTypeReturn => nil }
-        ua_values = { HPXML::DuctTypeSupply => 0, HPXML::DuctTypeReturn => 0 }
-        ducts.each do |duct|
-          next unless (duct_location.nil? && duct.zone.nil?) ||
-                      (!duct_location.nil? && !duct.zone.nil? && (duct.zone.name.to_s == duct_location.name.to_s)) ||
-                      (!duct_location.nil? && !duct.loc_schedule.nil? && (duct.loc_schedule.name.to_s == duct_location.name.to_s))
+      if not leakage_fracs[HPXML::DuctTypeSupply].nil?
+        duct_subroutine.addLine("  Set f_sup = #{leakage_fracs[HPXML::DuctTypeSupply]}") # frac
+      elsif not leakage_cfm25s[HPXML::DuctTypeSupply].nil?
+        duct_subroutine.addLine("  Set f_sup = #{UnitConversions.convert(leakage_cfm25s[HPXML::DuctTypeSupply], 'cfm', 'm^3/s').round(6)} / (#{@fan_mfr_max_var[air_loop].name} * 1.0135)") # frac
+      else
+        duct_subroutine.addLine('  Set f_sup = 0.0') # frac
+      end
+      if not leakage_fracs[HPXML::DuctTypeReturn].nil?
+        duct_subroutine.addLine("  Set f_ret = #{leakage_fracs[HPXML::DuctTypeReturn]}") # frac
+      elsif not leakage_cfm25s[HPXML::DuctTypeReturn].nil?
+        duct_subroutine.addLine("  Set f_ret = #{UnitConversions.convert(leakage_cfm25s[HPXML::DuctTypeReturn], 'cfm', 'm^3/s').round(6)} / (#{@fan_mfr_max_var[air_loop].name} * 1.0135)") # frac
+      else
+        duct_subroutine.addLine('  Set f_ret = 0.0') # frac
+      end
+      duct_subroutine.addLine('  Set sup_lk_mfr = f_sup * AH_MFR') # kg/s
+      duct_subroutine.addLine('  Set ret_lk_mfr = f_ret * AH_MFR') # kg/s
 
-          if not duct.leakage_frac.nil?
-            leakage_fracs[duct.side] = 0 if leakage_fracs[duct.side].nil?
-            leakage_fracs[duct.side] += duct.leakage_frac
-          elsif not duct.leakage_cfm25.nil?
-            leakage_cfm25s[duct.side] = 0 if leakage_cfm25s[duct.side].nil?
-            leakage_cfm25s[duct.side] += duct.leakage_cfm25
-          end
-          ua_values[duct.side] += duct.area / duct.rvalue
-        end
+      # Supply leakage to living
+      duct_subroutine.addLine('  Set SupTotLkToLiv = sup_lk_mfr*(h_RA - h_SA)') # W
+      duct_subroutine.addLine('  Set SupLatLkToLv = sup_lk_mfr*h_fg*(RA_W-AH_Wout)') # W
+      duct_subroutine.addLine('  Set SupSensLkToLv = SupTotLkToLiv-SupLatLkToLv') # W
 
-        # Calculate fraction of outside air specific to this duct location
-        f_oa = 1.0
-        if duct_location.is_a? OpenStudio::Model::ThermalZone # in a space
-          if (not building.unconditioned_basement.nil?) && (building.unconditioned_basement.zone.name.to_s == duct_location.name.to_s)
-            f_oa = 0.0
-          elsif (not building.unvented_crawlspace.nil?) && (building.unvented_crawlspace.zone.name.to_s == duct_location.name.to_s)
-            f_oa = 0.0
-          elsif (not building.unvented_attic.nil?) && (building.unvented_attic.zone.name.to_s == duct_location.name.to_s)
-            f_oa = 0.0
-          end
-        end
+      # Supply conduction
+      duct_subroutine.addLine("  Set supply_ua = #{UnitConversions.convert(ua_values[HPXML::DuctTypeSupply], 'Btu/(hr*F)', 'W/K').round(3)}")
+      duct_subroutine.addLine('  Set eTm = 0-((Fan_RTF/(AH_MFR*air_cp))*supply_ua)')
+      duct_subroutine.addLine('  Set t_sup = DZ_T+((AH_Tout-DZ_T)*(@Exp eTm))') # deg-C
+      duct_subroutine.addLine('  Set SupCondToLv = AH_MFR*air_cp*(t_sup-AH_Tout)') # W
+      duct_subroutine.addLine('  Set SupCondToDZ = 0-SupCondToLv') # W
 
-        # Duct Subroutine
+      # Return conduction
+      duct_subroutine.addLine("  Set return_ua = #{UnitConversions.convert(ua_values[HPXML::DuctTypeReturn], 'Btu/(hr*F)', 'W/K').round(3)}")
+      duct_subroutine.addLine('  Set eTm = 0-((Fan_RTF/(AH_MFR*air_cp))*return_ua)')
+      duct_subroutine.addLine('  Set t_ret = DZ_T+((RA_T-DZ_T)*(@Exp eTm))') # deg-C
+      duct_subroutine.addLine('  Set RetCondToRP = AH_MFR*air_cp*(t_ret-RA_T)') # W
+      duct_subroutine.addLine('  Set RetCondToDZ = 0-RetCondToRP') # W
 
-        duct_subroutine = OpenStudio::Model::EnergyManagementSystemSubroutine.new(model)
-        duct_subroutine.setName("#{air_loop_name_idx} duct subroutine")
-        duct_subroutine.addLine("Set AH_MFR = #{ah_mfr_var.name}")
-        duct_subroutine.addLine('If AH_MFR>0')
-        duct_subroutine.addLine("  Set AH_Tout = #{ah_tout_var.name}")
-        duct_subroutine.addLine("  Set AH_Wout = #{ah_wout_var.name}")
-        duct_subroutine.addLine("  Set RA_T = #{ra_t_var.name}")
-        duct_subroutine.addLine("  Set RA_W = #{ra_w_var.name}")
-        duct_subroutine.addLine("  Set Fan_RTF = #{fan_rtf_var.name}")
-        duct_subroutine.addLine("  Set DZ_T = #{dz_t_var.name}")
-        duct_subroutine.addLine("  Set DZ_W = #{dz_w_var.name}")
-        duct_subroutine.addLine("  Set AH_VFR = #{ah_vfr_var.name}")
-        duct_subroutine.addLine('  Set h_SA = (@HFnTdbW AH_Tout AH_Wout)') # J/kg
-        duct_subroutine.addLine('  Set h_RA = (@HFnTdbW RA_T RA_W)') # J/kg
-        duct_subroutine.addLine('  Set h_fg = (@HfgAirFnWTdb AH_Wout AH_Tout)') # J/kg
-        duct_subroutine.addLine('  Set h_DZ = (@HFnTdbW DZ_T DZ_W)') # J/kg
-        duct_subroutine.addLine('  Set air_cp = 1006.0') # J/kg-C
+      # Return leakage to return plenum
+      duct_subroutine.addLine('  Set RetLatLkToRP = 0') # W
+      duct_subroutine.addLine('  Set RetSensLkToRP = ret_lk_mfr*air_cp*(DZ_T-RA_T)') # W
 
-        if not leakage_fracs[HPXML::DuctTypeSupply].nil?
-          duct_subroutine.addLine("  Set f_sup = #{leakage_fracs[HPXML::DuctTypeSupply]}") # frac
-        elsif not leakage_cfm25s[HPXML::DuctTypeSupply].nil?
-          duct_subroutine.addLine("  Set f_sup = #{UnitConversions.convert(leakage_cfm25s[HPXML::DuctTypeSupply], 'cfm', 'm^3/s').round(6)} / (#{fan_mfr_max_var.name} * 1.0135)") # frac
-        else
-          duct_subroutine.addLine('  Set f_sup = 0.0') # frac
-        end
-        if not leakage_fracs[HPXML::DuctTypeReturn].nil?
-          duct_subroutine.addLine("  Set f_ret = #{leakage_fracs[HPXML::DuctTypeReturn]}") # frac
-        elsif not leakage_cfm25s[HPXML::DuctTypeReturn].nil?
-          duct_subroutine.addLine("  Set f_ret = #{UnitConversions.convert(leakage_cfm25s[HPXML::DuctTypeReturn], 'cfm', 'm^3/s').round(6)} / (#{fan_mfr_max_var.name} * 1.0135)") # frac
-        else
-          duct_subroutine.addLine('  Set f_ret = 0.0') # frac
-        end
-        duct_subroutine.addLine('  Set sup_lk_mfr = f_sup * AH_MFR') # kg/s
-        duct_subroutine.addLine('  Set ret_lk_mfr = f_ret * AH_MFR') # kg/s
+      # Supply leakage to duct zone
+      # The below terms are not the same as SupLatLkToLv and SupSensLkToLv.
+      # To understand why, suppose the AHzone temperature equals the supply air temperature. In this case, the terms below
+      # should be zero while SupLatLkToLv and SupSensLkToLv should still be non-zero.
+      duct_subroutine.addLine('  Set SupTotLkToDZ = sup_lk_mfr*(h_SA-h_DZ)') # W
+      duct_subroutine.addLine('  Set SupLatLkToDZ = sup_lk_mfr*h_fg*(AH_Wout-DZ_W)') # W
+      duct_subroutine.addLine('  Set SupSensLkToDZ = SupTotLkToDZ-SupLatLkToDZ') # W
 
-        # Supply leakage to living
-        duct_subroutine.addLine('  Set SupTotLkToLiv = sup_lk_mfr*(h_RA - h_SA)') # W
-        duct_subroutine.addLine('  Set SupLatLkToLv = sup_lk_mfr*h_fg*(RA_W-AH_Wout)') # W
-        duct_subroutine.addLine('  Set SupSensLkToLv = SupTotLkToLiv-SupLatLkToLv') # W
+      duct_subroutine.addLine('  Set f_imbalance = f_sup-f_ret') # frac
+      duct_subroutine.addLine("  Set oa_vfr = #{f_oa} * f_imbalance * AH_VFR") # m3/s
+      duct_subroutine.addLine('  Set sup_lk_vfr = f_sup * AH_VFR') # m3/s
+      duct_subroutine.addLine('  Set ret_lk_vfr = f_ret * AH_VFR') # m3/s
+      duct_subroutine.addLine('  If f_sup > f_ret') # Living zone is depressurized relative to duct zone
+      duct_subroutine.addLine('    Set ZoneMixLvToDZ = 0') # m3/s
+      duct_subroutine.addLine('    Set ZoneMixDZToLv = (sup_lk_vfr-ret_lk_vfr)-oa_vfr') # m3/s
+      duct_subroutine.addLine('  Else') # Living zone is pressurized relative to duct zone
+      duct_subroutine.addLine('    Set ZoneMixLvToDZ = (ret_lk_vfr-sup_lk_vfr)+oa_vfr') # m3/s
+      duct_subroutine.addLine('    Set ZoneMixDZToLv = 0') # m3/s
+      duct_subroutine.addLine('  EndIf')
 
-        # Supply conduction
-        supply_ua = UnitConversions.convert(ua_values[HPXML::DuctTypeSupply], 'Btu/(hr*F)', 'W/K')
-        duct_subroutine.addLine("  Set eTm = (Fan_RTF/(AH_MFR*air_cp))*#{supply_ua.round(3)}")
-        duct_subroutine.addLine('  Set eTm = 0-eTm')
-        duct_subroutine.addLine('  Set t_sup = DZ_T+((AH_Tout-DZ_T)*(@Exp eTm))') # deg-C
-        duct_subroutine.addLine('  Set SupCondToLv = AH_MFR*air_cp*(t_sup-AH_Tout)') # W
-        duct_subroutine.addLine('  Set SupCondToDZ = 0-SupCondToLv') # W
+      # Calculate supply/exhaust fan equivalent
+      duct_subroutine.addLine('  If oa_vfr > 0')
+      duct_subroutine.addLine('    Set LkSupFanEquiv = 0') # m3/s, QductsIn
+      duct_subroutine.addLine('    Set LkExhFanEquiv = oa_vfr') # m3/s, QductsOut
+      duct_subroutine.addLine('  Else')
+      duct_subroutine.addLine('    Set LkSupFanEquiv = 0-oa_vfr') # m3/s, QductsIn
+      duct_subroutine.addLine('    Set LkExhFanEquiv = 0') # m3/s, QductsOut
+      duct_subroutine.addLine('  EndIf')
+      duct_subroutine.addLine('Else') # No air handler flow rate
+      duct_subroutine.addLine('  Set SupLatLkToLv = 0')
+      duct_subroutine.addLine('  Set SupSensLkToLv = 0')
+      duct_subroutine.addLine('  Set SupCondToLv = 0')
+      duct_subroutine.addLine('  Set RetCondToRP = 0')
+      duct_subroutine.addLine('  Set RetLatLkToRP = 0')
+      duct_subroutine.addLine('  Set RetSensLkToRP = 0')
+      duct_subroutine.addLine('  Set RetCondToDZ = 0')
+      duct_subroutine.addLine('  Set SupCondToDZ = 0')
+      duct_subroutine.addLine('  Set SupLatLkToDZ = 0')
+      duct_subroutine.addLine('  Set SupSensLkToDZ = 0')
+      duct_subroutine.addLine('  Set ZoneMixLvToDZ = 0') # m3/s
+      duct_subroutine.addLine('  Set ZoneMixDZToLv = 0') # m3/s
+      duct_subroutine.addLine('  Set LkSupFanEquiv = 0') # m3/s
+      duct_subroutine.addLine('  Set LkExhFanEquiv = 0') # m3/s
+      duct_subroutine.addLine('EndIf')
+      duct_subroutine.addLine("Set #{duct_vars['supply_lat_lk_to_liv'].name} = SupLatLkToLv")
+      duct_subroutine.addLine("Set #{duct_vars['supply_sens_lk_to_liv'].name} = SupSensLkToLv")
+      duct_subroutine.addLine("Set #{duct_vars['supply_cond_to_liv'].name} = SupCondToLv")
+      duct_subroutine.addLine("Set #{duct_vars['return_cond_to_rp'].name} = RetCondToRP")
+      duct_subroutine.addLine("Set #{duct_vars['return_lat_lk_to_rp'].name} = RetLatLkToRP")
+      duct_subroutine.addLine("Set #{duct_vars['return_sens_lk_to_rp'].name} = RetSensLkToRP")
+      duct_subroutine.addLine("Set #{duct_vars['return_cond_to_dz'].name} = RetCondToDZ")
+      duct_subroutine.addLine("Set #{duct_vars['supply_cond_to_dz'].name} = SupCondToDZ")
+      duct_subroutine.addLine("Set #{duct_vars['supply_lat_lk_to_dz'].name} = SupLatLkToDZ")
+      duct_subroutine.addLine("Set #{duct_vars['supply_sens_lk_to_dz'].name} = SupSensLkToDZ")
+      if not duct_actuators['liv_to_dz_flow_rate'].nil?
+        duct_subroutine.addLine("Set #{duct_vars['liv_to_dz_flow_rate'].name} = ZoneMixLvToDZ")
+      end
+      if not duct_actuators['dz_to_liv_flow_rate'].nil?
+        duct_subroutine.addLine("Set #{duct_vars['dz_to_liv_flow_rate'].name} = ZoneMixDZToLv")
+      end
+      duct_subroutine.addLine("Set #{duct_lk_supply_fan_equiv_var.name} = LkSupFanEquiv")
+      duct_subroutine.addLine("Set #{duct_lk_exhaust_fan_equiv_var.name} = LkExhFanEquiv")
 
-        # Return conduction
-        return_ua = UnitConversions.convert(ua_values[HPXML::DuctTypeReturn], 'Btu/(hr*F)', 'W/K')
-        duct_subroutine.addLine("  Set eTm = (Fan_RTF/(AH_MFR*air_cp))*#{return_ua.round(3)}")
-        duct_subroutine.addLine('  Set eTm = 0-eTm')
-        duct_subroutine.addLine('  Set t_ret = DZ_T+((RA_T-DZ_T)*(@Exp eTm))') # deg-C
-        duct_subroutine.addLine('  Set RetCondToRP = AH_MFR*air_cp*(t_ret-RA_T)') # W
-        duct_subroutine.addLine('  Set RetCondToDZ = 0-RetCondToRP') # W
+      # Duct Program
 
-        # Return leakage to return plenum
-        duct_subroutine.addLine('  Set RetLatLkToRP = 0') # W
-        duct_subroutine.addLine('  Set RetSensLkToRP = ret_lk_mfr*air_cp*(DZ_T-RA_T)') # W
+      duct_program = OpenStudio::Model::EnergyManagementSystemProgram.new(model)
+      duct_program.setName(air_loop_name_idx + ' duct program')
+      duct_program.addLine("Set #{ah_mfr_var.name} = #{ah_mfr_sensor.name}")
+      if @fan_rtf_sensor[air_loop].is_a? OpenStudio::Model::EnergyManagementSystemGlobalVariable
+        duct_program.addLine("Set #{@fan_rtf_sensor[air_loop].name} = #{@fan_mfr_sensor[air_loop].name} / #{@fan_mfr_max_var[air_loop].name}")
+      end
+      duct_program.addLine("Set #{@fan_rtf_var[air_loop].name} = #{@fan_rtf_sensor[air_loop].name}")
+      duct_program.addLine("Set #{ah_vfr_var.name} = #{ah_vfr_sensor.name}")
+      duct_program.addLine("Set #{ah_tout_var.name} = #{ah_tout_sensor.name}")
+      duct_program.addLine("Set #{ah_wout_var.name} = #{ah_wout_sensor.name}")
+      duct_program.addLine("Set #{ra_t_var.name} = #{ra_t_sensor.name}")
+      duct_program.addLine("Set #{ra_w_var.name} = #{ra_w_sensor.name}")
+      duct_program.addLine("Set #{dz_t_var.name} = #{dz_t_sensor.name}")
+      duct_program.addLine("Set #{dz_w_var.name} = #{dz_w}")
+      duct_program.addLine("Run #{duct_subroutine.name}")
+      duct_program.addLine("Set #{duct_actuators['supply_sens_lk_to_liv'].name} = #{duct_vars['supply_sens_lk_to_liv'].name}")
+      duct_program.addLine("Set #{duct_actuators['supply_lat_lk_to_liv'].name} = #{duct_vars['supply_lat_lk_to_liv'].name}")
+      duct_program.addLine("Set #{duct_actuators['supply_cond_to_liv'].name} = #{duct_vars['supply_cond_to_liv'].name}")
+      duct_program.addLine("Set #{duct_actuators['return_sens_lk_to_rp'].name} = #{duct_vars['return_sens_lk_to_rp'].name}")
+      duct_program.addLine("Set #{duct_actuators['return_lat_lk_to_rp'].name} = #{duct_vars['return_lat_lk_to_rp'].name}")
+      duct_program.addLine("Set #{duct_actuators['return_cond_to_rp'].name} = #{duct_vars['return_cond_to_rp'].name}")
+      duct_program.addLine("Set #{duct_actuators['return_cond_to_dz'].name} = #{duct_vars['return_cond_to_dz'].name}")
+      duct_program.addLine("Set #{duct_actuators['supply_cond_to_dz'].name} = #{duct_vars['supply_cond_to_dz'].name}")
+      duct_program.addLine("Set #{duct_actuators['supply_sens_lk_to_dz'].name} = #{duct_vars['supply_sens_lk_to_dz'].name}")
+      duct_program.addLine("Set #{duct_actuators['supply_lat_lk_to_dz'].name} = #{duct_vars['supply_lat_lk_to_dz'].name}")
+      if not duct_actuators['dz_to_liv_flow_rate'].nil?
+        duct_program.addLine("Set #{duct_actuators['dz_to_liv_flow_rate'].name} = #{duct_vars['dz_to_liv_flow_rate'].name}")
+      end
+      if not duct_actuators['liv_to_dz_flow_rate'].nil?
+        duct_program.addLine("Set #{duct_actuators['liv_to_dz_flow_rate'].name} = #{duct_vars['liv_to_dz_flow_rate'].name}")
+      end
 
-        # Supply leakage to duct zone
-        # The below terms are not the same as SupLatLkToLv and SupSensLkToLv.
-        # To understand why, suppose the AHzone temperature equals the supply air temperature. In this case, the terms below
-        # should be zero while SupLatLkToLv and SupSensLkToLv should still be non-zero.
-        duct_subroutine.addLine('  Set SupTotLkToDZ = sup_lk_mfr*(h_SA-h_DZ)') # W
-        duct_subroutine.addLine('  Set SupLatLkToDZ = sup_lk_mfr*h_fg*(AH_Wout-DZ_W)') # W
-        duct_subroutine.addLine('  Set SupSensLkToDZ = SupTotLkToDZ-SupLatLkToDZ') # W
+      if (not @cfis_airloop.nil?) && (air_loop == @cfis_airloop)
 
-        duct_subroutine.addLine('  Set f_imbalance = f_sup-f_ret') # frac
-        duct_subroutine.addLine("  Set oa_vfr = #{f_oa} * f_imbalance * AH_VFR") # m3/s
-        duct_subroutine.addLine('  Set sup_lk_vfr = f_sup * AH_VFR') # m3/s
-        duct_subroutine.addLine('  Set ret_lk_vfr = f_ret * AH_VFR') # m3/s
-        duct_subroutine.addLine('  If f_sup > f_ret') # Living zone is depressurized relative to duct zone
-        duct_subroutine.addLine('    Set ZoneMixLvToDZ = 0') # m3/s
-        duct_subroutine.addLine('    Set ZoneMixDZToLv = (sup_lk_vfr-ret_lk_vfr)-oa_vfr') # m3/s
-        duct_subroutine.addLine('  Else') # Living zone is pressurized relative to duct zone
-        duct_subroutine.addLine('    Set ZoneMixLvToDZ = (ret_lk_vfr-sup_lk_vfr)+oa_vfr') # m3/s
-        duct_subroutine.addLine('    Set ZoneMixDZToLv = 0') # m3/s
-        duct_subroutine.addLine('  EndIf')
+        # Calculate CFIS duct losses
 
-        # Calculate supply/exhaust fan equivalent
-        duct_subroutine.addLine('  If oa_vfr > 0')
-        duct_subroutine.addLine('    Set LkSupFanEquiv = 0') # m3/s, QductsIn
-        duct_subroutine.addLine('    Set LkExhFanEquiv = oa_vfr') # m3/s, QductsOut
-        duct_subroutine.addLine('  Else')
-        duct_subroutine.addLine('    Set LkSupFanEquiv = 0-oa_vfr') # m3/s, QductsIn
-        duct_subroutine.addLine('    Set LkExhFanEquiv = 0') # m3/s, QductsOut
-        duct_subroutine.addLine('  EndIf')
-        duct_subroutine.addLine('Else') # No air handler flow rate
-        duct_subroutine.addLine('  Set SupLatLkToLv = 0')
-        duct_subroutine.addLine('  Set SupSensLkToLv = 0')
-        duct_subroutine.addLine('  Set SupCondToLv = 0')
-        duct_subroutine.addLine('  Set RetCondToRP = 0')
-        duct_subroutine.addLine('  Set RetLatLkToRP = 0')
-        duct_subroutine.addLine('  Set RetSensLkToRP = 0')
-        duct_subroutine.addLine('  Set RetCondToDZ = 0')
-        duct_subroutine.addLine('  Set SupCondToDZ = 0')
-        duct_subroutine.addLine('  Set SupLatLkToDZ = 0')
-        duct_subroutine.addLine('  Set SupSensLkToDZ = 0')
-        duct_subroutine.addLine('  Set ZoneMixLvToDZ = 0') # m3/s
-        duct_subroutine.addLine('  Set ZoneMixDZToLv = 0') # m3/s
-        duct_subroutine.addLine('  Set LkSupFanEquiv = 0') # m3/s
-        duct_subroutine.addLine('  Set LkExhFanEquiv = 0') # m3/s
-        duct_subroutine.addLine('EndIf')
-        duct_subroutine.addLine("Set #{duct_vars['supply_lat_lk_to_liv'].name} = SupLatLkToLv")
-        duct_subroutine.addLine("Set #{duct_vars['supply_sens_lk_to_liv'].name} = SupSensLkToLv")
-        duct_subroutine.addLine("Set #{duct_vars['supply_cond_to_liv'].name} = SupCondToLv")
-        duct_subroutine.addLine("Set #{duct_vars['return_cond_to_rp'].name} = RetCondToRP")
-        duct_subroutine.addLine("Set #{duct_vars['return_lat_lk_to_rp'].name} = RetLatLkToRP")
-        duct_subroutine.addLine("Set #{duct_vars['return_sens_lk_to_rp'].name} = RetSensLkToRP")
-        duct_subroutine.addLine("Set #{duct_vars['return_cond_to_dz'].name} = RetCondToDZ")
-        duct_subroutine.addLine("Set #{duct_vars['supply_cond_to_dz'].name} = SupCondToDZ")
-        duct_subroutine.addLine("Set #{duct_vars['supply_lat_lk_to_dz'].name} = SupLatLkToDZ")
-        duct_subroutine.addLine("Set #{duct_vars['supply_sens_lk_to_dz'].name} = SupSensLkToDZ")
-        if not duct_actuators['liv_to_dz_flow_rate'].nil?
-          duct_subroutine.addLine("Set #{duct_vars['liv_to_dz_flow_rate'].name} = ZoneMixLvToDZ")
-        end
+        duct_program.addLine("If #{@cfis_f_damper_extra_open_var.name} > 0")
+        duct_program.addLine("  Set cfis_m3s = (#{@fan_mfr_max_var[air_loop].name} / 1.16097654)") # Density of 1.16097654 was back calculated using E+ results
+        duct_program.addLine("  Set #{@fan_rtf_var[air_loop].name} = #{@cfis_f_damper_extra_open_var.name}") # Need to use global vars to sync duct_program and infiltration program of different calling points
+        duct_program.addLine("  Set #{ah_vfr_var.name} = #{@fan_rtf_var[air_loop].name}*cfis_m3s")
+        duct_program.addLine("  Set rho_in = (@RhoAirFnPbTdbW #{@pbar_sensor.name} #{@tin_sensor.name} #{win_sensor.name})")
+        duct_program.addLine("  Set #{ah_mfr_var.name} = #{ah_vfr_var.name} * rho_in")
+        duct_program.addLine("  Set #{ah_tout_var.name} = #{ra_t_sensor.name}")
+        duct_program.addLine("  Set #{ah_wout_var.name} = #{ra_w_sensor.name}")
+        duct_program.addLine("  Set #{ra_t_var.name} = #{ra_t_sensor.name}")
+        duct_program.addLine("  Set #{ra_w_var.name} = #{ra_w_sensor.name}")
+        duct_program.addLine("  Run #{duct_subroutine.name}")
+        duct_program.addLine("  Set #{duct_actuators['cfis_supply_sens_lk_to_liv'].name} = #{duct_vars['supply_sens_lk_to_liv'].name}")
+        duct_program.addLine("  Set #{duct_actuators['cfis_supply_lat_lk_to_liv'].name} = #{duct_vars['supply_lat_lk_to_liv'].name}")
+        duct_program.addLine("  Set #{duct_actuators['cfis_supply_cond_to_liv'].name} = #{duct_vars['supply_cond_to_liv'].name}")
+        duct_program.addLine("  Set #{duct_actuators['cfis_return_sens_lk_to_rp'].name} = #{duct_vars['return_sens_lk_to_rp'].name}")
+        duct_program.addLine("  Set #{duct_actuators['cfis_return_lat_lk_to_rp'].name} = #{duct_vars['return_lat_lk_to_rp'].name}")
+        duct_program.addLine("  Set #{duct_actuators['cfis_return_cond_to_rp'].name} = #{duct_vars['return_cond_to_rp'].name}")
+        duct_program.addLine("  Set #{duct_actuators['cfis_return_cond_to_dz'].name} = #{duct_vars['return_cond_to_dz'].name}")
+        duct_program.addLine("  Set #{duct_actuators['cfis_supply_cond_to_dz'].name} = #{duct_vars['supply_cond_to_dz'].name}")
+        duct_program.addLine("  Set #{duct_actuators['cfis_supply_sens_lk_to_dz'].name} = #{duct_vars['supply_sens_lk_to_dz'].name}")
+        duct_program.addLine("  Set #{duct_actuators['cfis_supply_lat_lk_to_dz'].name} = #{duct_vars['supply_lat_lk_to_dz'].name}")
         if not duct_actuators['dz_to_liv_flow_rate'].nil?
-          duct_subroutine.addLine("Set #{duct_vars['dz_to_liv_flow_rate'].name} = ZoneMixDZToLv")
-        end
-        duct_subroutine.addLine("Set #{duct_lk_supply_fan_equiv_var.name} = LkSupFanEquiv")
-        duct_subroutine.addLine("Set #{duct_lk_exhaust_fan_equiv_var.name} = LkExhFanEquiv")
-
-        # Duct Program
-
-        duct_program = OpenStudio::Model::EnergyManagementSystemProgram.new(model)
-        duct_program.setName(air_loop_name_idx + ' duct program')
-        duct_program.addLine("Set #{ah_mfr_var.name} = #{ah_mfr_sensor.name}")
-        if fan_rtf_sensor.is_a? OpenStudio::Model::EnergyManagementSystemGlobalVariable
-          duct_program.addLine("Set #{fan_rtf_sensor.name} = #{fan_mfr_sensor.name} / #{fan_mfr_max_var.name}")
-        end
-        duct_program.addLine("Set #{fan_rtf_var.name} = #{fan_rtf_sensor.name}")
-        duct_program.addLine("Set #{ah_vfr_var.name} = #{ah_vfr_sensor.name}")
-        duct_program.addLine("Set #{ah_tout_var.name} = #{ah_tout_sensor.name}")
-        duct_program.addLine("Set #{ah_wout_var.name} = #{ah_wout_sensor.name}")
-        duct_program.addLine("Set #{ra_t_var.name} = #{ra_t_sensor.name}")
-        duct_program.addLine("Set #{ra_w_var.name} = #{ra_w_sensor.name}")
-        duct_program.addLine("Set #{dz_t_var.name} = #{dz_t_sensor.name}")
-        duct_program.addLine("Set #{dz_w_var.name} = #{dz_w}")
-        duct_program.addLine("Run #{duct_subroutine.name}")
-        duct_program.addLine("Set #{duct_actuators['supply_sens_lk_to_liv'].name} = #{duct_vars['supply_sens_lk_to_liv'].name}")
-        duct_program.addLine("Set #{duct_actuators['supply_lat_lk_to_liv'].name} = #{duct_vars['supply_lat_lk_to_liv'].name}")
-        duct_program.addLine("Set #{duct_actuators['supply_cond_to_liv'].name} = #{duct_vars['supply_cond_to_liv'].name}")
-        duct_program.addLine("Set #{duct_actuators['return_sens_lk_to_rp'].name} = #{duct_vars['return_sens_lk_to_rp'].name}")
-        duct_program.addLine("Set #{duct_actuators['return_lat_lk_to_rp'].name} = #{duct_vars['return_lat_lk_to_rp'].name}")
-        duct_program.addLine("Set #{duct_actuators['return_cond_to_rp'].name} = #{duct_vars['return_cond_to_rp'].name}")
-        duct_program.addLine("Set #{duct_actuators['return_cond_to_dz'].name} = #{duct_vars['return_cond_to_dz'].name}")
-        duct_program.addLine("Set #{duct_actuators['supply_cond_to_dz'].name} = #{duct_vars['supply_cond_to_dz'].name}")
-        duct_program.addLine("Set #{duct_actuators['supply_sens_lk_to_dz'].name} = #{duct_vars['supply_sens_lk_to_dz'].name}")
-        duct_program.addLine("Set #{duct_actuators['supply_lat_lk_to_dz'].name} = #{duct_vars['supply_lat_lk_to_dz'].name}")
-        if not duct_actuators['dz_to_liv_flow_rate'].nil?
-          duct_program.addLine("Set #{duct_actuators['dz_to_liv_flow_rate'].name} = #{duct_vars['dz_to_liv_flow_rate'].name}")
+          duct_program.addLine("  Set #{duct_actuators['cfis_dz_to_liv_flow_rate'].name} = #{duct_vars['dz_to_liv_flow_rate'].name}")
         end
         if not duct_actuators['liv_to_dz_flow_rate'].nil?
-          duct_program.addLine("Set #{duct_actuators['liv_to_dz_flow_rate'].name} = #{duct_vars['liv_to_dz_flow_rate'].name}")
+          duct_program.addLine("  Set #{duct_actuators['cfis_liv_to_dz_flow_rate'].name} = #{duct_vars['liv_to_dz_flow_rate'].name}")
         end
-
-        if (mech_vent.type == HPXML::MechVentTypeCFIS) && (air_loop == mech_vent.cfis_air_loop)
-
-          # Calculate CFIS duct losses
-
-          duct_program.addLine("If #{mech_vent.cfis_f_damper_extra_open_var.name} > 0")
-          duct_program.addLine("  Set cfis_m3s = (#{mech_vent.cfis_fan_mfr_max_var} / 1.16097654) * #{mech_vent.cfis_airflow_frac}") # Density of 1.16097654 was back calculated using E+ results
-          duct_program.addLine("  Set #{fan_rtf_var.name} = #{mech_vent.cfis_f_damper_extra_open_var.name}") # Need to use global vars to sync duct_program and infiltration program of different calling points
-          duct_program.addLine("  Set #{ah_vfr_var.name} = #{fan_rtf_var.name}*cfis_m3s")
-          duct_program.addLine("  Set rho_in = (@RhoAirFnPbTdbW #{pbar_sensor.name} #{tin_sensor.name} #{win_sensor.name})")
-          duct_program.addLine("  Set #{ah_mfr_var.name} = #{ah_vfr_var.name} * rho_in")
-          duct_program.addLine("  Set #{ah_tout_var.name} = #{ra_t_sensor.name}")
-          duct_program.addLine("  Set #{ah_wout_var.name} = #{ra_w_sensor.name}")
-          duct_program.addLine("  Set #{ra_t_var.name} = #{ra_t_sensor.name}")
-          duct_program.addLine("  Set #{ra_w_var.name} = #{ra_w_sensor.name}")
-          duct_program.addLine("  Run #{duct_subroutine.name}")
-          duct_program.addLine("  Set #{duct_actuators['cfis_supply_sens_lk_to_liv'].name} = #{duct_vars['supply_sens_lk_to_liv'].name}")
-          duct_program.addLine("  Set #{duct_actuators['cfis_supply_lat_lk_to_liv'].name} = #{duct_vars['supply_lat_lk_to_liv'].name}")
-          duct_program.addLine("  Set #{duct_actuators['cfis_supply_cond_to_liv'].name} = #{duct_vars['supply_cond_to_liv'].name}")
-          duct_program.addLine("  Set #{duct_actuators['cfis_return_sens_lk_to_rp'].name} = #{duct_vars['return_sens_lk_to_rp'].name}")
-          duct_program.addLine("  Set #{duct_actuators['cfis_return_lat_lk_to_rp'].name} = #{duct_vars['return_lat_lk_to_rp'].name}")
-          duct_program.addLine("  Set #{duct_actuators['cfis_return_cond_to_rp'].name} = #{duct_vars['return_cond_to_rp'].name}")
-          duct_program.addLine("  Set #{duct_actuators['cfis_return_cond_to_dz'].name} = #{duct_vars['return_cond_to_dz'].name}")
-          duct_program.addLine("  Set #{duct_actuators['cfis_supply_cond_to_dz'].name} = #{duct_vars['supply_cond_to_dz'].name}")
-          duct_program.addLine("  Set #{duct_actuators['cfis_supply_sens_lk_to_dz'].name} = #{duct_vars['supply_sens_lk_to_dz'].name}")
-          duct_program.addLine("  Set #{duct_actuators['cfis_supply_lat_lk_to_dz'].name} = #{duct_vars['supply_lat_lk_to_dz'].name}")
-          if not duct_actuators['dz_to_liv_flow_rate'].nil?
-            duct_program.addLine("  Set #{duct_actuators['cfis_dz_to_liv_flow_rate'].name} = #{duct_vars['dz_to_liv_flow_rate'].name}")
-          end
-          if not duct_actuators['liv_to_dz_flow_rate'].nil?
-            duct_program.addLine("  Set #{duct_actuators['cfis_liv_to_dz_flow_rate'].name} = #{duct_vars['liv_to_dz_flow_rate'].name}")
-          end
-          duct_program.addLine('Else')
-          duct_program.addLine("  Set #{duct_actuators['cfis_supply_sens_lk_to_liv'].name} = 0")
-          duct_program.addLine("  Set #{duct_actuators['cfis_supply_lat_lk_to_liv'].name} = 0")
-          duct_program.addLine("  Set #{duct_actuators['cfis_supply_cond_to_liv'].name} = 0")
-          duct_program.addLine("  Set #{duct_actuators['cfis_return_sens_lk_to_rp'].name} = 0")
-          duct_program.addLine("  Set #{duct_actuators['cfis_return_lat_lk_to_rp'].name} = 0")
-          duct_program.addLine("  Set #{duct_actuators['cfis_return_cond_to_rp'].name} = 0")
-          duct_program.addLine("  Set #{duct_actuators['cfis_return_cond_to_dz'].name} = 0")
-          duct_program.addLine("  Set #{duct_actuators['cfis_supply_cond_to_dz'].name} = 0")
-          duct_program.addLine("  Set #{duct_actuators['cfis_supply_sens_lk_to_dz'].name} = 0")
-          duct_program.addLine("  Set #{duct_actuators['cfis_supply_lat_lk_to_dz'].name} = 0")
-          if not duct_actuators['dz_to_liv_flow_rate'].nil?
-            duct_program.addLine("  Set #{duct_actuators['cfis_dz_to_liv_flow_rate'].name} = 0")
-          end
-          if not duct_actuators['liv_to_dz_flow_rate'].nil?
-            duct_program.addLine("  Set #{duct_actuators['cfis_liv_to_dz_flow_rate'].name} = 0")
-          end
-          duct_program.addLine('EndIf')
-
+        duct_program.addLine('Else')
+        duct_program.addLine("  Set #{duct_actuators['cfis_supply_sens_lk_to_liv'].name} = 0")
+        duct_program.addLine("  Set #{duct_actuators['cfis_supply_lat_lk_to_liv'].name} = 0")
+        duct_program.addLine("  Set #{duct_actuators['cfis_supply_cond_to_liv'].name} = 0")
+        duct_program.addLine("  Set #{duct_actuators['cfis_return_sens_lk_to_rp'].name} = 0")
+        duct_program.addLine("  Set #{duct_actuators['cfis_return_lat_lk_to_rp'].name} = 0")
+        duct_program.addLine("  Set #{duct_actuators['cfis_return_cond_to_rp'].name} = 0")
+        duct_program.addLine("  Set #{duct_actuators['cfis_return_cond_to_dz'].name} = 0")
+        duct_program.addLine("  Set #{duct_actuators['cfis_supply_cond_to_dz'].name} = 0")
+        duct_program.addLine("  Set #{duct_actuators['cfis_supply_sens_lk_to_dz'].name} = 0")
+        duct_program.addLine("  Set #{duct_actuators['cfis_supply_lat_lk_to_dz'].name} = 0")
+        if not duct_actuators['dz_to_liv_flow_rate'].nil?
+          duct_program.addLine("  Set #{duct_actuators['cfis_dz_to_liv_flow_rate'].name} = 0")
         end
+        if not duct_actuators['liv_to_dz_flow_rate'].nil?
+          duct_program.addLine("  Set #{duct_actuators['cfis_liv_to_dz_flow_rate'].name} = 0")
+        end
+        duct_program.addLine('EndIf')
 
-        duct_programs[air_loop_name_idx] = duct_program
+      end
+
+      manager = OpenStudio::Model::EnergyManagementSystemProgramCallingManager.new(model)
+      manager.setName("#{duct_program.name} calling manager")
+      manager.setCallingPoint('EndOfSystemTimestepAfterHVACReporting')
+      manager.addProgram(duct_program)
+    end
+  end
+
+  def self.apply_infiltration_to_garage(model, weather, ach50)
+    return if @spaces[HPXML::LocationGarage].nil?
+
+    space = @spaces[HPXML::LocationGarage]
+    area = UnitConversions.convert(space.floorArea, 'm^2', 'ft^2')
+    volume = Geometry.get_zone_volume(space.thermalZone.get)
+    hor_lk_frac = 0.4
+    neutral_level = 0.5
+    sla = get_infiltration_SLA_from_ACH50(ach50, 0.65, area, volume)
+    ela = sla * area
+    ach = get_infiltration_ACH_from_SLA(sla, 8.202, weather)
+    cfm = ach / UnitConversions.convert(1.0, 'hr', 'min') * volume
+    c_w_SG, c_s_SG = calc_wind_stack_coeffs(hor_lk_frac, neutral_level, space)
+    apply_infiltration_to_unconditioned_space(model, space, nil, ela, c_w_SG, c_s_SG)
+  end
+
+  def self.apply_infiltration_to_unconditioned_basement(model, weather)
+    return if @spaces[HPXML::LocationBasementUnconditioned].nil?
+
+    space = @spaces[HPXML::LocationBasementUnconditioned]
+    volume = UnitConversions.convert(space.volume, 'm^3', 'ft^3')
+    ach = 0.1 # Assumption
+    cfm = ach / UnitConversions.convert(1.0, 'hr', 'min') * volume
+    apply_infiltration_to_unconditioned_space(model, space, ach, nil, nil, nil)
+
+    # Store info for HVAC Sizing measure
+    space.thermalZone.get.additionalProperties.setFeature(Constants.SizingInfoZoneInfiltrationCFM, cfm.to_f)
+  end
+
+  def self.apply_infiltration_to_vented_crawlspace(model, weather, vented_crawl)
+    return if @spaces[HPXML::LocationCrawlspaceVented].nil?
+
+    space = @spaces[HPXML::LocationCrawlspaceVented]
+    volume = UnitConversions.convert(space.volume, 'm^3', 'ft^3')
+    sla = vented_crawl.vented_crawlspace_sla
+    ach = get_infiltration_ACH_from_SLA(sla, 8.202, weather)
+    cfm = ach / UnitConversions.convert(1.0, 'hr', 'min') * volume
+    apply_infiltration_to_unconditioned_space(model, space, ach, nil, nil, nil)
+
+    # Store info for HVAC Sizing measure
+    space.thermalZone.get.additionalProperties.setFeature(Constants.SizingInfoZoneInfiltrationCFM, cfm.to_f)
+  end
+
+  def self.apply_infiltration_to_unvented_crawlspace(model, weather)
+    return if @spaces[HPXML::LocationCrawlspaceUnvented].nil?
+
+    space = @spaces[HPXML::LocationCrawlspaceUnvented]
+    volume = UnitConversions.convert(space.volume, 'm^3', 'ft^3')
+    sla = 0 # Assumption
+    ach = get_infiltration_ACH_from_SLA(sla, 8.202, weather)
+    cfm = ach / UnitConversions.convert(1.0, 'hr', 'min') * volume
+    apply_infiltration_to_unconditioned_space(model, space, ach, nil, nil, nil)
+
+    # Store info for HVAC Sizing measure
+    space.thermalZone.get.additionalProperties.setFeature(Constants.SizingInfoZoneInfiltrationCFM, cfm.to_f)
+  end
+
+  def self.apply_infiltration_to_vented_attic(model, weather, vented_attic)
+    return if @spaces[HPXML::LocationAtticVented].nil?
+
+    if not vented_attic.vented_attic_sla.nil?
+      vented_attic_sla = vented_attic.vented_attic_sla
+    elsif not vented_attic.vented_attic_ach.nil?
+      if @apply_ashrae140_assumptions
+        vented_attic_const_ach = vented_attic.vented_attic_ach
+      else
+        vented_attic_sla = get_infiltration_SLA_from_ACH(vented_attic.vented_attic_ach, 8.202, weather)
       end
     end
-  end
 
-  def self.create_cfis_objects(model, building, mech_vent)
-    if (mech_vent.cfis_airflow_frac < 0) || (mech_vent.cfis_airflow_frac > 1)
-      fail 'Mechanical Ventilation: CFIS blower airflow rate must be greater than or equal to 0 and less than or equal to 1.'
+    space = @spaces[HPXML::LocationAtticVented]
+    volume = UnitConversions.convert(space.volume, 'm^3', 'ft^3')
+    if not vented_attic_sla.nil?
+      vented_attic_area = UnitConversions.convert(space.floorArea, 'm^2', 'ft^2')
+      hor_lk_frac = 1.0
+      neutral_level = 0.5
+      sla = vented_attic_sla
+      ach = get_infiltration_ACH_from_SLA(sla, 8.202, weather)
+      ela = sla * vented_attic_area
+      cfm = ach / UnitConversions.convert(1.0, 'hr', 'min') * volume
+      c_w_SG, c_s_SG = calc_wind_stack_coeffs(hor_lk_frac, neutral_level, space)
+      apply_infiltration_to_unconditioned_space(model, space, nil, ela, c_w_SG, c_s_SG)
+    elsif not vented_attic_const_ach.nil?
+      ach = vented_attic_const_ach
+      cfm = ach / UnitConversions.convert(1.0, 'hr', 'min') * volume
+      apply_infiltration_to_unconditioned_space(model, space, ach, nil, nil, nil)
     end
 
-    mech_vent.cfis_t_sum_open_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{Constants.ObjectNameMechanicalVentilation.gsub(' ', '_')}_cfis_t_sum_open") # Sums the time during an hour the CFIS damper has been open
-    mech_vent.cfis_f_damper_extra_open_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, "#{Constants.ObjectNameMechanicalVentilation.gsub(' ', '_')}_cfis_f_extra_damper_open") # Fraction of timestep the CFIS blower is running while hvac is not operating. Used by infiltration and duct leakage programs
-
-    if mech_vent.fan_power_w.nil?
-      supply_fan = HVAC.get_unitary_system_from_air_loop_hvac(mech_vent.cfis_air_loop).supplyFan.get.to_FanOnOff.get
-
-      mech_vent.cfis_fan_pressure_rise = OpenStudio::Model::EnergyManagementSystemInternalVariable.new(model, 'Fan Nominal Pressure Rise')
-      mech_vent.cfis_fan_pressure_rise.setName("#{Constants.ObjectNameMechanicalVentilation} sup fan press".gsub(' ', '_'))
-      mech_vent.cfis_fan_pressure_rise.setInternalDataIndexKeyName(supply_fan.name.to_s)
-
-      mech_vent.cfis_fan_efficiency = OpenStudio::Model::EnergyManagementSystemInternalVariable.new(model, 'Fan Nominal Total Efficiency')
-      mech_vent.cfis_fan_efficiency.setName("#{Constants.ObjectNameMechanicalVentilation} sup fan eff".gsub(' ', '_'))
-      mech_vent.cfis_fan_efficiency.setInternalDataIndexKeyName(supply_fan.name.to_s)
-    end
-
-    # CFIS Program
-    cfis_program = OpenStudio::Model::EnergyManagementSystemProgram.new(model)
-    cfis_program.setName(Constants.ObjectNameMechanicalVentilation + ' cfis init program')
-    cfis_program.addLine("Set #{mech_vent.cfis_t_sum_open_var.name} = 0")
-    cfis_program.addLine("Set #{mech_vent.cfis_f_damper_extra_open_var.name} = 0")
-
-    return cfis_program
+    # Store info for HVAC Sizing measure
+    space.thermalZone.get.additionalProperties.setFeature(Constants.SizingInfoZoneInfiltrationCFM, cfm.to_f)
   end
 
-  def self.create_infil_mech_vent_objects(model, building, infil, mech_vent, vent_fan_kitchen, vent_fan_bath, wind_speed, tin_sensor, tout_sensor, vwind_sensor, duct_lks, wout_sensor, pbar_sensor)
-    # Sensors
+  def self.apply_infiltration_to_unvented_attic(model, weather)
+    return if @spaces[HPXML::LocationAtticUnvented].nil?
 
-    range_array = [0.0] * 24
-    if not vent_fan_kitchen.nil?
-      remaining_hrs = vent_fan_kitchen.hours_in_operation
-      for hr in 1..(vent_fan_kitchen.hours_in_operation.ceil)
+    space = @spaces[HPXML::LocationAtticUnvented]
+    area = UnitConversions.convert(space.floorArea, 'm^2', 'ft^2')
+    volume = UnitConversions.convert(space.volume, 'm^3', 'ft^3')
+    hor_lk_frac = 1.0
+    neutral_level = 0.5
+    sla = 0 # Assumption
+    ach = get_infiltration_ACH_from_SLA(sla, 8.202, weather)
+    ela = sla * area
+    cfm = ach / UnitConversions.convert(1.0, 'hr', 'min') * volume
+    c_w_SG, c_s_SG = calc_wind_stack_coeffs(hor_lk_frac, neutral_level, space)
+    apply_infiltration_to_unconditioned_space(model, space, nil, ela, c_w_SG, c_s_SG)
+
+    # Store info for HVAC Sizing measure
+    space.thermalZone.get.additionalProperties.setFeature(Constants.SizingInfoZoneInfiltrationCFM, cfm.to_f)
+  end
+
+  def self.apply_local_ventilation(model, vent_object, obj_name)
+    daily_sch = [0.0] * 24
+    if not vent_object.nil?
+      remaining_hrs = vent_object.hours_in_operation
+      for hr in 1..(vent_object.hours_in_operation.ceil)
         if remaining_hrs >= 1
-          range_array[(vent_fan_kitchen.start_hour + hr - 1) % 24] = 1.0
+          daily_sch[(vent_object.start_hour + hr - 1) % 24] = 1.0
         else
-          range_array[(vent_fan_kitchen.start_hour + hr - 1) % 24] = remaining_hrs
+          daily_sch[(vent_object.start_hour + hr - 1) % 24] = remaining_hrs
         end
         remaining_hrs -= 1
       end
     end
-    range_hood_sch = HourlyByMonthSchedule.new(model, Constants.ObjectNameMechanicalVentilation + ' range exhaust schedule', [range_array] * 12, [range_array] * 12, false, true, Constants.ScheduleTypeLimitsOnOff)
-    range_sch_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Schedule Value')
-    range_sch_sensor.setName("#{Constants.ObjectNameMechanicalVentilation} range sch s")
-    range_sch_sensor.setKeyName(range_hood_sch.schedule.name.to_s)
+    obj_sch = HourlyByMonthSchedule.new(model, "#{obj_name} schedule", [daily_sch] * 12, [daily_sch] * 12, false, true, Constants.ScheduleTypeLimitsOnOff)
+    obj_sch_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Schedule Value')
+    obj_sch_sensor.setName("#{obj_name} sch s")
+    obj_sch_sensor.setKeyName(obj_sch.schedule.name.to_s)
 
-    bathroom_array = [0.0] * 24
-    if not vent_fan_bath.nil?
-      remaining_hrs = vent_fan_bath.hours_in_operation
-      for hr in 1..(vent_fan_bath.hours_in_operation.ceil)
-        if remaining_hrs >= 1
-          bathroom_array[(vent_fan_bath.start_hour + hr - 1) % 24] = 1.0
+    equip_def = OpenStudio::Model::ElectricEquipmentDefinition.new(model)
+    equip_def.setName(obj_name)
+    equip = OpenStudio::Model::ElectricEquipment.new(equip_def)
+    equip.setName(obj_name)
+    equip.setSpace(@living_space)
+    if vent_object.nil?
+      equip_def.setDesignLevel(0.0)
+    else
+      equip_def.setDesignLevel(vent_object.fan_power)
+    end
+    equip_def.setFractionRadiant(0)
+    equip_def.setFractionLatent(0)
+    equip_def.setFractionLost(1)
+    equip.setSchedule(obj_sch.schedule)
+    equip.setEndUseSubcategory(Constants.ObjectNameMechanicalVentilation)
+
+    return obj_sch, obj_sch_sensor
+  end
+
+  def self.calc_hrv_erv_effectiveness(vent_mech, vent_mech_cfm, vent_mech_fan_w)
+    if [HPXML::MechVentTypeERV, HPXML::MechVentTypeHRV].include?(vent_mech.fan_type) && (vent_mech_cfm > 0)
+      # Must assume an operating condition (HVI seems to use CSA 439)
+      t_sup_in = 0.0
+      w_sup_in = 0.0028
+      t_exh_in = 22.0
+      w_exh_in = 0.0065
+      cp_a = 1006.0
+      p_fan = vent_mech_fan_w # Watts
+
+      m_fan = UnitConversions.convert(vent_mech_cfm, 'cfm', 'm^3/s') * 16.02 * Psychrometrics.rhoD_fT_w_P(UnitConversions.convert(t_sup_in, 'C', 'F'), w_sup_in, 14.7) # kg/s
+
+      if not vent_mech.sensible_recovery_efficiency.nil?
+        # The following is derived from CSA 439, Clause 9.3.3.1, Eq. 12:
+        #    E_SHR = (m_sup,fan * Cp * (Tsup,out - Tsup,in) - P_sup,fan) / (m_exh,fan * Cp * (Texh,in - Tsup,in) + P_exh,fan)
+        t_sup_out = t_sup_in + (vent_mech.sensible_recovery_efficiency * (m_fan * cp_a * (t_exh_in - t_sup_in) + p_fan) + p_fan) / (m_fan * cp_a)
+
+        # Calculate the apparent sensible effectiveness
+        vent_mech_apparent_sens_eff = (t_sup_out - t_sup_in) / (t_exh_in - t_sup_in)
+
+      else
+        # The following is derived from (taken from CSA 439, Clause 9.2.1, Eq. 7):
+        t_sup_out = t_sup_in + (vent_mech.sensible_recovery_efficiency_adjusted * (t_exh_in - t_sup_in))
+
+        vent_mech_apparent_sens_eff = vent_mech.sensible_recovery_efficiency_adjusted
+
+      end
+
+      # Calculate the supply temperature before the fan
+      t_sup_out_gross = t_sup_out - p_fan / (m_fan * cp_a)
+
+      # Sensible effectiveness of the HX only
+      vent_mech_sens_eff = (t_sup_out_gross - t_sup_in) / (t_exh_in - t_sup_in)
+
+      if (vent_mech_sens_eff < 0.0) || (vent_mech_sens_eff > 1.0)
+        fail "The calculated ERV/HRV sensible effectiveness is #{vent_mech_sens_eff} but should be between 0 and 1. Please revise ERV/HRV efficiency values."
+      end
+
+      # Use summer test condition to determine the latent effectiveness since TRE is generally specified under the summer condition
+      if (not vent_mech.total_recovery_efficiency.nil?) || (not vent_mech.total_recovery_efficiency_adjusted.nil?)
+
+        t_sup_in = 35.0
+        w_sup_in = 0.0178
+        t_exh_in = 24.0
+        w_exh_in = 0.0092
+
+        m_fan = UnitConversions.convert(vent_mech_cfm, 'cfm', 'm^3/s') * UnitConversions.convert(Psychrometrics.rhoD_fT_w_P(UnitConversions.convert(t_sup_in, 'C', 'F'), w_sup_in, 14.7), 'lbm/ft^3', 'kg/m^3') # kg/s
+
+        t_sup_out_gross = t_sup_in - vent_mech_sens_eff * (t_sup_in - t_exh_in)
+        t_sup_out = t_sup_out_gross + p_fan / (m_fan * cp_a)
+
+        h_sup_in = Psychrometrics.h_fT_w_SI(t_sup_in, w_sup_in)
+        h_exh_in = Psychrometrics.h_fT_w_SI(t_exh_in, w_exh_in)
+
+        if not vent_mech.total_recovery_efficiency.nil?
+          # The following is derived from CSA 439, Clause 9.3.3.2, Eq. 13:
+          #    E_THR = (m_sup,fan * Cp * (h_sup,out - h_sup,in) - P_sup,fan) / (m_exh,fan * Cp * (h_exh,in - h_sup,in) + P_exh,fan)
+          h_sup_out = h_sup_in - (vent_mech.total_recovery_efficiency * (m_fan * (h_sup_in - h_exh_in) + p_fan) + p_fan) / m_fan
         else
-          bathroom_array[(vent_fan_bath.start_hour + hr - 1) % 24] = remaining_hrs
+          # The following is derived from (taken from CSA 439, Clause 9.2.1, Eq. 7):
+          h_sup_out = h_sup_in - (vent_mech.total_recovery_efficiency_adjusted * (h_sup_in - h_exh_in))
         end
-        remaining_hrs -= 1
+
+        w_sup_out = Psychrometrics.w_fT_h_SI(t_sup_out, h_sup_out)
+        vent_mech_lat_eff = [0.0, (w_sup_out - w_sup_in) / (w_exh_in - w_sup_in)].max
+
+        if (vent_mech_lat_eff < 0.0) || (vent_mech_lat_eff > 1.0)
+          fail "The calculated ERV/HRV latent effectiveness is #{vent_mech_lat_eff} but should be between 0 and 1. Please revise ERV/HRV efficiency values."
+        end
+
+      else
+        vent_mech_lat_eff = 0.0
+      end
+    else
+      vent_mech_apparent_sens_eff = 0.0
+      vent_mech_sens_eff = 0.0
+      vent_mech_lat_eff = 0.0
+    end
+
+    return vent_mech_sens_eff, vent_mech_lat_eff, vent_mech_apparent_sens_eff
+  end
+
+  def self.apply_infiltration_and_ventilation_fans(model, weather, vent_mech, vent_kitchen, vent_bath, duct_lks, has_flue_chimney, air_infils, vented_attic, vented_crawl)
+    # Get living space infiltration
+    living_ach50 = nil
+    living_const_ach = nil
+    air_infils.each do |air_infil|
+      if (air_infil.unit_of_measure == HPXML::UnitsACH) && (air_infil.house_pressure == 50)
+        living_ach50 = air_infil.air_leakage
+      elsif (air_infil.unit_of_measure == HPXML::UnitsCFM) && (air_infil.house_pressure == 50)
+        living_ach50 = air_infil.air_leakage * 60.0 / @infil_volume # Convert CFM50 to ACH50
+      elsif air_infil.unit_of_measure == HPXML::UnitsACHNatural
+        if @apply_ashrae140_assumptions
+          living_const_ach = air_infil.air_leakage
+        else
+          sla = get_infiltration_SLA_from_ACH(air_infil.air_leakage, @infil_height, weather)
+          living_ach50 = get_infiltration_ACH50_from_SLA(sla, 0.65, @cfa, @infil_volume)
+        end
       end
     end
-    bath_exhaust_sch = HourlyByMonthSchedule.new(model, Constants.ObjectNameMechanicalVentilation + ' bath exhaust schedule', [bathroom_array] * 12, [bathroom_array] * 12, false, true, Constants.ScheduleTypeLimitsOnOff)
-    bath_sch_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Schedule Value')
-    bath_sch_sensor.setName("#{Constants.ObjectNameMechanicalVentilation} bath sch s")
-    bath_sch_sensor.setKeyName(bath_exhaust_sch.schedule.name.to_s)
 
-    if mech_vent.has_dryer && (mech_vent.dryer_exhaust > 0)
-      dryer_exhaust_sch = HotWaterSchedule.new(model, Constants.ObjectNameMechanicalVentilation + ' dryer exhaust schedule', building.nbeds, 0, true)
-      dryer_sch_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Schedule Value')
-      dryer_sch_sensor.setName("#{Constants.ObjectNameMechanicalVentilation} dryer sch s")
-      dryer_sch_sensor.setKeyName(dryer_exhaust_sch.schedule.name.to_s)
+    # Get mechanical ventilation
+    if not vent_mech.nil?
+      vent_mech_fan_w = vent_mech.fan_power
+      vent_mech_cfm = vent_mech.tested_flow_rate
+      if vent_mech_cfm.nil?
+        vent_mech_cfm = vent_mech.rated_flow_rate
+      end
+      if vent_mech.fan_type != HPXML::MechVentTypeCFIS
+        # Calculate 24-hour average cfm and fan power
+        vent_mech_cfm *= (vent_mech.hours_in_operation / 24.0)
+        vent_mech_fan_w *= (vent_mech.hours_in_operation / 24.0)
+      end
+      vent_mech_sens_eff, vent_mech_lat_eff, vent_mech_apparent_sens_eff = calc_hrv_erv_effectiveness(vent_mech, vent_mech_cfm, vent_mech_fan_w)
+
+      # Store info for HVAC Sizing measure
+      model.getBuilding.additionalProperties.setFeature(Constants.SizingInfoMechVentTotalEfficiency, vent_mech.total_recovery_efficiency.to_f)
+      model.getBuilding.additionalProperties.setFeature(Constants.SizingInfoMechVentLatentEffectiveness, vent_mech_lat_eff.to_f)
+      model.getBuilding.additionalProperties.setFeature(Constants.SizingInfoMechVentApparentSensibleEffectiveness, vent_mech_apparent_sens_eff.to_f)
+      model.getBuilding.additionalProperties.setFeature(Constants.SizingInfoMechVentWholeHouseRate, vent_mech_cfm.to_f)
+      model.getBuilding.additionalProperties.setFeature(Constants.SizingInfoMechVentType, vent_mech.fan_type.to_s)
     end
 
-    wh_sch_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Schedule Value')
-    wh_sch_sensor.setName("#{Constants.ObjectNameMechanicalVentilation} wh sch s")
-    wh_sch_sensor.setKeyName(model.alwaysOnDiscreteSchedule.name.to_s)
+    # Infiltration for unconditioned spaces
+    apply_infiltration_to_garage(model, weather, living_ach50)
+    apply_infiltration_to_unconditioned_basement(model, weather)
+    apply_infiltration_to_vented_crawlspace(model, weather, vented_crawl)
+    apply_infiltration_to_unvented_crawlspace(model, weather)
+    apply_infiltration_to_vented_attic(model, weather, vented_attic)
+    apply_infiltration_to_unvented_attic(model, weather)
+
+    # Local ventilation
+    range_hood_sch, range_sch_sensor = apply_local_ventilation(model, vent_kitchen, Constants.ObjectNameMechanicalVentilationRangeFan)
+    bath_exhaust_sch, bath_sch_sensor = apply_local_ventilation(model, vent_bath, Constants.ObjectNameMechanicalVentilationBathFan)
 
     # Actuators
-
-    living_space = building.living.zone.spaces[0]
 
     equip_def = OpenStudio::Model::ElectricEquipmentDefinition.new(model)
     equip_def.setName(Constants.ObjectNameMechanicalVentilationHouseFan)
     equip = OpenStudio::Model::ElectricEquipment.new(equip_def)
     equip.setName(Constants.ObjectNameMechanicalVentilationHouseFan)
-    equip.setSpace(living_space)
+    equip.setSpace(@living_space)
     equip_def.setFractionRadiant(0)
     equip_def.setFractionLatent(0)
-    equip_def.setFractionLost(1.0 - mech_vent.frac_fan_heat)
+    if vent_mech.nil?
+      equip_def.setFractionLost(1.0) # Arbitrary
+    elsif [HPXML::MechVentTypeExhaust].include? vent_mech.fan_type
+      equip_def.setFractionLost(1.0) # Fan heat does not enter space
+    elsif [HPXML::MechVentTypeSupply, HPXML::MechVentTypeCFIS].include? vent_mech.fan_type
+      equip_def.setFractionLost(0.0) # Fan heat does enter space
+    elsif [HPXML::MechVentTypeBalanced, HPXML::MechVentTypeERV, HPXML::MechVentTypeHRV].include? vent_mech.fan_type
+      equip_def.setFractionLost(0.5) # Supply fan heat enters space
+    end
     equip.setSchedule(model.alwaysOnDiscreteSchedule)
     equip.setEndUseSubcategory(Constants.ObjectNameMechanicalVentilation)
-    mech_vent_fan_actuator = OpenStudio::Model::EnergyManagementSystemActuator.new(equip, 'ElectricEquipment', 'Electric Power Level')
-    mech_vent_fan_actuator.setName("#{equip.name} act")
-
-    equip_def = OpenStudio::Model::ElectricEquipmentDefinition.new(model)
-    equip_def.setName(Constants.ObjectNameMechanicalVentilationRangeFan)
-    equip = OpenStudio::Model::ElectricEquipment.new(equip_def)
-    equip.setName(Constants.ObjectNameMechanicalVentilationRangeFan)
-    equip.setSpace(living_space)
-    if vent_fan_kitchen.nil?
-      equip_def.setDesignLevel(0.0)
-    else
-      equip_def.setDesignLevel(vent_fan_kitchen.fan_power)
-    end
-    equip_def.setFractionRadiant(0)
-    equip_def.setFractionLatent(0)
-    equip_def.setFractionLost(1)
-    equip.setSchedule(range_hood_sch.schedule)
-    equip.setEndUseSubcategory(Constants.ObjectNameMechanicalVentilation)
-
-    equip_def = OpenStudio::Model::ElectricEquipmentDefinition.new(model)
-    equip_def.setName(Constants.ObjectNameMechanicalVentilationBathFan)
-    equip = OpenStudio::Model::ElectricEquipment.new(equip_def)
-    equip.setName(Constants.ObjectNameMechanicalVentilationBathFan)
-    equip.setSpace(living_space)
-    if vent_fan_bath.nil?
-      equip_def.setDesignLevel(0.0)
-    else
-      equip_def.setDesignLevel(vent_fan_bath.fan_power)
-    end
-    equip_def.setFractionRadiant(0)
-    equip_def.setFractionLatent(0)
-    equip_def.setFractionLost(1)
-    equip.setSchedule(bath_exhaust_sch.schedule)
-    equip.setEndUseSubcategory(Constants.ObjectNameMechanicalVentilation)
+    vent_mech_fan_actuator = OpenStudio::Model::EnergyManagementSystemActuator.new(equip, 'ElectricEquipment', 'Electric Power Level')
+    vent_mech_fan_actuator.setName("#{equip.name} act")
 
     infil_flow = OpenStudio::Model::SpaceInfiltrationDesignFlowRate.new(model)
     infil_flow.setName(Constants.ObjectNameInfiltration + ' flow')
     infil_flow.setSchedule(model.alwaysOnDiscreteSchedule)
-    infil_flow.setSpace(living_space)
+    infil_flow.setSpace(@living_space)
     infil_flow_actuator = OpenStudio::Model::EnergyManagementSystemActuator.new(infil_flow, 'Zone Infiltration', 'Air Exchange Flow Rate')
     infil_flow_actuator.setName("#{infil_flow.name} act")
 
     imbal_ducts_flow = OpenStudio::Model::SpaceInfiltrationDesignFlowRate.new(model)
     imbal_ducts_flow.setName(Constants.ObjectNameDucts + ' flow')
     imbal_ducts_flow.setSchedule(model.alwaysOnDiscreteSchedule)
-    imbal_ducts_flow.setSpace(living_space)
+    imbal_ducts_flow.setSpace(@living_space)
     imbal_ducts_flow_actuator = OpenStudio::Model::EnergyManagementSystemActuator.new(imbal_ducts_flow, 'Zone Infiltration', 'Air Exchange Flow Rate')
     imbal_ducts_flow_actuator.setName("#{imbal_ducts_flow.name} act")
 
     imbal_mechvent_flow = OpenStudio::Model::SpaceInfiltrationDesignFlowRate.new(model)
     imbal_mechvent_flow.setName(Constants.ObjectNameMechanicalVentilation + ' flow')
     imbal_mechvent_flow.setSchedule(model.alwaysOnDiscreteSchedule)
-    imbal_mechvent_flow.setSpace(living_space)
+    imbal_mechvent_flow.setSpace(@living_space)
     imbal_mechvent_flow_actuator = OpenStudio::Model::EnergyManagementSystemActuator.new(imbal_mechvent_flow, 'Zone Infiltration', 'Air Exchange Flow Rate')
     imbal_mechvent_flow_actuator.setName("#{imbal_mechvent_flow.name} act")
 
-    # Program
-
+    # Living Space Infiltration Calculation/Program
     infil_program = OpenStudio::Model::EnergyManagementSystemProgram.new(model)
     infil_program.setName(Constants.ObjectNameInfiltration + ' program')
-    if building.living.inf_method == @infMethodAIM2
-      if building.living.SLA > 0
-        infil_program.addLine("Set p_m = #{wind_speed.ashrae_terrain_exponent}")
-        infil_program.addLine("Set p_s = #{wind_speed.ashrae_site_terrain_exponent}")
-        infil_program.addLine("Set s_m = #{wind_speed.ashrae_terrain_thickness}")
-        infil_program.addLine("Set s_s = #{wind_speed.ashrae_site_terrain_thickness}")
-        infil_program.addLine("Set z_m = #{UnitConversions.convert(wind_speed.height, 'ft', 'm')}")
-        infil_program.addLine("Set z_s = #{UnitConversions.convert(building.infilheight, 'ft', 'm')}")
-        infil_program.addLine('Set f_t = (((s_m/z_m)^p_m)*((z_s/s_s)^p_s))')
-        infil_program.addLine("Set Tdiff = #{tin_sensor.name}-#{tout_sensor.name}")
-        infil_program.addLine('Set dT = @Abs Tdiff')
-        infil_program.addLine("Set c = #{((UnitConversions.convert(infil.c_i, 'cfm', 'm^3/s') / (UnitConversions.convert(1.0, 'inH2O', 'Pa')**infil.n_i))).round(4)}")
-        infil_program.addLine("Set Cs = #{(infil.stack_coef * (UnitConversions.convert(1.0, 'inH2O/R', 'Pa/K')**infil.n_i)).round(4)}")
-        infil_program.addLine("Set Cw = #{(infil.wind_coef * (UnitConversions.convert(1.0, 'inH2O/mph^2', 'Pa*s^2/m^2')**infil.n_i)).round(4)}")
-        infil_program.addLine("Set n = #{infil.n_i}")
-        infil_program.addLine("Set sft = (f_t*#{(((wind_speed.S_wo * (1.0 - infil.y_i)) + (infil.s_wflue * (1.5 * infil.y_i))))})")
-        infil_program.addLine("Set temp1 = ((c*Cw)*((sft*#{vwind_sensor.name})^(2*n)))^2")
-        infil_program.addLine('Set Qn = (((c*Cs*(dT^n))^2)+temp1)^0.5')
+
+    if living_ach50.to_f > 0
+      # Based on "Field Validation of Algebraic Equations for Stack and
+      # Wind Driven Air Infiltration Calculations" by Walker and Wilson (1998)
+
+      outside_air_density = UnitConversions.convert(weather.header.LocalPressure, 'atm', 'Btu/ft^3') / (Gas.Air.r * (weather.data.AnnualAvgDrybulb + 460.0))
+
+      n_i = 0.65 # Pressure Exponent
+      living_sla = get_infiltration_SLA_from_ACH50(living_ach50, n_i, @cfa, @infil_volume) # Calculate SLA
+      a_o = living_sla * @cfa # Effective Leakage Area (ft^2)
+
+      # Flow Coefficient (cfm/inH2O^n) (based on ASHRAE HoF)
+      inf_conv_factor = 776.25 # [ft/min]/[inH2O^(1/2)*ft^(3/2)/lbm^(1/2)]
+      delta_pref = 0.016 # inH2O
+      c_i = a_o * (2.0 / outside_air_density)**0.5 * delta_pref**(0.5 - n_i) * inf_conv_factor
+
+      if has_flue_chimney
+        y_i = 0.2 # Fraction of leakage through the flue; 0.2 is a "typical" value according to THE ALBERTA AIR INFIL1RATION MODEL, Walker and Wilson, 1990
+        flue_height = @building_height + 2.0 # ft
+        s_wflue = 1.0 # Flue Shelter Coefficient
       else
-        infil_program.addLine('Set Qn = 0')
+        y_i = 0.0 # Fraction of leakage through the flu
+        flue_height = 0.0 # ft
+        s_wflue = 0.0 # Flue Shelter Coefficient
       end
-    elsif building.living.inf_method == @infMethodConstantCFM
-      infil_program.addLine("Set Qn = #{building.living.ACH * UnitConversions.convert(building.infilvolume, 'ft^3', 'm^3') / UnitConversions.convert(1.0, 'hr', 's')}")
+
+      # Leakage distributions per Iain Walker (LBL) recommendations
+      if not @spaces[HPXML::LocationCrawlspaceVented].nil?
+        # 15% ceiling, 35% walls, 50% floor leakage distribution for vented crawl
+        leakage_ceiling = 0.15
+        leakage_walls = 0.35
+        leakage_floor = 0.50
+      else
+        # 25% ceiling, 50% walls, 25% floor leakage distribution for slab/basement/unvented crawl
+        leakage_ceiling = 0.25
+        leakage_walls = 0.50
+        leakage_floor = 0.25
+      end
+
+      r_i = (leakage_ceiling + leakage_floor)
+      x_i = (leakage_ceiling - leakage_floor)
+      r_i *= (1 - y_i)
+      x_i *= (1 - y_i)
+      z_f = flue_height / (@infil_height + Geometry.get_z_origin_for_zone(@living_zone))
+
+      # Calculate Stack Coefficient
+      m_o = (x_i + (2.0 * n_i + 1.0) * y_i)**2.0 / (2 - r_i)
+      if m_o <=  1.0
+        m_i = m_o # eq. 10
+      else
+        m_i = 1.0 # eq. 11
+      end
+      if has_flue_chimney
+        x_c = r_i + (2.0 * (1.0 - r_i - y_i)) / (n_i + 1.0) - 2.0 * y_i * (z_f - 1.0)**n_i # Eq. 13
+        f_i = n_i * y_i * (z_f - 1.0)**((3.0 * n_i - 1.0) / 3.0) * (1.0 - (3.0 * (x_c - x_i)**2.0 * r_i**(1 - n_i)) / (2.0 * (z_f + 1.0))) # Additive flue function, Eq. 12
+      else
+        x_c = r_i + (2.0 * (1.0 - r_i - y_i)) / (n_i + 1.0) # Critical value of ceiling-floor leakage difference where the neutral level is located at the ceiling (eq. 13)
+        f_i = 0.0 # Additive flue function (eq. 12)
+      end
+      f_s = ((1.0 + n_i * r_i) / (n_i + 1.0)) * (0.5 - 0.5 * m_i**1.2)**(n_i + 1.0) + f_i
+      stack_coef = f_s * (UnitConversions.convert(outside_air_density * Constants.g * @infil_height, 'lbm/(ft*s^2)', 'inH2O') / (Constants.AssumedInsideTemp + 460.0))**n_i # inH2O^n/R^n
+
+      # Calculate wind coefficient
+      if not @spaces[HPXML::LocationCrawlspaceVented].nil?
+        if x_i > 1.0 - 2.0 * y_i
+          # Critical floor to ceiling difference above which f_w does not change (eq. 25)
+          x_i = 1.0 - 2.0 * y_i
+        end
+        r_x = 1.0 - r_i * (n_i / 2.0 + 0.2) # Redefined R for wind calculations for houses with crawlspaces (eq. 21)
+        y_x = 1.0 - y_i / 4.0 # Redefined Y for wind calculations for houses with crawlspaces (eq. 22)
+        x_s = (1.0 - r_i) / 5.0 - 1.5 * y_i # Used to calculate X_x (eq.24)
+        x_x = 1.0 - (((x_i - x_s) / (2.0 - r_i))**2.0)**0.75 # Redefined X for wind calculations for houses with crawlspaces (eq. 23)
+        f_w = 0.19 * (2.0 - n_i) * x_x * r_x * y_x # Wind factor (eq. 20)
+      else
+        j_i = (x_i + r_i + 2.0 * y_i) / 2.0
+        f_w = 0.19 * (2.0 - n_i) * (1.0 - ((x_i + r_i) / 2.0)**(1.5 - y_i)) - y_i / 4.0 * (j_i - 2.0 * y_i * j_i**4.0)
+      end
+      wind_coef = f_w * UnitConversions.convert(outside_air_density / 2.0, 'lbm/ft^3', 'inH2O/mph^2')**n_i # inH2O^n/mph^2n
+
+      living_ach = get_infiltration_ACH_from_SLA(living_sla, @infil_height, weather)
+      living_cfm = living_ach / UnitConversions.convert(1.0, 'hr', 'min') * @infil_volume
+
+      infil_program.addLine("Set p_m = #{@wind_speed.ashrae_terrain_exponent}")
+      infil_program.addLine("Set p_s = #{@wind_speed.ashrae_site_terrain_exponent}")
+      infil_program.addLine("Set s_m = #{@wind_speed.ashrae_terrain_thickness}")
+      infil_program.addLine("Set s_s = #{@wind_speed.ashrae_site_terrain_thickness}")
+      infil_program.addLine("Set z_m = #{UnitConversions.convert(@wind_speed.height, 'ft', 'm')}")
+      infil_program.addLine("Set z_s = #{UnitConversions.convert(@infil_height, 'ft', 'm')}")
+      infil_program.addLine('Set f_t = (((s_m/z_m)^p_m)*((z_s/s_s)^p_s))')
+      infil_program.addLine("Set Tdiff = #{@tin_sensor.name}-#{@tout_sensor.name}")
+      infil_program.addLine('Set dT = @Abs Tdiff')
+      infil_program.addLine("Set c = #{((UnitConversions.convert(c_i, 'cfm', 'm^3/s') / (UnitConversions.convert(1.0, 'inH2O', 'Pa')**n_i))).round(4)}")
+      infil_program.addLine("Set Cs = #{(stack_coef * (UnitConversions.convert(1.0, 'inH2O/R', 'Pa/K')**n_i)).round(4)}")
+      infil_program.addLine("Set Cw = #{(wind_coef * (UnitConversions.convert(1.0, 'inH2O/mph^2', 'Pa*s^2/m^2')**n_i)).round(4)}")
+      infil_program.addLine("Set n = #{n_i}")
+      infil_program.addLine("Set sft = (f_t*#{(((@wind_speed.S_wo * (1.0 - y_i)) + (s_wflue * (1.5 * y_i))))})")
+      infil_program.addLine("Set temp1 = ((c*Cw)*((sft*#{@vwind_sensor.name})^(2*n)))^2")
+      infil_program.addLine('Set Qn = (((c*Cs*(dT^n))^2)+temp1)^0.5')
+
+    elsif living_const_ach.to_f > 0
+
+      living_ach = living_const_ach
+      living_cfm = living_ach / UnitConversions.convert(1.0, 'hr', 'min') * @infil_volume
+
+      infil_program.addLine("Set Qn = #{living_ach * UnitConversions.convert(@infil_volume, 'ft^3', 'm^3') / UnitConversions.convert(1.0, 'hr', 's')}")
+    else
+      infil_program.addLine('Set Qn = 0')
     end
 
-    if [HPXML::MechVentTypeBalanced, HPXML::MechVentTypeERV, HPXML::MechVentTypeHRV].include?(mech_vent.type) && (mech_vent.cfm > 0)
+    # Store info for HVAC Sizing measure
+    @living_zone.additionalProperties.setFeature(Constants.SizingInfoZoneInfiltrationCFM, living_cfm.to_f)
+    @living_zone.additionalProperties.setFeature(Constants.SizingInfoZoneInfiltrationACH, living_ach.to_f)
+
+    if (not vent_mech.nil?) && [HPXML::MechVentTypeBalanced, HPXML::MechVentTypeERV, HPXML::MechVentTypeHRV].include?(vent_mech.fan_type) && (vent_mech_cfm > 0)
       # ERV/HRV/Balanced EMS load model
       # E+ ERV model is using standard density for MFR calculation, caused discrepancy with other system types.
       # E+ ERV model also does not meet setpoint perfectly.
@@ -1680,37 +1505,37 @@ class Airflow
       # Sensors for ERV/HRV
       win_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Zone Air Humidity Ratio')
       win_sensor.setName("#{Constants.ObjectNameAirflow} win s")
-      win_sensor.setKeyName(building.living.zone.name.to_s)
+      win_sensor.setKeyName(@living_zone.name.to_s)
 
       # Actuators for ERV/HRV
       sens_name = "#{Constants.ObjectNameERVHRV} sensible load"
       erv_sens_load_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, sens_name.gsub(' ', '_'))
-      erv_sens_load_actuator = create_sens_lat_load_actuator_and_equipment(model, sens_name, living_space, 0.0, 0.0)
+      erv_sens_load_actuator = create_sens_lat_load_actuator_and_equipment(model, sens_name, @living_space, 0.0, 0.0)
       lat_name = "#{Constants.ObjectNameERVHRV} latent load"
       erv_lat_load_var = OpenStudio::Model::EnergyManagementSystemGlobalVariable.new(model, lat_name.gsub(' ', '_'))
-      erv_lat_load_actuator = create_sens_lat_load_actuator_and_equipment(model, lat_name, living_space, 1.0, 0.0)
+      erv_lat_load_actuator = create_sens_lat_load_actuator_and_equipment(model, lat_name, @living_space, 1.0, 0.0)
 
       # Air property at inlet nodes in two sides of ERV
-      infil_program.addLine("Set ERVSupInPb = #{pbar_sensor.name}") # oa barometric pressure
-      infil_program.addLine("Set ERVSupInTemp = #{tout_sensor.name}") # oa db temperature
-      infil_program.addLine("Set ERVSupInW = #{wout_sensor.name}")   # oa humidity ratio
+      infil_program.addLine("Set ERVSupInPb = #{@pbar_sensor.name}") # oa barometric pressure
+      infil_program.addLine("Set ERVSupInTemp = #{@tout_sensor.name}") # oa db temperature
+      infil_program.addLine("Set ERVSupInW = #{@wout_sensor.name}")   # oa humidity ratio
       infil_program.addLine('Set ERVSupRho = (@RhoAirFnPbTdbW ERVSupInPb ERVSupInTemp ERVSupInW)')
       infil_program.addLine('Set ERVSupCp = (@CpAirFnW ERVSupInW)')
       infil_program.addLine('Set ERVSupInEnth = (@HFnTdbW ERVSupInTemp ERVSupInW)')
 
-      infil_program.addLine("Set ERVSecInTemp = #{tin_sensor.name}") # zone air temperature
+      infil_program.addLine("Set ERVSecInTemp = #{@tin_sensor.name}") # zone air temperature
       infil_program.addLine("Set ERVSecInW = #{win_sensor.name}") # zone air humidity ratio
       infil_program.addLine('Set ERVSecCp = (@CpAirFnW ERVSecInW)')
       infil_program.addLine('Set ERVSecInEnth = (@HFnTdbW ERVSecInTemp ERVSecInW)')
 
       # Calculate mass flow rate based on outdoor air density
-      infil_program.addLine("Set balanced_mechvent_flow_rate = #{UnitConversions.convert(mech_vent.cfm, 'cfm', 'm^3/s')}")
+      infil_program.addLine("Set balanced_mechvent_flow_rate = #{UnitConversions.convert(vent_mech_cfm, 'cfm', 'm^3/s')}")
       infil_program.addLine('Set ERV_MFR = balanced_mechvent_flow_rate * ERVSupRho')
 
       # Heat exchanger calculation
       infil_program.addLine('Set ERVCpMin = (@Min ERVSupCp ERVSecCp)')
-      infil_program.addLine("Set ERVSupOutTemp = ERVSupInTemp + ERVCpMin/ERVSupCp * #{mech_vent.sensible_effectiveness} * (ERVSecInTemp - ERVSupInTemp)")
-      infil_program.addLine("Set ERVSupOutW = ERVSupInW + ERVCpMin/ERVSupCp * #{mech_vent.latent_effectiveness} * (ERVSecInW - ERVSupInW)")
+      infil_program.addLine("Set ERVSupOutTemp = ERVSupInTemp + ERVCpMin/ERVSupCp * #{vent_mech_sens_eff} * (ERVSecInTemp - ERVSupInTemp)")
+      infil_program.addLine("Set ERVSupOutW = ERVSupInW + ERVCpMin/ERVSupCp * #{vent_mech_lat_eff} * (ERVSecInW - ERVSupInW)")
       infil_program.addLine('Set ERVSupOutEnth = (@HFnTdbW ERVSupOutTemp ERVSupOutW)')
       infil_program.addLine('Set ERVSensHeatTrans = ERV_MFR * ERVSupCp * (ERVSupOutTemp - ERVSupInTemp)')
       infil_program.addLine('Set ERVTotalHeatTrans = ERV_MFR * (ERVSupOutEnth - ERVSupInEnth)')
@@ -1728,124 +1553,93 @@ class Airflow
       infil_program.addLine('Set balanced_mechvent_flow_rate = 0')
     end
 
-    if mech_vent.type == HPXML::MechVentTypeCFIS
+    if (not vent_mech.nil?) && (vent_mech.fan_type == HPXML::MechVentTypeCFIS)
 
-      infil_program.addLine("Set fan_rtf_hvac = #{mech_vent.cfis_fan_rtf_sensor}")
-      if mech_vent.fan_power_w.nil?
-        # Use supply fan W/cfm
-        infil_program.addLine("Set CFIS_fan_power = #{mech_vent.cfis_fan_pressure_rise.name} / #{mech_vent.cfis_fan_efficiency.name} * #{UnitConversions.convert(1.0, 'cfm', 'm^3/s').round(6)}") # W/cfm
-      else
-        # Use specified CFIS fan W
-        infil_program.addLine("Set airloop_cfm = (#{mech_vent.cfis_fan_mfr_max_var} / 1.16097654) * #{UnitConversions.convert(1.0, 'm^3/s', 'cfm')}") # Density of 1.16097654 was back calculated using E+ results
-        infil_program.addLine("Set CFIS_fan_w = #{mech_vent.fan_power_w}") # W
-        infil_program.addLine('Set CFIS_fan_power = CFIS_fan_w / airloop_cfm') # W/cfm
-      end
+      infil_program.addLine("Set fan_rtf_hvac = #{@fan_rtf_sensor[@cfis_airloop].name}")
+      infil_program.addLine("Set CFIS_fan_w = #{vent_mech_fan_w}") # W
 
       infil_program.addLine('If @ABS(Minute - ZoneTimeStep*60) < 0.1')
-      infil_program.addLine("  Set #{mech_vent.cfis_t_sum_open_var.name} = 0") # New hour, time on summation re-initializes to 0
+      infil_program.addLine("  Set #{@cfis_t_sum_open_var.name} = 0") # New hour, time on summation re-initializes to 0
       infil_program.addLine('EndIf')
 
-      infil_program.addLine("Set CFIS_t_min_hr_open = #{mech_vent.cfis_open_time}") # minutes per hour the CFIS damper is open
-      infil_program.addLine("Set CFIS_Q_duct = #{UnitConversions.convert(mech_vent.cfm, 'cfm', 'm^3/s')}")
+      cfis_open_time = [vent_mech.hours_in_operation / 24.0 * 60.0, 59.999].min # Minimum open time in minutes
+      infil_program.addLine("Set CFIS_t_min_hr_open = #{cfis_open_time}") # minutes per hour the CFIS damper is open
+      infil_program.addLine("Set CFIS_Q_duct = #{UnitConversions.convert(vent_mech_cfm, 'cfm', 'm^3/s')}")
       infil_program.addLine('Set cfis_f_damper_open = 0') # fraction of the timestep the CFIS damper is open
-      infil_program.addLine("Set #{mech_vent.cfis_f_damper_extra_open_var.name} = 0") # additional runtime fraction to meet min/hr
+      infil_program.addLine("Set #{@cfis_f_damper_extra_open_var.name} = 0") # additional runtime fraction to meet min/hr
 
-      infil_program.addLine("If #{mech_vent.cfis_t_sum_open_var.name} < CFIS_t_min_hr_open")
-      infil_program.addLine("  Set CFIS_t_fan_on = 60 - (CFIS_t_min_hr_open - #{mech_vent.cfis_t_sum_open_var.name})") # minute at which the blower needs to turn on to meet the ventilation requirements
-      # Evaluate condition of if supply fan have to run to achieve target minutes per hour of operation
+      infil_program.addLine("If #{@cfis_t_sum_open_var.name} < CFIS_t_min_hr_open")
+      infil_program.addLine("  Set CFIS_t_fan_on = 60 - (CFIS_t_min_hr_open - #{@cfis_t_sum_open_var.name})") # minute at which the blower needs to turn on to meet the ventilation requirements
+      # Evaluate condition of whether supply fan has to run to achieve target minutes per hour of operation
       infil_program.addLine('  If (Minute+0.00001) >= CFIS_t_fan_on')
       # Consider fan rtf read in current calling point (results of previous time step) + CFIS_t_fan_on based on min/hr requirement and previous EMS results.
       infil_program.addLine('    Set cfis_fan_runtime = @Max (@ABS(Minute - CFIS_t_fan_on)) (fan_rtf_hvac * ZoneTimeStep * 60)')
       # If fan_rtf_hvac, make sure it's not exceeding ventilation requirements
-      infil_program.addLine("    Set cfis_fan_runtime = @Min cfis_fan_runtime (CFIS_t_min_hr_open - #{mech_vent.cfis_t_sum_open_var.name})")
+      infil_program.addLine("    Set cfis_fan_runtime = @Min cfis_fan_runtime (CFIS_t_min_hr_open - #{@cfis_t_sum_open_var.name})")
       infil_program.addLine('    Set cfis_f_damper_open = cfis_fan_runtime/(60.0*ZoneTimeStep)') # calculates the portion of the current timestep the CFIS damper needs to be open
       infil_program.addLine('    Set QWHV = cfis_f_damper_open*CFIS_Q_duct')
-      infil_program.addLine("    Set #{mech_vent.cfis_t_sum_open_var.name} = #{mech_vent.cfis_t_sum_open_var.name}+cfis_fan_runtime")
-      infil_program.addLine("    Set cfis_cfm = airloop_cfm*#{mech_vent.cfis_airflow_frac}")
-      infil_program.addLine("    Set #{mech_vent.cfis_f_damper_extra_open_var.name} = @Max (cfis_f_damper_open-fan_rtf_hvac) 0.0")
-      infil_program.addLine("    Set #{mech_vent_fan_actuator.name} = CFIS_fan_power*cfis_cfm*#{mech_vent.cfis_f_damper_extra_open_var.name}")
+      infil_program.addLine("    Set #{@cfis_t_sum_open_var.name} = #{@cfis_t_sum_open_var.name}+cfis_fan_runtime")
+      infil_program.addLine("    Set #{@cfis_f_damper_extra_open_var.name} = @Max (cfis_f_damper_open-fan_rtf_hvac) 0.0")
+      infil_program.addLine("    Set #{vent_mech_fan_actuator.name} = CFIS_fan_w*#{@cfis_f_damper_extra_open_var.name}")
       infil_program.addLine('  Else')
       # No need to turn on blower for extra ventilation
       infil_program.addLine('    Set cfis_fan_runtime = fan_rtf_hvac*ZoneTimeStep*60')
-      infil_program.addLine("    If (#{mech_vent.cfis_t_sum_open_var.name}+cfis_fan_runtime) > CFIS_t_min_hr_open")
+      infil_program.addLine("    If (#{@cfis_t_sum_open_var.name}+cfis_fan_runtime) > CFIS_t_min_hr_open")
       # Damper is only open for a portion of this time step to achieve target minutes per hour
-      infil_program.addLine("      Set cfis_fan_runtime = CFIS_t_min_hr_open-#{mech_vent.cfis_t_sum_open_var.name}")
+      infil_program.addLine("      Set cfis_fan_runtime = CFIS_t_min_hr_open-#{@cfis_t_sum_open_var.name}")
       infil_program.addLine('      Set cfis_f_damper_open = cfis_fan_runtime/(ZoneTimeStep*60)')
       infil_program.addLine('      Set QWHV = cfis_f_damper_open*CFIS_Q_duct')
-      infil_program.addLine("      Set #{mech_vent.cfis_t_sum_open_var.name} = CFIS_t_min_hr_open")
+      infil_program.addLine("      Set #{@cfis_t_sum_open_var.name} = CFIS_t_min_hr_open")
       infil_program.addLine('    Else')
       # Damper is open and using call for heat/cool to supply fresh air
       infil_program.addLine('      Set cfis_fan_runtime = fan_rtf_hvac*ZoneTimeStep*60')
       infil_program.addLine('      Set cfis_f_damper_open = fan_rtf_hvac')
       infil_program.addLine('      Set QWHV = cfis_f_damper_open * CFIS_Q_duct')
-      infil_program.addLine("      Set #{mech_vent.cfis_t_sum_open_var.name} = #{mech_vent.cfis_t_sum_open_var.name}+cfis_fan_runtime")
+      infil_program.addLine("      Set #{@cfis_t_sum_open_var.name} = #{@cfis_t_sum_open_var.name}+cfis_fan_runtime")
       infil_program.addLine('    EndIf')
       # Fan power is metered under fan cooling and heating meters
-      infil_program.addLine("    Set #{mech_vent_fan_actuator.name} = 0")
+      infil_program.addLine("    Set #{vent_mech_fan_actuator.name} = 0")
       infil_program.addLine('  EndIf')
       infil_program.addLine('Else')
       # The ventilation requirement for the hour has been met
       infil_program.addLine('  Set QWHV = 0')
-      infil_program.addLine("  Set #{mech_vent_fan_actuator.name} = 0")
+      infil_program.addLine("  Set #{vent_mech_fan_actuator.name} = 0")
       infil_program.addLine('EndIf')
-
-      # Create EMS output variables for CFIS tests
-
-      ems_output_var = OpenStudio::Model::EnergyManagementSystemOutputVariable.new(model, 'CFIS_fan_w')
-      ems_output_var.setName("#{Constants.ObjectNameMechanicalVentilation} cfis fan power".gsub(' ', '_'))
-      ems_output_var.setTypeOfDataInVariable('Averaged')
-      ems_output_var.setUpdateFrequency('ZoneTimestep')
-      ems_output_var.setEMSProgramOrSubroutineName(infil_program)
-      ems_output_var.setUnits('W')
-
-      ems_output_var = OpenStudio::Model::EnergyManagementSystemOutputVariable.new(model, 'QWHV')
-      ems_output_var.setName("#{Constants.ObjectNameMechanicalVentilation} cfis flow rate".gsub(' ', '_'))
-      ems_output_var.setTypeOfDataInVariable('Averaged')
-      ems_output_var.setUpdateFrequency('ZoneTimestep')
-      ems_output_var.setEMSProgramOrSubroutineName(infil_program)
-      ems_output_var.setUnits('m3/s')
     else
-      infil_program.addLine("Set QWHV = #{wh_sch_sensor.name}*#{UnitConversions.convert(mech_vent.cfm, 'cfm', 'm^3/s').round(4)}")
+      infil_program.addLine("Set QWHV = #{UnitConversions.convert(vent_mech_cfm.to_f, 'cfm', 'm^3/s').round(4)}")
     end
 
-    if vent_fan_kitchen.nil?
+    if vent_kitchen.nil?
       infil_program.addLine('Set Qrange = 0')
     else
-      infil_program.addLine("Set Qrange = #{range_sch_sensor.name}*#{UnitConversions.convert(vent_fan_kitchen.rated_flow_rate, 'cfm', 'm^3/s').round(4)}")
+      infil_program.addLine("Set Qrange = #{UnitConversions.convert(vent_kitchen.rated_flow_rate, 'cfm', 'm^3/s').round(4)} * #{range_sch_sensor.name}")
     end
-    if mech_vent.has_dryer && (mech_vent.dryer_exhaust > 0)
-      infil_program.addLine("Set Qdryer = #{dryer_sch_sensor.name}*#{UnitConversions.convert(mech_vent.dryer_exhaust, 'cfm', 'm^3/s').round(4)}")
-    else
-      infil_program.addLine('Set Qdryer = 0.0')
-    end
-    if vent_fan_bath.nil?
+    if vent_bath.nil?
       infil_program.addLine('Set Qbath = 0')
     else
-      infil_program.addLine("Set Qbath = #{bath_sch_sensor.name}*#{UnitConversions.convert(vent_fan_bath.rated_flow_rate * vent_fan_bath.quantity, 'cfm', 'm^3/s').round(4)}")
+      infil_program.addLine("Set Qbath = #{UnitConversions.convert(vent_bath.rated_flow_rate * vent_bath.quantity, 'cfm', 'm^3/s').round(4)} * #{bath_sch_sensor.name}")
     end
     infil_program.addLine('Set QductsOut = 0')
     infil_program.addLine('Set QductsIn = 0')
     # Disabling duct imbalance affect on infiltration for consistency with other software tools
     # Revisit this in the future.
-    # duct_lks.each do |air_loop_name, value|
+    # duct_lks.each do |value|
     #  duct_lk_supply_fan_equiv_var, duct_lk_exhaust_fan_equiv_var = value
     #  infil_program.addLine("Set QductsOut = QductsOut+#{duct_lk_exhaust_fan_equiv_var.name}")
     #  infil_program.addLine("Set QductsIn = QductsIn+#{duct_lk_supply_fan_equiv_var.name}")
     # end
-    infil_program.addLine('Set Qout = Qrange+Qbath+Qdryer+QductsOut')
+    infil_program.addLine('Set Qout = Qrange+Qbath+QductsOut')
     infil_program.addLine('Set Qin = QductsIn')
-    if mech_vent.type == HPXML::MechVentTypeExhaust
+    if (not vent_mech.nil?) && (vent_mech.fan_type == HPXML::MechVentTypeExhaust)
       infil_program.addLine('Set Qout = Qout+QWHV')
-    elsif (mech_vent.type == HPXML::MechVentTypeSupply) || (mech_vent.type == HPXML::MechVentTypeCFIS)
+    elsif (not vent_mech.nil?) && [HPXML::MechVentTypeSupply, HPXML::MechVentTypeCFIS].include?(vent_mech.fan_type)
       infil_program.addLine('Set Qin = Qin+QWHV')
     end
     infil_program.addLine('Set Qu = (@Abs (Qout-Qin))')
-    if mech_vent.type != HPXML::MechVentTypeCFIS
-      if mech_vent.cfm > 0
-        infil_program.addLine("Set #{mech_vent_fan_actuator.name} = QWHV * #{mech_vent.fan_power_w} / #{UnitConversions.convert(mech_vent.cfm, 'cfm', 'm^3/s')}")
-      else
-        infil_program.addLine("Set #{mech_vent_fan_actuator.name} = #{mech_vent.fan_power_w}")
-      end
+    if (not vent_mech.nil?) && (vent_mech.fan_type != HPXML::MechVentTypeCFIS)
+      infil_program.addLine("Set #{vent_mech_fan_actuator.name} = #{vent_mech_fan_w}")
+    elsif vent_mech.nil?
+      infil_program.addLine("Set #{vent_mech_fan_actuator.name} = 0")
     end
 
     infil_program.addLine('Set Q_tot_flow = (((Qu^2)+(Qn^2))^0.5)')
@@ -1854,40 +1648,30 @@ class Airflow
     # Assign total airflow to different component loads
     infil_program.addLine("Set #{imbal_mechvent_flow_actuator.name} = (@Abs ((Qout - QductsOut) - (Qin - QductsIn)))")
     infil_program.addLine("Set #{imbal_ducts_flow_actuator.name} = (@Abs (QductsOut - QductsIn))")
+
     # Assign the remainder to infiltration:
     infil_program.addLine("Set #{infil_flow_actuator.name} = Q_tot_flow - #{imbal_mechvent_flow_actuator.name} - #{imbal_ducts_flow_actuator.name}")
     infil_program.addLine("If #{infil_flow_actuator.name} < 0")
     infil_program.addLine("  Set #{infil_flow_actuator.name} = 0")
     infil_program.addLine('EndIf')
 
-    return infil_program
-  end
-
-  def self.create_ems_program_managers(model, infil_program, nv_and_whf_program, cfis_program, duct_programs)
     program_calling_manager = OpenStudio::Model::EnergyManagementSystemProgramCallingManager.new(model)
-    program_calling_manager.setName(Constants.ObjectNameAirflow + ' program calling manager')
+    program_calling_manager.setName("#{infil_program.name} calling manager")
     program_calling_manager.setCallingPoint('BeginTimestepBeforePredictor')
     program_calling_manager.addProgram(infil_program)
-    program_calling_manager.addProgram(nv_and_whf_program)
+  end
 
-    if not cfis_program.nil?
-      program_calling_manager = OpenStudio::Model::EnergyManagementSystemProgramCallingManager.new(model)
-      program_calling_manager.setName(Constants.ObjectNameMechanicalVentilation + ' cfis init program 1 calling manager')
-      program_calling_manager.setCallingPoint('BeginNewEnvironment')
-      program_calling_manager.addProgram(cfis_program)
-
-      program_calling_manager = OpenStudio::Model::EnergyManagementSystemProgramCallingManager.new(model)
-      program_calling_manager.setName(Constants.ObjectNameMechanicalVentilation + ' cfis init program 2 calling manager')
-      program_calling_manager.setCallingPoint('AfterNewEnvironmentWarmUpIsComplete')
-      program_calling_manager.addProgram(cfis_program)
+  def self.calc_wind_stack_coeffs(hor_lk_frac, neutral_level, space, space_height = nil)
+    if space_height.nil?
+      space_height = Geometry.get_height_of_spaces([space])
     end
-
-    duct_programs.each do |air_loop_name, duct_program|
-      program_calling_manager = OpenStudio::Model::EnergyManagementSystemProgramCallingManager.new(model)
-      program_calling_manager.setName(air_loop_name + ' program calling manager')
-      program_calling_manager.setCallingPoint('EndOfSystemTimestepAfterHVACReporting')
-      program_calling_manager.addProgram(duct_program)
-    end
+    coord_z = Geometry.get_z_origin_for_zone(space.thermalZone.get)
+    f_t_SG = @wind_speed.site_terrain_multiplier * ((space_height + coord_z) / 32.8)**@wind_speed.site_terrain_exponent / (@wind_speed.terrain_multiplier * (@wind_speed.height / 32.8)**@wind_speed.terrain_exponent)
+    f_s_SG = 2.0 / 3.0 * (1 + hor_lk_frac / 2.0) * (2.0 * neutral_level * (1.0 - neutral_level))**0.5 / (neutral_level**0.5 + (1.0 - neutral_level)**0.5)
+    f_w_SG = @wind_speed.shielding_coef * (1.0 - hor_lk_frac)**(1.0 / 3.0) * f_t_SG
+    c_s_SG = f_s_SG**2.0 * Constants.g * space_height / (Constants.AssumedInsideTemp + 460.0)
+    c_w_SG = f_w_SG**2.0
+    return c_w_SG, c_s_SG
   end
 
   def self.calc_inferred_infiltration_height(cfa, ncfl, ncfl_ag, infil_volume, hpxml)
@@ -1990,95 +1774,8 @@ class Duct
   attr_accessor(:side, :loc_space, :loc_schedule, :leakage_frac, :leakage_cfm25, :area, :rvalue, :zone, :location_handle)
 end
 
-class Infiltration
-  def initialize(living_ach50, living_constant_ach, shelter_coef, garage_ach50, vented_crawl_sla, unvented_crawl_sla, vented_attic_sla, unvented_attic_sla,
-                 vented_attic_const_ach, unconditioned_basement_ach, has_flue_chimney, terrain)
-    @living_ach50 = living_ach50
-    @living_constant_ach = living_constant_ach
-    @shelter_coef = shelter_coef
-    @garage_ach50 = garage_ach50
-    @vented_crawl_sla = vented_crawl_sla
-    @unvented_crawl_sla = unvented_crawl_sla
-    @vented_attic_sla = vented_attic_sla
-    @unvented_attic_sla = unvented_attic_sla
-    @vented_attic_const_ach = vented_attic_const_ach
-    @unconditioned_basement_ach = unconditioned_basement_ach
-    @has_flue_chimney = has_flue_chimney
-    @terrain = terrain
-  end
-  attr_accessor(:living_ach50, :living_constant_ach, :shelter_coef, :garage_ach50, :vented_crawl_sla, :unvented_crawl_sla, :vented_attic_sla, :unvented_attic_sla, :vented_attic_const_ach,
-                :unconditioned_basement_ach, :has_flue_chimney, :terrain, :a_o, :c_i, :n_i, :stack_coef, :wind_coef, :y_i, :s_wflue)
-end
-
-class NaturalVentilation
-  def initialize(nv_frac_window_area_open, max_oa_hr, max_oa_rh, nv_num_days_per_week,
-                 htg_weekday_setpoints, htg_weekend_setpoints, clg_weekday_setpoints, clg_weekend_setpoints, clg_ssn_sensor)
-    @nv_frac_window_area_open = nv_frac_window_area_open
-    @max_oa_hr = max_oa_hr
-    @max_oa_rh = max_oa_rh
-    @nv_num_days_per_week = nv_num_days_per_week
-    @htg_weekday_setpoints = htg_weekday_setpoints
-    @htg_weekend_setpoints = htg_weekend_setpoints
-    @clg_weekday_setpoints = clg_weekday_setpoints
-    @clg_weekend_setpoints = clg_weekend_setpoints
-    @clg_ssn_sensor = clg_ssn_sensor
-  end
-  attr_accessor(:nv_frac_window_area_open, :max_oa_hr, :max_oa_rh, :nv_num_days_per_week,
-                :htg_weekday_setpoints, :htg_weekend_setpoints, :clg_weekday_setpoints, :clg_weekend_setpoints, :clg_ssn_sensor)
-end
-
-class WholeHouseFan
-  def initialize(cfm, fan_power_w, whf_num_days_per_week)
-    @cfm = cfm
-    @fan_power_w = fan_power_w
-    @whf_num_days_per_week = whf_num_days_per_week
-  end
-  attr_accessor(:cfm, :fan_power_w, :whf_num_days_per_week)
-end
-
-class MechanicalVentilation
-  def initialize(type, total_efficiency, total_efficiency_adjusted, cfm,
-                 fan_power_w, sensible_efficiency, sensible_efficiency_adjusted,
-                 dryer_exhaust, cfis_open_time, cfis_airflow_frac, cfis_air_loop)
-    @type = type
-    @total_efficiency = total_efficiency
-    @total_efficiency_adjusted = total_efficiency_adjusted
-    @cfm = cfm
-    @fan_power_w = fan_power_w
-    @sensible_efficiency = sensible_efficiency
-    @sensible_efficiency_adjusted = sensible_efficiency_adjusted
-    @dryer_exhaust = dryer_exhaust
-    @cfis_open_time = cfis_open_time
-    @cfis_airflow_frac = cfis_airflow_frac
-    @cfis_air_loop = cfis_air_loop
-  end
-  attr_accessor(:type, :total_efficiency, :total_efficiency_adjusted, :cfm, :fan_power_w, :sensible_efficiency, :sensible_efficiency_adjusted,
-                :dryer_exhaust, :cfis_open_time, :cfis_airflow_frac, :cfis_air_loop, :cfis_t_sum_open_var, :cfis_f_damper_extra_open_var,
-                :cfis_fan_mfr_max_var, :cfis_fan_rtf_sensor, :cfis_fan_pressure_rise, :cfis_fan_efficiency,
-                :frac_fan_heat, :latent_effectiveness, :sensible_effectiveness, :dryer_exhaust_day_shift, :has_dryer)
-end
-
-class ZoneInfo
-  def initialize(zone, height, area, volume, coord_z, ach = nil, sla = nil)
-    @zone = zone
-    @height = height
-    @area = area
-    @volume = volume
-    @coord_z = coord_z
-    @ACH = ach
-    @SLA = sla
-  end
-  attr_accessor(:zone, :height, :area, :volume, :coord_z, :inf_method, :SLA, :ACH, :inf_flow, :hor_lk_frac, :neutral_level, :f_t_SG, :f_s_SG, :f_w_SG, :C_s_SG, :C_w_SG, :ELA)
-end
-
 class WindSpeed
   def initialize
   end
   attr_accessor(:height, :terrain_multiplier, :terrain_exponent, :ashrae_terrain_thickness, :ashrae_terrain_exponent, :site_terrain_multiplier, :site_terrain_exponent, :ashrae_site_terrain_thickness, :ashrae_site_terrain_exponent, :S_wo, :shielding_coef)
-end
-
-class Building
-  def initialize
-  end
-  attr_accessor(:cfa, :infilvolume, :infilheight, :nbeds, :nbaths, :ncfl_ag, :window_area, :height, :stories, :SLA, :living, :garage, :unconditioned_basement, :vented_crawlspace, :unvented_crawlspace, :vented_attic, :unvented_attic)
 end

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/constants.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/constants.rb
@@ -653,30 +653,6 @@ class Constants
     return __method__.to_s
   end
 
-  def self.SizingInfoZoneInfiltrationELA
-    return __method__.to_s
-  end
-
-  def self.TerrainOcean
-    return 'ocean'
-  end
-
-  def self.TerrainPlains
-    return 'plains'
-  end
-
-  def self.TerrainRural
-    return 'rural'
-  end
-
-  def self.TerrainSuburban
-    return 'suburban'
-  end
-
-  def self.TerrainCity
-    return 'city'
-  end
-
   def self.BAZoneHotDry
     return 'Hot-Dry'
   end

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/constructions.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/constructions.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'constants'
-require_relative 'unit_conversions'
-require_relative 'materials'
-require_relative 'geometry'
-
 class Constructions
   # Container class for walls, floors/ceilings, roofs, etc.
 

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/geometry.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/geometry.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'constants'
-require_relative 'unit_conversions'
-require_relative 'util'
-
 class Geometry
   def self.get_zone_volume(zone)
     if zone.isVolumeAutocalculated || (not zone.volume.is_initialized)

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/hotwater_appliances.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/hotwater_appliances.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'constants'
-require_relative 'weather'
-
 class HotWaterAndAppliances
   def self.apply(model, weather, living_space,
                  cfa, nbeds, ncfl, has_uncond_bsmnt, wh_setpoint,

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'xmlhelper'
-
 '''
 Example Usage:
 
@@ -90,6 +88,8 @@ class HPXML < Object
   FoundationTypeCrawlspaceUnvented = 'UnventedCrawlspace'
   FoundationTypeCrawlspaceVented = 'VentedCrawlspace'
   FoundationTypeSlab = 'SlabOnGrade'
+  FrameFloorOtherSpaceAbove = 'above'
+  FrameFloorOtherSpaceBelow = 'below'
   FuelTypeElectricity = 'electricity'
   FuelTypeNaturalGas = 'natural gas'
   FuelTypeOil = 'fuel oil'
@@ -135,8 +135,6 @@ class HPXML < Object
   LocationLivingSpace = 'living space'
   LocationOtherExterior = 'other exterior'
   LocationOtherHousingUnit = 'other housing unit'
-  LocationOtherHousingUnitAbove = 'other housing unit above'
-  LocationOtherHousingUnitBelow = 'other housing unit below'
   LocationOtherHeatedSpace = 'other heated space'
   LocationOtherMultifamilyBufferSpace = 'other multifamily buffer space'
   LocationOtherNonFreezingSpace = 'other non-freezing space'
@@ -180,6 +178,9 @@ class HPXML < Object
   SidingTypeStucco = 'stucco'
   SidingTypeVinyl = 'vinyl siding'
   SidingTypeWood = 'wood siding'
+  SiteTypeUrban = 'urban'
+  SiteTypeSuburban = 'suburban'
+  SiteTypeRural = 'rural'
   SolarThermalLoopTypeDirect = 'liquid direct'
   SolarThermalLoopTypeIndirect = 'liquid indirect'
   SolarThermalLoopTypeThermosyphon = 'passive thermosyphon'
@@ -362,7 +363,7 @@ class HPXML < Object
 
         # Update Compartmentalization Boundary areas
         total_area += surface.area
-        if not (surface.exterior_adjacent_to.include?(LocationOtherHousingUnit) || (surface.exterior_adjacent_to == LocationGarage))
+        if not [LocationOtherHousingUnit, LocationGarage].include? surface.exterior_adjacent_to # FIXME: Need to add additional "other" spaces?
           exterior_area += surface.area
         end
       end
@@ -663,7 +664,7 @@ class HPXML < Object
   end
 
   class Site < BaseElement
-    ATTRS = [:surroundings, :orientation_of_front_of_home, :fuels, :shelter_coefficient]
+    ATTRS = [:site_type, :surroundings, :orientation_of_front_of_home, :fuels, :shelter_coefficient]
     attr_accessor(*ATTRS)
 
     def check_for_errors
@@ -675,6 +676,9 @@ class HPXML < Object
       return if nil?
 
       site = XMLHelper.create_elements_as_needed(doc, ['HPXML', 'Building', 'BuildingDetails', 'BuildingSummary', 'Site'])
+      XMLHelper.add_element(site, 'SiteType', @site_type) unless @site_type.nil?
+      XMLHelper.add_element(site, 'Surroundings', @surroundings) unless @surroundings.nil?
+      XMLHelper.add_element(site, 'OrientationOfFrontOfHome', @orientation_of_front_of_home) unless @orientation_of_front_of_home.nil?
       if (not @fuels.nil?) && (not @fuels.empty?)
         fuel_types_available = XMLHelper.add_element(site, 'FuelTypesAvailable')
         @fuels.each do |fuel|
@@ -691,6 +695,7 @@ class HPXML < Object
       site = XMLHelper.get_element(hpxml, 'Building/BuildingDetails/BuildingSummary/Site')
       return if site.nil?
 
+      @site_type = XMLHelper.get_value(site, 'SiteType')
       @surroundings = XMLHelper.get_value(site, 'Surroundings')
       @orientation_of_front_of_home = XMLHelper.get_value(site, 'OrientationOfFrontOfHome')
       @fuels = XMLHelper.get_values(site, 'FuelTypesAvailable/Fuel')
@@ -1722,13 +1727,16 @@ class HPXML < Object
 
   class FrameFloor < BaseElement
     ATTRS = [:id, :exterior_adjacent_to, :interior_adjacent_to, :area, :insulation_id,
-             :insulation_assembly_r_value, :insulation_cavity_r_value, :insulation_continuous_r_value]
+             :insulation_assembly_r_value, :insulation_cavity_r_value, :insulation_continuous_r_value,
+             :other_space_above_or_below]
     attr_accessor(*ATTRS)
 
     def is_ceiling
       if [LocationAtticVented, LocationAtticUnvented].include? @interior_adjacent_to
         return true
-      elsif [LocationAtticVented, LocationAtticUnvented, LocationOtherHousingUnitAbove].include? @exterior_adjacent_to
+      elsif [LocationAtticVented, LocationAtticUnvented].include? @exterior_adjacent_to
+        return true
+      elsif [LocationOtherHousingUnit, LocationOtherHeatedSpace, LocationOtherMultifamilyBufferSpace, LocationOtherNonFreezingSpace].include?(@exterior_adjacent_to) && (@other_space_above_or_below == FrameFloorOtherSpaceAbove)
         return true
       end
 
@@ -1792,6 +1800,8 @@ class HPXML < Object
         XMLHelper.add_attribute(sys_id, 'id', @id + 'Insulation')
       end
       XMLHelper.add_element(insulation, 'AssemblyEffectiveRValue', to_float(@insulation_assembly_r_value)) unless @insulation_assembly_r_value.nil?
+      HPXML::add_extension(parent: frame_floor,
+                           extensions: { 'OtherSpaceAboveOrBelow' => @other_space_above_or_below })
     end
 
     def from_oga(frame_floor)
@@ -1808,6 +1818,7 @@ class HPXML < Object
         @insulation_cavity_r_value = to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='cavity']/NominalRValue"))
         @insulation_continuous_r_value = to_float_or_nil(XMLHelper.get_value(insulation, "Layer[InstallationType='continuous']/NominalRValue"))
       end
+      @other_space_above_or_below = XMLHelper.get_value(frame_floor, 'extension/OtherSpaceAboveOrBelow')
     end
   end
 
@@ -4219,7 +4230,7 @@ class HPXML < Object
       return false
     end
 
-    if surface.exterior_adjacent_to.include? HPXML::LocationOtherHousingUnit
+    if surface.exterior_adjacent_to == HPXML::LocationOtherHousingUnit
       return false # adiabatic
     end
 

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/hvac.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/hvac.rb
@@ -1,12 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'constants'
-require_relative 'geometry'
-require_relative 'util'
-require_relative 'unit_conversions'
-require_relative 'psychrometrics'
-require_relative 'schedules'
-
 class HVAC
   def self.apply_central_air_conditioner_furnace(model, runner, cooling_system, heating_system,
                                                  remaining_cool_load_frac, remaining_heat_load_frac,

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/lighting.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/lighting.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'schedules'
-require_relative 'geometry'
-require_relative 'unit_conversions'
-
 class Lighting
   def self.apply(model, weather, interior_kwh, garage_kwh, exterior_kwh, cfa, gfa,
                  living_space, garage_space)

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/location.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/location.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'constants'
-require_relative 'unit_conversions'
-require_relative 'weather'
-
 class Location
   def self.apply(model, runner, weather_file_path, weather_cache_path, dst_start_date, dst_end_date)
     weather, epw_file = apply_weather_file(model, runner, weather_file_path, weather_cache_path)

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/materials.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/materials.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'constants'
-require_relative 'unit_conversions'
-
 class Material
   # thick_in - Thickness [in]
   # mat_base - Material object that defines k, rho, and cp. Can be overridden with values for those arguments.

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/misc_loads.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/misc_loads.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'constants'
-require_relative 'unit_conversions'
-require_relative 'schedules'
-
 class MiscLoads
   def self.apply_plug(model, plug_load_misc, plug_load_tv, schedule, cfa,
                       living_space)

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/psychrometrics.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/psychrometrics.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'constants'
-require_relative 'unit_conversions'
-require_relative 'materials'
-require_relative 'util'
-
 class Psychrometrics
   def self.H_fg_fT(t)
     '''

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/schedules.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/schedules.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'unit_conversions'
-
 # Annual schedule defined by 12 24-hour values for weekdays and weekends.
 class HourlyByMonthSchedule
   # weekday_month_by_hour_values must be a 12-element array of 24-element arrays of numbers.

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/unit_conversions.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/unit_conversions.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'constants'
-require_relative 'hpxml'
-
 class UnitConversions
   # As there is a performance penalty to using OpenStudio's built-in unit convert()
   # method, we use our own approach here.

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/util.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/util.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'constants'
-require_relative 'unit_conversions'
-
 class HelperMethods
   def self.eplus_fuel_map(fuel)
     if fuel == HPXML::FuelTypeElectricity

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/waterheater.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/waterheater.rb
@@ -1,13 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'constants'
-require_relative 'util'
-require_relative 'geometry'
-require_relative 'schedules'
-require_relative 'unit_conversions'
-require_relative 'psychrometrics'
-require_relative 'hotwater_appliances'
-
 class Waterheater
   def self.apply_tank(model, loc_space, loc_schedule, fuel_type, cap, vol,
                       ef, re, t_set, ec_adj, dhw_map,

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/weather.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/weather.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'psychrometrics'
-require_relative 'constants'
-require_relative 'unit_conversions'
-
 class WeatherHeader
   def initialize
   end

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/xmlhelper.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/xmlhelper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'oga'
-
 class XMLHelper
   # Adds the child element with 'element_name' and sets its value. Returns the
   # child element.

--- a/hpxml-measures/HPXMLtoOpenStudio/tests/test_airflow.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/tests/test_airflow.rb
@@ -1,0 +1,296 @@
+# frozen_string_literal: true
+
+require_relative '../resources/minitest_helper'
+require 'openstudio'
+require 'openstudio/ruleset/ShowRunnerOutput'
+require 'minitest/autorun'
+require 'fileutils'
+require_relative '../measure.rb'
+require_relative '../resources/util.rb'
+
+class HPXMLtoOpenStudioTest < MiniTest::Test
+  def sample_files_dir
+    return File.join(File.dirname(__FILE__), '..', '..', 'workflow', 'sample_files')
+  end
+
+  def get_ems_values(ems_objects, name)
+    values = {}
+    ems_objects.each do |ems_object|
+      next unless ems_object.name.to_s.include? name.gsub(' ', '_')
+      ems_object.lines.each do |line|
+        next unless line.downcase.start_with? 'set'
+        lhs, rhs = line.split('=')
+        lhs = lhs.gsub('Set', '').gsub('set', '').strip
+        rhs = rhs.gsub(',', '').gsub(';', '').strip
+        values[lhs] = rhs
+      end
+    end
+    assert_operator(values.size, :>, 0)
+    return values
+  end
+
+  def test_infiltration_ach50
+    args_hash = {}
+    args_hash['hpxml_path'] = File.absolute_path(File.join(sample_files_dir, 'base.xml'))
+    model, hpxml = _test_measure(args_hash)
+
+    # Check infiltration/ventilation program
+    program_values = get_ems_values(model.getEnergyManagementSystemPrograms, "#{Constants.ObjectNameInfiltration} program")
+    assert_in_epsilon(0.0436, Float(program_values['c']), 0.01)
+    assert_in_epsilon(0.0544, Float(program_values['Cs']), 0.01)
+    assert_in_epsilon(0.1446, Float(program_values['Cw']), 0.01)
+  end
+
+  def test_infiltration_cfm50
+    args_hash = {}
+    args_hash['hpxml_path'] = File.absolute_path(File.join(sample_files_dir, 'base-enclosure-infil-cfm50.xml'))
+    model, hpxml = _test_measure(args_hash)
+
+    # Check infiltration/ventilation program
+    program_values = get_ems_values(model.getEnergyManagementSystemPrograms, "#{Constants.ObjectNameInfiltration} program")
+    assert_in_epsilon(0.0436, Float(program_values['c']), 0.01)
+    assert_in_epsilon(0.0544, Float(program_values['Cs']), 0.01)
+    assert_in_epsilon(0.1446, Float(program_values['Cw']), 0.01)
+  end
+
+  def test_infiltration_natural_ach
+    args_hash = {}
+    args_hash['hpxml_path'] = File.absolute_path(File.join(sample_files_dir, 'base-enclosure-infil-natural-ach.xml'))
+    model, hpxml = _test_measure(args_hash)
+
+    # Check infiltration/ventilation program
+    program_values = get_ems_values(model.getEnergyManagementSystemPrograms, "#{Constants.ObjectNameInfiltration} program")
+    assert_in_epsilon(0.3127, Float(program_values['c']), 0.01)
+    assert_in_epsilon(0.0544, Float(program_values['Cs']), 0.01)
+    assert_in_epsilon(0.1446, Float(program_values['Cw']), 0.01)
+  end
+
+  def test_natural_ventilation
+    args_hash = {}
+    args_hash['hpxml_path'] = File.absolute_path(File.join(sample_files_dir, 'base.xml'))
+    model, hpxml = _test_measure(args_hash)
+
+    # Check natural ventilation/whole house fan program
+    program_values = get_ems_values(model.getEnergyManagementSystemPrograms, "#{Constants.ObjectNameNaturalVentilation} program")
+    assert_in_epsilon(14.5, UnitConversions.convert(Float(program_values['NVArea']), 'cm^2', 'ft^2'), 0.01)
+    assert_in_epsilon(0.000100, Float(program_values['Cs']), 0.01)
+    assert_in_epsilon(0.000065, Float(program_values['Cw']), 0.01)
+    assert_in_epsilon(0.0, UnitConversions.convert(Float(program_values['WHF_Flow']), 'm^3/s', 'cfm'), 0.01)
+  end
+
+  def test_mechanical_ventilation_none
+    args_hash = {}
+    args_hash['hpxml_path'] = File.absolute_path(File.join(sample_files_dir, 'base.xml'))
+    model, hpxml = _test_measure(args_hash)
+
+    # Check infiltration/ventilation program
+    program_values = get_ems_values(model.getEnergyManagementSystemPrograms, "#{Constants.ObjectNameInfiltration} program")
+    assert_in_epsilon(0.0, UnitConversions.convert(Float(program_values['QWHV']), 'm^3/s', 'cfm'), 0.01)
+    assert_in_epsilon(0.0, Float(program_values['mech_vent_house_fan_act']), 0.01)
+    assert_in_epsilon(0.0, UnitConversions.convert(Float(program_values['Qrange']), 'm^3/s', 'cfm'), 0.01)
+    assert_in_epsilon(0.0, UnitConversions.convert(Float(program_values['Qbath']), 'm^3/s', 'cfm'), 0.01)
+  end
+
+  def test_mechanical_ventilation_supply
+    args_hash = {}
+    args_hash['hpxml_path'] = File.absolute_path(File.join(sample_files_dir, 'base-mechvent-supply.xml'))
+    model, hpxml = _test_measure(args_hash)
+
+    # Get HPXML values
+    vent_fan = hpxml.ventilation_fans.select { |f| f.used_for_whole_building_ventilation }[0]
+    vent_fan_cfm = vent_fan.tested_flow_rate
+    vent_fan_power = vent_fan.fan_power
+
+    # Check infiltration/ventilation program
+    program_values = get_ems_values(model.getEnergyManagementSystemPrograms, "#{Constants.ObjectNameInfiltration} program")
+    assert_in_epsilon(vent_fan_cfm, UnitConversions.convert(Float(program_values['QWHV']), 'm^3/s', 'cfm'), 0.01)
+    assert_in_epsilon(vent_fan_power, Float(program_values['mech_vent_house_fan_act']), 0.01)
+    assert_in_epsilon(0.0, UnitConversions.convert(Float(program_values['Qrange']), 'm^3/s', 'cfm'), 0.01)
+    assert_in_epsilon(0.0, UnitConversions.convert(Float(program_values['Qbath']), 'm^3/s', 'cfm'), 0.01)
+  end
+
+  def test_mechanical_ventilation_exhaust
+    args_hash = {}
+    args_hash['hpxml_path'] = File.absolute_path(File.join(sample_files_dir, 'base-mechvent-exhaust.xml'))
+    model, hpxml = _test_measure(args_hash)
+
+    # Get HPXML values
+    vent_fan = hpxml.ventilation_fans.select { |f| f.used_for_whole_building_ventilation }[0]
+    vent_fan_cfm = vent_fan.tested_flow_rate
+    vent_fan_power = vent_fan.fan_power
+
+    # Check infiltration/ventilation program
+    program_values = get_ems_values(model.getEnergyManagementSystemPrograms, "#{Constants.ObjectNameInfiltration} program")
+    assert_in_epsilon(vent_fan_cfm, UnitConversions.convert(Float(program_values['QWHV']), 'm^3/s', 'cfm'), 0.01)
+    assert_in_epsilon(vent_fan_power, Float(program_values['mech_vent_house_fan_act']), 0.01)
+    assert_in_epsilon(0.0, UnitConversions.convert(Float(program_values['Qrange']), 'm^3/s', 'cfm'), 0.01)
+    assert_in_epsilon(0.0, UnitConversions.convert(Float(program_values['Qbath']), 'm^3/s', 'cfm'), 0.01)
+  end
+
+  def test_mechanical_ventilation_balanced
+    args_hash = {}
+    args_hash['hpxml_path'] = File.absolute_path(File.join(sample_files_dir, 'base-mechvent-balanced.xml'))
+    model, hpxml = _test_measure(args_hash)
+
+    # Get HPXML values
+    vent_fan = hpxml.ventilation_fans.select { |f| f.used_for_whole_building_ventilation }[0]
+    vent_fan_cfm = vent_fan.tested_flow_rate
+    vent_fan_power = vent_fan.fan_power
+
+    # Check infiltration/ventilation program
+    program_values = get_ems_values(model.getEnergyManagementSystemPrograms, "#{Constants.ObjectNameInfiltration} program")
+    assert_in_epsilon(vent_fan_cfm, UnitConversions.convert(Float(program_values['QWHV']), 'm^3/s', 'cfm'), 0.01)
+    assert_in_epsilon(vent_fan_power, Float(program_values['mech_vent_house_fan_act']), 0.01)
+    assert_in_epsilon(0.0, UnitConversions.convert(Float(program_values['Qrange']), 'm^3/s', 'cfm'), 0.01)
+    assert_in_epsilon(0.0, UnitConversions.convert(Float(program_values['Qbath']), 'm^3/s', 'cfm'), 0.01)
+  end
+
+  def test_mechanical_ventilation_erv
+    args_hash = {}
+    args_hash['hpxml_path'] = File.absolute_path(File.join(sample_files_dir, 'base-mechvent-erv.xml'))
+    model, hpxml = _test_measure(args_hash)
+
+    # Get HPXML values
+    vent_fan = hpxml.ventilation_fans.select { |f| f.used_for_whole_building_ventilation }[0]
+    vent_fan_cfm = vent_fan.tested_flow_rate
+    vent_fan_power = vent_fan.fan_power
+
+    # Check infiltration/ventilation program
+    program_values = get_ems_values(model.getEnergyManagementSystemPrograms, "#{Constants.ObjectNameInfiltration} program")
+    assert_in_epsilon(vent_fan_cfm, UnitConversions.convert(Float(program_values['QWHV']), 'm^3/s', 'cfm'), 0.01)
+    assert_in_epsilon(vent_fan_power, Float(program_values['mech_vent_house_fan_act']), 0.01)
+    assert_in_epsilon(0.0, UnitConversions.convert(Float(program_values['Qrange']), 'm^3/s', 'cfm'), 0.01)
+    assert_in_epsilon(0.0, UnitConversions.convert(Float(program_values['Qbath']), 'm^3/s', 'cfm'), 0.01)
+  end
+
+  def test_mechanical_ventilation_hrv
+    args_hash = {}
+    args_hash['hpxml_path'] = File.absolute_path(File.join(sample_files_dir, 'base-mechvent-hrv.xml'))
+    model, hpxml = _test_measure(args_hash)
+
+    # Get HPXML values
+    vent_fan = hpxml.ventilation_fans.select { |f| f.used_for_whole_building_ventilation }[0]
+    vent_fan_cfm = vent_fan.tested_flow_rate
+    vent_fan_power = vent_fan.fan_power
+
+    # Check infiltration/ventilation program
+    program_values = get_ems_values(model.getEnergyManagementSystemPrograms, "#{Constants.ObjectNameInfiltration} program")
+    assert_in_epsilon(vent_fan_cfm, UnitConversions.convert(Float(program_values['QWHV']), 'm^3/s', 'cfm'), 0.01)
+    assert_in_epsilon(vent_fan_power, Float(program_values['mech_vent_house_fan_act']), 0.01)
+    assert_in_epsilon(0.0, UnitConversions.convert(Float(program_values['Qrange']), 'm^3/s', 'cfm'), 0.01)
+    assert_in_epsilon(0.0, UnitConversions.convert(Float(program_values['Qbath']), 'm^3/s', 'cfm'), 0.01)
+  end
+
+  def test_mechanical_ventilation_cfis
+    args_hash = {}
+    args_hash['hpxml_path'] = File.absolute_path(File.join(sample_files_dir, 'base-mechvent-cfis.xml'))
+    model, hpxml = _test_measure(args_hash)
+
+    # Get HPXML values
+    vent_fan = hpxml.ventilation_fans.select { |f| f.used_for_whole_building_ventilation }[0]
+    vent_fan_cfm = vent_fan.tested_flow_rate
+    vent_fan_power = vent_fan.fan_power
+    vent_fan_mins = vent_fan.hours_in_operation / 24.0 * 60.0
+
+    # Check infiltration/ventilation program
+    program_values = get_ems_values(model.getEnergyManagementSystemPrograms, "#{Constants.ObjectNameInfiltration} program")
+    assert_in_epsilon(vent_fan_cfm, UnitConversions.convert(Float(program_values['CFIS_Q_duct']), 'm^3/s', 'cfm'), 0.01)
+    assert_in_epsilon(vent_fan_power, Float(program_values['CFIS_fan_w']), 0.01)
+    assert_in_epsilon(vent_fan_mins, Float(program_values['CFIS_t_min_hr_open']), 0.01)
+    assert_in_epsilon(0.0, UnitConversions.convert(Float(program_values['Qrange']), 'm^3/s', 'cfm'), 0.01)
+    assert_in_epsilon(0.0, UnitConversions.convert(Float(program_values['Qbath']), 'm^3/s', 'cfm'), 0.01)
+  end
+
+  def test_ventilation_bath_kitchen_fans
+    args_hash = {}
+    args_hash['hpxml_path'] = File.absolute_path(File.join(sample_files_dir, 'base-mechvent-bath-kitchen-fans.xml'))
+    model, hpxml = _test_measure(args_hash)
+
+    # Get HPXML values
+    bath_fan = hpxml.ventilation_fans.select { |f| f.used_for_local_ventilation && f.fan_location == HPXML::VentilationFanLocationBath }[0]
+    bath_fan_cfm = bath_fan.rated_flow_rate * bath_fan.quantity
+    kitchen_fan = hpxml.ventilation_fans.select { |f| f.used_for_local_ventilation && f.fan_location == HPXML::VentilationFanLocationKitchen }[0]
+    kitchen_fan_cfm = kitchen_fan.rated_flow_rate
+
+    # Check infiltration/ventilation program
+    program_values = get_ems_values(model.getEnergyManagementSystemPrograms, "#{Constants.ObjectNameInfiltration} program")
+    program_values = get_ems_values(model.getEnergyManagementSystemPrograms, "#{Constants.ObjectNameInfiltration} program")
+    assert_in_epsilon(0.0, UnitConversions.convert(Float(program_values['QWHV']), 'm^3/s', 'cfm'), 0.01)
+    assert_in_epsilon(0.0, Float(program_values['mech_vent_house_fan_act']), 0.01)
+    assert_in_epsilon(kitchen_fan_cfm, UnitConversions.convert(program_values['Qrange'].to_f, 'm^3/s', 'cfm'), 0.01)
+    assert_in_epsilon(bath_fan_cfm, UnitConversions.convert(program_values['Qbath'].to_f, 'm^3/s', 'cfm'), 0.01)
+  end
+
+  def test_ducts_leakage_cfm25
+    args_hash = {}
+    args_hash['hpxml_path'] = File.absolute_path(File.join(sample_files_dir, 'base.xml'))
+    model, hpxml = _test_measure(args_hash)
+
+    # Get HPXML values
+    supply_leakage = hpxml.hvac_distributions[0].duct_leakage_measurements.select { |m| m.duct_type == HPXML::DuctTypeSupply }[0]
+    return_leakage = hpxml.hvac_distributions[0].duct_leakage_measurements.select { |m| m.duct_type == HPXML::DuctTypeReturn }[0]
+    supply_leakage_cfm25 = supply_leakage.duct_leakage_value
+    return_leakage_cfm25 = return_leakage.duct_leakage_value
+
+    # Check ducts program
+    program_values = get_ems_values(model.getEnergyManagementSystemSubroutines, 'duct subroutine')
+    assert_in_epsilon(supply_leakage_cfm25, UnitConversions.convert(program_values['f_sup'].to_f, 'm^3/s', 'cfm'), 0.01)
+    assert_in_epsilon(return_leakage_cfm25, UnitConversions.convert(program_values['f_ret'].to_f, 'm^3/s', 'cfm'), 0.01)
+    assert_in_epsilon(33.4, UnitConversions.convert(Float(program_values['supply_ua']), 'W/K', 'Btu/(hr*F)'), 0.01)
+    assert_in_epsilon(29.4, UnitConversions.convert(Float(program_values['return_ua']), 'W/K', 'Btu/(hr*F)'), 0.01)
+  end
+
+  def test_ducts_leakage_percent
+    args_hash = {}
+    args_hash['hpxml_path'] = File.absolute_path(File.join(sample_files_dir, 'base-hvac-ducts-leakage-percent.xml'))
+    model, hpxml = _test_measure(args_hash)
+
+    # Get HPXML values
+    supply_leakage = hpxml.hvac_distributions[0].duct_leakage_measurements.select { |m| m.duct_type == HPXML::DuctTypeSupply }[0]
+    return_leakage = hpxml.hvac_distributions[0].duct_leakage_measurements.select { |m| m.duct_type == HPXML::DuctTypeReturn }[0]
+    supply_leakage_frac = supply_leakage.duct_leakage_value
+    return_leakage_frac = return_leakage.duct_leakage_value
+
+    # Check ducts program
+    program_values = get_ems_values(model.getEnergyManagementSystemSubroutines, 'duct subroutine')
+    assert_in_epsilon(supply_leakage_frac, Float(program_values['f_sup']), 0.01)
+    assert_in_epsilon(return_leakage_frac, Float(program_values['f_ret']), 0.01)
+    assert_in_epsilon(33.4, UnitConversions.convert(Float(program_values['supply_ua']), 'W/K', 'Btu/(hr*F)'), 0.01)
+    assert_in_epsilon(29.4, UnitConversions.convert(Float(program_values['return_ua']), 'W/K', 'Btu/(hr*F)'), 0.01)
+  end
+
+  def _test_measure(args_hash)
+    # create an instance of the measure
+    measure = HPXMLtoOpenStudio.new
+
+    runner = OpenStudio::Measure::OSRunner.new(OpenStudio::WorkflowJSON.new)
+    model = OpenStudio::Model::Model.new
+
+    # get arguments
+    arguments = measure.arguments(model)
+    argument_map = OpenStudio::Measure.convertOSArgumentVectorToMap(arguments)
+
+    # populate argument with specified hash value if specified
+    arguments.each do |arg|
+      temp_arg_var = arg.clone
+      if args_hash.has_key?(arg.name)
+        assert(temp_arg_var.setValue(args_hash[arg.name]))
+      end
+      argument_map[arg.name] = temp_arg_var
+    end
+
+    # run the measure
+    measure.run(model, runner, argument_map)
+    result = runner.result
+
+    # show the output
+    show_output(result) unless result.value.valueName == 'Success'
+
+    # assert that it ran correctly
+    assert_equal('Success', result.value.valueName)
+
+    hpxml = HPXML.new(hpxml_path: args_hash['hpxml_path'])
+
+    return model, hpxml
+  end
+end

--- a/hpxml-measures/SimulationOutputReport/measure.rb
+++ b/hpxml-measures/SimulationOutputReport/measure.rb
@@ -1416,10 +1416,10 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       load_fraction = 1.0
       if is_dfhp(heat_pump)
         if dfhp_primary_sys_id(sys_id) == sys_id
-          load_fraction = dfhp_loads[[sys_id, true]] / (dfhp_loads[[sys_id, true]] + dfhp_loads[[sys_id, false]])
+          load_fraction = dfhp_loads[[sys_id, true]] / (dfhp_loads[[sys_id, true]] + dfhp_loads[[sys_id, false]]) unless dfhp_loads[[sys_id, true]].nil?
         else
           sys_id = dfhp_primary_sys_id(sys_id)
-          load_fraction = dfhp_loads[[sys_id, false]] / (dfhp_loads[[sys_id, true]] + dfhp_loads[[sys_id, false]])
+          load_fraction = dfhp_loads[[sys_id, false]] / (dfhp_loads[[sys_id, true]] + dfhp_loads[[sys_id, false]]) unless dfhp_loads[[sys_id, true]].nil?
         end
       end
       next unless get_system_or_seed_id(heat_pump) == sys_id

--- a/hpxml-measures/SimulationOutputReport/measure.xml
+++ b/hpxml-measures/SimulationOutputReport/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>d255f269-ea32-4058-838f-ae4e2b75f539</version_id>
-  <version_modified>20200508T162226Z</version_modified>
+  <version_id>942ddcb7-c078-4c2f-88f9-197d05ce120d</version_id>
+  <version_modified>20200513T213715Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -555,7 +555,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>14CC5250</checksum>
+      <checksum>70FE8D1E</checksum>
     </file>
   </files>
 </measure>

--- a/hpxml-measures/docs/source/hpxml_to_openstudio.rst
+++ b/hpxml-measures/docs/source/hpxml_to_openstudio.rst
@@ -112,7 +112,7 @@ Shelter Coefficient  Description
 0.3                  Complete shielding with large buildings immediately adjacent
 ===================  =========================================================================
 
-The terrain surrounding the building is assumed to be suburban.
+The terrain surrounding the building can be entered as ``Site/SiteType``; if not provided, it is assumed to be suburban.
 
 Weather File
 ~~~~~~~~~~~~
@@ -147,8 +147,6 @@ crawlspace - vented
 crawlspace - unvented     
 garage                    
 other housing unit              Conditioned space of an adjacent attached housing unit.               Same as conditioned space.
-other housing unit above        Conditioned space of an attached housing unit above.                  Same as conditioned space.
-other housing unit below        Conditioned space of an attached housing unit below.                  Same as conditioned space.
 other heated space              Heated multifamily space (e.g., shared laundry or equipment.)         Average of conditioned space and outside; minimum of 68F.
 other multifamily buffer space  Unconditioned multifamily space (e.g., enclosed unheated stairwell).  Average of conditioned space and outside; minimum of 50F.
 other non-freezing space        Non-freezing multifamily space (e.g., parking garage ceiling).        Floats with outside; minimum of 40F.
@@ -241,6 +239,7 @@ Frame Floors
 ************
 
 Any horizontal floor/ceiling surface that is not in contact with the ground (Slab) nor adjacent to ambient conditions above (Roof) should be specified as an ``Enclosure/FrameFloors/FrameFloor``.
+Frame floors in an attached/multifamily building that are adjacent to "other housing unit", "other heated space", "other multifamily buffer space", or "other non-freezing space" must have the ``extension/OtherSpaceAboveOrBelow`` property set to signify whether the other space is "above" or "below".
 
 Frame floors are primarily defined by their ``Insulation/AssemblyEffectiveRValue``.
 

--- a/hpxml-measures/tasks.rb
+++ b/hpxml-measures/tasks.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 def create_hpxmls
+  require 'oga'
+  require_relative 'HPXMLtoOpenStudio/resources/constants'
+  require_relative 'HPXMLtoOpenStudio/resources/hotwater_appliances'
+  require_relative 'HPXMLtoOpenStudio/resources/hpxml'
+  require_relative 'HPXMLtoOpenStudio/resources/misc_loads'
+  require_relative 'HPXMLtoOpenStudio/resources/waterheater'
+  require_relative 'HPXMLtoOpenStudio/resources/xmlhelper'
+
   this_dir = File.dirname(__FILE__)
   sample_files_dir = File.join(this_dir, 'workflow/sample_files')
 
@@ -258,6 +266,7 @@ def create_hpxmls
     'base-location-epw-filepath-AMY-2012.xml' => 'base.xml',
     'base-mechvent-balanced.xml' => 'base.xml',
     'base-mechvent-cfis.xml' => 'base.xml',
+    'base-mechvent-cfis-dse.xml' => 'base-hvac-dse.xml',
     'base-mechvent-cfis-evap-cooler-only-ducted.xml' => 'base-hvac-evap-cooler-only-ducted.xml',
     'base-mechvent-erv.xml' => 'base.xml',
     'base-mechvent-erv-atre-asre.xml' => 'base.xml',
@@ -457,8 +466,11 @@ end
 def set_hpxml_site(hpxml_file, hpxml)
   if ['base.xml'].include? hpxml_file
     hpxml.site.fuels = [HPXML::FuelTypeElectricity, HPXML::FuelTypeNaturalGas]
+    hpxml.site.site_type = HPXML::SiteTypeSuburban
   elsif ['base-hvac-none-no-fuel-access.xml'].include? hpxml_file
     hpxml.site.fuels = [HPXML::FuelTypeElectricity]
+  elsif ['base-misc-defaults.xml'].include? hpxml_file
+    hpxml.site.site_type = nil
   end
 end
 
@@ -1029,7 +1041,7 @@ def set_hpxml_walls(hpxml_file, hpxml)
                     emittance: 0.92,
                     insulation_assembly_r_value: 4.0)
   elsif ['base-enclosure-attached-multifamily.xml'].include? hpxml_file
-    hpxml.walls.add(id: 'WallUnratedHeatedSpace',
+    hpxml.walls.add(id: 'WallOtherHeatedSpace',
                     exterior_adjacent_to: HPXML::LocationOtherHeatedSpace,
                     interior_adjacent_to: HPXML::LocationLivingSpace,
                     wall_type: 'WoodStud',
@@ -1037,7 +1049,7 @@ def set_hpxml_walls(hpxml_file, hpxml)
                     solar_absorptance: 0.7,
                     emittance: 0.92,
                     insulation_assembly_r_value: 23.0)
-    hpxml.walls.add(id: 'WallMultifamilyBuffer',
+    hpxml.walls.add(id: 'WallOtherMultifamilyBufferSpace',
                     exterior_adjacent_to: HPXML::LocationOtherMultifamilyBufferSpace,
                     interior_adjacent_to: HPXML::LocationLivingSpace,
                     wall_type: 'WoodStud',
@@ -1045,7 +1057,7 @@ def set_hpxml_walls(hpxml_file, hpxml)
                     solar_absorptance: 0.7,
                     emittance: 0.92,
                     insulation_assembly_r_value: 22.3)
-    hpxml.walls.add(id: 'WallNonFreezingSpace',
+    hpxml.walls.add(id: 'WallOtherNonFreezingSpace',
                     exterior_adjacent_to: HPXML::LocationOtherNonFreezingSpace,
                     interior_adjacent_to: HPXML::LocationLivingSpace,
                     wall_type: 'WoodStud',
@@ -1053,7 +1065,7 @@ def set_hpxml_walls(hpxml_file, hpxml)
                     solar_absorptance: 0.7,
                     emittance: 0.92,
                     insulation_assembly_r_value: 23.0)
-    hpxml.walls.add(id: 'WallAdiabatic',
+    hpxml.walls.add(id: 'WallOtherHousingUnit',
                     exterior_adjacent_to: HPXML::LocationOtherHousingUnit,
                     interior_adjacent_to: HPXML::LocationLivingSpace,
                     wall_type: 'WoodStud',
@@ -1159,16 +1171,16 @@ def set_hpxml_walls(hpxml_file, hpxml)
     hpxml.walls[-1].area *= 0.65
     hpxml.walls[-1].insulation_assembly_r_value = 4
     if ['base-enclosure-other-housing-unit.xml'].include? hpxml_file
-      hpxml.walls[-1].id = 'OtherHousingUnitWall'
+      hpxml.walls[-1].id = 'WallOtherHousingUnit'
       hpxml.walls[-1].exterior_adjacent_to = HPXML::LocationOtherHousingUnit
     elsif ['base-enclosure-other-heated-space.xml'].include? hpxml_file
-      hpxml.walls[-1].id = 'OtherHeatedSpaceWall'
+      hpxml.walls[-1].id = 'WallOtherHeatedSpace'
       hpxml.walls[-1].exterior_adjacent_to = HPXML::LocationOtherHeatedSpace
     elsif ['base-enclosure-other-non-freezing-space.xml'].include? hpxml_file
-      hpxml.walls[-1].id = 'OtherNonFreezingSpaceWall'
+      hpxml.walls[-1].id = 'WallOtherNonFreezingSpace'
       hpxml.walls[-1].exterior_adjacent_to = HPXML::LocationOtherNonFreezingSpace
     elsif ['base-enclosure-other-multifamily-buffer-space.xml'].include? hpxml_file
-      hpxml.walls[-1].id = 'OtherMultifamilyBufferSpaceWall'
+      hpxml.walls[-1].id = 'WallOtherMultifamilyBufferSpace'
       hpxml.walls[-1].exterior_adjacent_to = HPXML::LocationOtherMultifamilyBufferSpace
     end
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
@@ -1270,7 +1282,7 @@ def set_hpxml_foundation_walls(hpxml_file, hpxml)
                                 insulation_exterior_distance_to_bottom: 8,
                                 insulation_exterior_r_value: 8.9)
   elsif ['base-enclosure-attached-multifamily.xml'].include? hpxml_file
-    hpxml.foundation_walls.add(id: 'FoundationWall1',
+    hpxml.foundation_walls.add(id: 'FoundationWallOtherNonFreezingSpace',
                                exterior_adjacent_to: HPXML::LocationOtherNonFreezingSpace,
                                interior_adjacent_to: HPXML::LocationBasementConditioned,
                                height: 8,
@@ -1283,7 +1295,7 @@ def set_hpxml_foundation_walls(hpxml_file, hpxml)
                                insulation_exterior_distance_to_top: 0,
                                insulation_exterior_distance_to_bottom: 8,
                                insulation_exterior_r_value: 8.9)
-    hpxml.foundation_walls.add(id: 'FoundationWall2',
+    hpxml.foundation_walls.add(id: 'FoundationWallOtherMultifamilyBufferSpace',
                                exterior_adjacent_to: HPXML::LocationOtherMultifamilyBufferSpace,
                                interior_adjacent_to: HPXML::LocationBasementConditioned,
                                height: 4,
@@ -1296,7 +1308,7 @@ def set_hpxml_foundation_walls(hpxml_file, hpxml)
                                insulation_exterior_distance_to_top: 0,
                                insulation_exterior_distance_to_bottom: 4,
                                insulation_exterior_r_value: 8.9)
-    hpxml.foundation_walls.add(id: 'FoundationWall3',
+    hpxml.foundation_walls.add(id: 'FoundationWallOtherHeatedSpace',
                                exterior_adjacent_to: HPXML::LocationOtherHeatedSpace,
                                interior_adjacent_to: HPXML::LocationBasementConditioned,
                                height: 2,
@@ -1587,44 +1599,45 @@ def set_hpxml_frame_floors(hpxml_file, hpxml)
          'base-enclosure-other-non-freezing-space.xml',
          'base-enclosure-other-multifamily-buffer-space.xml'].include? hpxml_file
     hpxml.frame_floors.clear
-    hpxml.frame_floors.add(id: 'FloorBelowOtherHousingUnit',
-                           exterior_adjacent_to: HPXML::LocationOtherHousingUnitAbove,
-                           interior_adjacent_to: HPXML::LocationLivingSpace,
+    hpxml.frame_floors.add(interior_adjacent_to: HPXML::LocationLivingSpace,
                            area: 1350,
-                           insulation_assembly_r_value: 2.1)
+                           insulation_assembly_r_value: 2.1,
+                           other_space_above_or_below: HPXML::FrameFloorOtherSpaceAbove)
     if ['base-enclosure-other-housing-unit.xml'].include? hpxml_file
-      hpxml.frame_floors << hpxml.frame_floors[0].dup
-      hpxml.frame_floors[1].id = 'FloorAboveOtherHousingUnit'
-      hpxml.frame_floors[1].exterior_adjacent_to = HPXML::LocationOtherHousingUnitBelow
+      hpxml.frame_floors[0].exterior_adjacent_to = HPXML::LocationOtherHousingUnit
+      hpxml.frame_floors[0].id = 'FloorBelowOtherHousingUnit'
     elsif ['base-enclosure-other-heated-space.xml'].include? hpxml_file
-      hpxml.frame_floors << hpxml.frame_floors[0].dup
-      hpxml.frame_floors[1].id = 'FloorOtherHeatedSpace'
-      hpxml.frame_floors[1].exterior_adjacent_to = HPXML::LocationOtherHeatedSpace
+      hpxml.frame_floors[0].exterior_adjacent_to = HPXML::LocationOtherHeatedSpace
+      hpxml.frame_floors[0].id = 'FloorBelowOtherHeatedSpace'
     elsif ['base-enclosure-other-non-freezing-space.xml'].include? hpxml_file
-      hpxml.frame_floors << hpxml.frame_floors[0].dup
-      hpxml.frame_floors[1].id = 'FloorOtherNonFreezingSpace'
-      hpxml.frame_floors[1].exterior_adjacent_to = HPXML::LocationOtherNonFreezingSpace
+      hpxml.frame_floors[0].exterior_adjacent_to = HPXML::LocationOtherNonFreezingSpace
+      hpxml.frame_floors[0].id = 'FloorBelowOtherNonFreezingSpace'
     elsif ['base-enclosure-other-multifamily-buffer-space.xml'].include? hpxml_file
-      hpxml.frame_floors << hpxml.frame_floors[0].dup
-      hpxml.frame_floors[1].id = 'FloorOtherMultifamilyBufferSpace'
-      hpxml.frame_floors[1].exterior_adjacent_to = HPXML::LocationOtherMultifamilyBufferSpace
+      hpxml.frame_floors[0].exterior_adjacent_to = HPXML::LocationOtherMultifamilyBufferSpace
+      hpxml.frame_floors[0].id = 'FloorBelowOtherMultifamilyBufferSpace'
     end
+    hpxml.frame_floors << hpxml.frame_floors[0].dup
+    hpxml.frame_floors[1].id = hpxml.frame_floors[0].id.gsub('Below', 'Above')
+    hpxml.frame_floors[1].other_space_above_or_below = HPXML::FrameFloorOtherSpaceBelow
   elsif ['base-enclosure-attached-multifamily.xml'].include? hpxml_file
-    hpxml.frame_floors.add(id: 'FloorNonFreezingSpace',
+    hpxml.frame_floors.add(id: 'FloorAboveNonFreezingSpace',
                            exterior_adjacent_to: HPXML::LocationOtherNonFreezingSpace,
                            interior_adjacent_to: HPXML::LocationLivingSpace,
                            area: 1000,
-                           insulation_assembly_r_value: 2.1)
-    hpxml.frame_floors.add(id: 'FloorMultifamilyBuffer',
+                           insulation_assembly_r_value: 2.1,
+                           other_space_above_or_below: HPXML::FrameFloorOtherSpaceBelow)
+    hpxml.frame_floors.add(id: 'FloorAboveMultifamilyBuffer',
                            exterior_adjacent_to: HPXML::LocationOtherMultifamilyBufferSpace,
                            interior_adjacent_to: HPXML::LocationLivingSpace,
                            area: 200,
-                           insulation_assembly_r_value: 2.1)
-    hpxml.frame_floors.add(id: 'FloorUnratedHeatedSpace',
+                           insulation_assembly_r_value: 2.1,
+                           other_space_above_or_below: HPXML::FrameFloorOtherSpaceBelow)
+    hpxml.frame_floors.add(id: 'FloorAboveOtherHeatedSpace',
                            exterior_adjacent_to: HPXML::LocationOtherHeatedSpace,
                            interior_adjacent_to: HPXML::LocationLivingSpace,
                            area: 150,
-                           insulation_assembly_r_value: 2.1)
+                           insulation_assembly_r_value: 2.1,
+                           other_space_above_or_below: HPXML::FrameFloorOtherSpaceBelow)
   elsif ['base-enclosure-split-surfaces.xml'].include? hpxml_file
     for n in 1..hpxml.frame_floors.size
       hpxml.frame_floors[n - 1].area /= 9.0
@@ -1915,7 +1928,7 @@ def set_hpxml_windows(hpxml_file, hpxml)
                       wall_idref: 'Wall')
   elsif ['invalid_files/attached-multifamily-window-outside-condition.xml'].include? hpxml_file
     hpxml.windows[0].area = 50
-    hpxml.windows[0].wall_idref = 'WallMultifamilyBuffer'
+    hpxml.windows[0].wall_idref = 'WallOtherMultifamilyBufferSpace'
   elsif ['base-enclosure-overhangs.xml'].include? hpxml_file
     hpxml.windows[0].overhangs_depth = 2.5
     hpxml.windows[0].overhangs_distance_to_top_of_window = 0
@@ -2166,22 +2179,22 @@ def set_hpxml_doors(hpxml_file, hpxml)
                     azimuth: 180,
                     r_value: 4.4)
   elsif ['base-enclosure-attached-multifamily.xml'].include? hpxml_file
-    hpxml.doors.add(id: 'DoorOnUnratedHeatedSpace',
-                    wall_idref: 'WallUnratedHeatedSpace',
+    hpxml.doors.add(id: 'DoorOnWallOtherHeatedSpace',
+                    wall_idref: 'WallOtherHeatedSpace',
                     area: 40,
                     azimuth: 0,
                     r_value: 4.4)
-    hpxml.doors.add(id: 'DoorOnNonFreezingFndWall',
-                    wall_idref: 'FoundationWall1',
+    hpxml.doors.add(id: 'DoorOnFoundationWallOtherNonFreezingSpace',
+                    wall_idref: 'FoundationWallOtherNonFreezingSpace',
                     area: 40,
                     azimuth: 0,
                     r_value: 4.4)
-    hpxml.doors.add(id: 'DoorOnOtherUnit',
-                    wall_idref: 'WallAdiabatic',
+    hpxml.doors.add(id: 'DoorOnWallOtherHousingUnit',
+                    wall_idref: 'WallOtherHousingUnit',
                     area: 40,
                     azimuth: 0,
                     r_value: 4.4)
-    hpxml.doors.add(id: 'DoorAttic',
+    hpxml.doors.add(id: 'DoorOnWallAtticLivingWall',
                     wall_idref: 'WallAtticLivingWall',
                     area: 10,
                     azimuth: 0,
@@ -2190,20 +2203,20 @@ def set_hpxml_doors(hpxml_file, hpxml)
          'base-enclosure-other-heated-space.xml',
          'base-enclosure-other-non-freezing-space.xml',
          'base-enclosure-other-multifamily-buffer-space.xml'].include? hpxml_file
-    hpxml.doors.add(id: 'DoorOnOtherHousingUnitWall',
-                    wall_idref: 'OtherHousingUnitWall',
+    hpxml.doors.add(id: 'DoorOnWallOtherHousingUnit',
+                    wall_idref: 'WallOtherHousingUnit',
                     area: 40,
                     azimuth: 0,
                     r_value: 4.4)
     if ['base-enclosure-other-heated-space.xml'].include? hpxml_file
-      hpxml.doors[-1].id = 'DoorOnOtherHeatedSpaceWall'
-      hpxml.doors[-1].wall_idref = 'OtherHeatedSpaceWall'
+      hpxml.doors[-1].id = 'DoorOnWallOtherHeatedSpace'
+      hpxml.doors[-1].wall_idref = 'WallOtherHeatedSpace'
     elsif ['base-enclosure-other-non-freezing-space.xml'].include? hpxml_file
-      hpxml.doors[-1].id = 'DoorOnOtherNonFreezingSpaceWall'
-      hpxml.doors[-1].wall_idref = 'OtherNonFreezingSpaceWall'
+      hpxml.doors[-1].id = 'DoorOnWallOtherNonFreezingSpace'
+      hpxml.doors[-1].wall_idref = 'WallOtherNonFreezingSpace'
     elsif ['base-enclosure-other-multifamily-buffer-space.xml'].include? hpxml_file
-      hpxml.doors[-1].id = 'DoorOnOtherMultifamilyBufferSpaceWall'
-      hpxml.doors[-1].wall_idref = 'OtherMultifamilyBufferSpaceWall'
+      hpxml.doors[-1].id = 'DoorOnWallOtherMultifamilyBufferSpace'
+      hpxml.doors[-1].wall_idref = 'WallOtherMultifamilyBufferSpace'
     end
   elsif ['invalid_files/unattached-door.xml'].include? hpxml_file
     hpxml.doors[0].wall_idref = 'foobar'
@@ -3062,6 +3075,7 @@ def set_hpxml_ventilation_fans(hpxml_file, hpxml)
   elsif ['invalid_files/unattached-cfis.xml',
          'invalid_files/cfis-with-hydronic-distribution.xml',
          'base-mechvent-cfis.xml',
+         'base-mechvent-cfis-dse.xml',
          'base-mechvent-cfis-evap-cooler-only-ducted.xml'].include? hpxml_file
     hpxml.ventilation_fans.add(id: 'MechanicalVentilation',
                                fan_type: HPXML::MechVentTypeCFIS,
@@ -3998,10 +4012,6 @@ elsif not command_list.include? ARGV[0].to_sym
 end
 
 if ARGV[0].to_sym == :update_measures
-  require_relative 'HPXMLtoOpenStudio/resources/hpxml'
-  require_relative 'HPXMLtoOpenStudio/resources/misc_loads'
-  require_relative 'HPXMLtoOpenStudio/resources/waterheater'
-
   # Prevent NREL error regarding U: drive when not VPNed in
   ENV['HOME'] = 'C:' if !ENV['HOME'].nil? && ENV['HOME'].start_with?('U:')
   ENV['HOMEDRIVE'] = 'C:\\' if !ENV['HOMEDRIVE'].nil? && ENV['HOMEDRIVE'].start_with?('U:')

--- a/hpxml-measures/workflow/sample_files/base-appliances-dehumidifier-50percent.xml
+++ b/hpxml-measures/workflow/sample_files/base-appliances-dehumidifier-50percent.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-appliances-dehumidifier-ief.xml
+++ b/hpxml-measures/workflow/sample_files/base-appliances-dehumidifier-ief.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-appliances-dehumidifier.xml
+++ b/hpxml-measures/workflow/sample_files/base-appliances-dehumidifier.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-appliances-gas.xml
+++ b/hpxml-measures/workflow/sample_files/base-appliances-gas.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-appliances-modified.xml
+++ b/hpxml-measures/workflow/sample_files/base-appliances-modified.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-appliances-none.xml
+++ b/hpxml-measures/workflow/sample_files/base-appliances-none.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-appliances-propane.xml
+++ b/hpxml-measures/workflow/sample_files/base-appliances-propane.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-appliances-wood.xml
+++ b/hpxml-measures/workflow/sample_files/base-appliances-wood.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-atticroof-cathedral.xml
+++ b/hpxml-measures/workflow/sample_files/base-atticroof-cathedral.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-atticroof-conditioned.xml
+++ b/hpxml-measures/workflow/sample_files/base-atticroof-conditioned.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-atticroof-flat.xml
+++ b/hpxml-measures/workflow/sample_files/base-atticroof-flat.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-atticroof-radiant-barrier.xml
+++ b/hpxml-measures/workflow/sample_files/base-atticroof-radiant-barrier.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-atticroof-unvented-insulated-roof.xml
+++ b/hpxml-measures/workflow/sample_files/base-atticroof-unvented-insulated-roof.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-atticroof-vented.xml
+++ b/hpxml-measures/workflow/sample_files/base-atticroof-vented.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-combi-tankless-outside.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-combi-tankless-outside.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-combi-tankless.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-combi-tankless.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-desuperheater-2-speed.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-desuperheater-2-speed.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-desuperheater-gshp.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-desuperheater-gshp.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-desuperheater-hpwh.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-desuperheater-hpwh.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-desuperheater-tankless.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-desuperheater-tankless.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-desuperheater-var-speed.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-desuperheater-var-speed.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-desuperheater.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-desuperheater.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-dwhr.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-dwhr.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-indirect-dse.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-indirect-dse.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-indirect-outside.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-indirect-outside.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-indirect-standbyloss.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-indirect-standbyloss.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-indirect-with-solar-fraction.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-indirect-with-solar-fraction.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-indirect.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-indirect.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-jacket-electric.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-jacket-electric.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-jacket-gas.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-jacket-gas.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-jacket-hpwh.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-jacket-hpwh.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-jacket-indirect.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-jacket-indirect.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-low-flow-fixtures.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-low-flow-fixtures.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-multiple.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-multiple.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-none.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-none.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-recirc-demand.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-recirc-demand.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-recirc-manual.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-recirc-manual.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-recirc-nocontrol.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-recirc-nocontrol.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-recirc-temperature.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-recirc-temperature.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-recirc-timer.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-recirc-timer.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-solar-direct-evacuated-tube.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-solar-direct-evacuated-tube.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-solar-direct-flat-plate.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-solar-direct-flat-plate.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-solar-direct-ics.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-solar-direct-ics.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-solar-fraction.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-solar-fraction.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-solar-indirect-flat-plate.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-solar-indirect-flat-plate.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-solar-thermosyphon-flat-plate.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-solar-thermosyphon-flat-plate.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-tank-gas-outside.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-tank-gas-outside.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-tank-gas.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-tank-gas.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-tank-heat-pump-outside.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-tank-heat-pump-outside.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-tank-heat-pump-with-solar-fraction.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-tank-heat-pump-with-solar-fraction.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-tank-heat-pump-with-solar.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-tank-heat-pump-with-solar.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-tank-heat-pump.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-tank-heat-pump.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-tank-oil.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-tank-oil.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-tank-propane.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-tank-propane.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-tank-wood.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-tank-wood.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-tankless-electric-outside.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-tankless-electric-outside.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-tankless-electric.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-tankless-electric.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-tankless-gas-with-solar-fraction.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-tankless-gas-with-solar-fraction.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-tankless-gas-with-solar.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-tankless-gas-with-solar.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-tankless-gas.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-tankless-gas.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-tankless-oil.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-tankless-oil.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-tankless-propane.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-tankless-propane.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-tankless-wood.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-tankless-wood.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-dhw-uef.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-uef.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-enclosure-2stories-garage.xml
+++ b/hpxml-measures/workflow/sample_files/base-enclosure-2stories-garage.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-enclosure-2stories.xml
+++ b/hpxml-measures/workflow/sample_files/base-enclosure-2stories.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-enclosure-attached-multifamily.xml
+++ b/hpxml-measures/workflow/sample_files/base-enclosure-attached-multifamily.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>
@@ -143,7 +144,7 @@
             </Insulation>
           </Wall>
           <Wall>
-            <SystemIdentifier id='WallUnratedHeatedSpace'/>
+            <SystemIdentifier id='WallOtherHeatedSpace'/>
             <ExteriorAdjacentTo>other heated space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <WallType>
@@ -153,12 +154,12 @@
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
-              <SystemIdentifier id='WallUnratedHeatedSpaceInsulation'/>
+              <SystemIdentifier id='WallOtherHeatedSpaceInsulation'/>
               <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
             </Insulation>
           </Wall>
           <Wall>
-            <SystemIdentifier id='WallMultifamilyBuffer'/>
+            <SystemIdentifier id='WallOtherMultifamilyBufferSpace'/>
             <ExteriorAdjacentTo>other multifamily buffer space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <WallType>
@@ -168,12 +169,12 @@
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
-              <SystemIdentifier id='WallMultifamilyBufferInsulation'/>
+              <SystemIdentifier id='WallOtherMultifamilyBufferSpaceInsulation'/>
               <AssemblyEffectiveRValue>22.3</AssemblyEffectiveRValue>
             </Insulation>
           </Wall>
           <Wall>
-            <SystemIdentifier id='WallNonFreezingSpace'/>
+            <SystemIdentifier id='WallOtherNonFreezingSpace'/>
             <ExteriorAdjacentTo>other non-freezing space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <WallType>
@@ -183,12 +184,12 @@
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
-              <SystemIdentifier id='WallNonFreezingSpaceInsulation'/>
+              <SystemIdentifier id='WallOtherNonFreezingSpaceInsulation'/>
               <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
             </Insulation>
           </Wall>
           <Wall>
-            <SystemIdentifier id='WallAdiabatic'/>
+            <SystemIdentifier id='WallOtherHousingUnit'/>
             <ExteriorAdjacentTo>other housing unit</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <WallType>
@@ -198,7 +199,7 @@
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
-              <SystemIdentifier id='WallAdiabaticInsulation'/>
+              <SystemIdentifier id='WallOtherHousingUnitInsulation'/>
               <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
             </Insulation>
           </Wall>
@@ -248,7 +249,7 @@
             </Insulation>
           </FoundationWall>
           <FoundationWall>
-            <SystemIdentifier id='FoundationWall1'/>
+            <SystemIdentifier id='FoundationWallOtherNonFreezingSpace'/>
             <ExteriorAdjacentTo>other non-freezing space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
             <Height>8.0</Height>
@@ -256,7 +257,7 @@
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>7.0</DepthBelowGrade>
             <Insulation>
-              <SystemIdentifier id='FoundationWall1Insulation'/>
+              <SystemIdentifier id='FoundationWallOtherNonFreezingSpaceInsulation'/>
               <Layer>
                 <InstallationType>continuous - exterior</InstallationType>
                 <NominalRValue>8.9</NominalRValue>
@@ -276,7 +277,7 @@
             </Insulation>
           </FoundationWall>
           <FoundationWall>
-            <SystemIdentifier id='FoundationWall2'/>
+            <SystemIdentifier id='FoundationWallOtherMultifamilyBufferSpace'/>
             <ExteriorAdjacentTo>other multifamily buffer space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
             <Height>4.0</Height>
@@ -284,7 +285,7 @@
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>3.0</DepthBelowGrade>
             <Insulation>
-              <SystemIdentifier id='FoundationWall2Insulation'/>
+              <SystemIdentifier id='FoundationWallOtherMultifamilyBufferSpaceInsulation'/>
               <Layer>
                 <InstallationType>continuous - exterior</InstallationType>
                 <NominalRValue>8.9</NominalRValue>
@@ -304,7 +305,7 @@
             </Insulation>
           </FoundationWall>
           <FoundationWall>
-            <SystemIdentifier id='FoundationWall3'/>
+            <SystemIdentifier id='FoundationWallOtherHeatedSpace'/>
             <ExteriorAdjacentTo>other heated space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
             <Height>2.0</Height>
@@ -312,7 +313,7 @@
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>1.0</DepthBelowGrade>
             <Insulation>
-              <SystemIdentifier id='FoundationWall3Insulation'/>
+              <SystemIdentifier id='FoundationWallOtherHeatedSpaceInsulation'/>
               <Layer>
                 <InstallationType>continuous - exterior</InstallationType>
                 <NominalRValue>8.9</NominalRValue>
@@ -344,34 +345,43 @@
             </Insulation>
           </FrameFloor>
           <FrameFloor>
-            <SystemIdentifier id='FloorNonFreezingSpace'/>
+            <SystemIdentifier id='FloorAboveNonFreezingSpace'/>
             <ExteriorAdjacentTo>other non-freezing space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <Area>1000.0</Area>
             <Insulation>
-              <SystemIdentifier id='FloorNonFreezingSpaceInsulation'/>
+              <SystemIdentifier id='FloorAboveNonFreezingSpaceInsulation'/>
               <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
             </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>below</OtherSpaceAboveOrBelow>
+            </extension>
           </FrameFloor>
           <FrameFloor>
-            <SystemIdentifier id='FloorMultifamilyBuffer'/>
+            <SystemIdentifier id='FloorAboveMultifamilyBuffer'/>
             <ExteriorAdjacentTo>other multifamily buffer space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <Area>200.0</Area>
             <Insulation>
-              <SystemIdentifier id='FloorMultifamilyBufferInsulation'/>
+              <SystemIdentifier id='FloorAboveMultifamilyBufferInsulation'/>
               <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
             </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>below</OtherSpaceAboveOrBelow>
+            </extension>
           </FrameFloor>
           <FrameFloor>
-            <SystemIdentifier id='FloorUnratedHeatedSpace'/>
+            <SystemIdentifier id='FloorAboveOtherHeatedSpace'/>
             <ExteriorAdjacentTo>other heated space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <Area>150.0</Area>
             <Insulation>
-              <SystemIdentifier id='FloorUnratedHeatedSpaceInsulation'/>
+              <SystemIdentifier id='FloorAboveOtherHeatedSpaceInsulation'/>
               <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
             </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>below</OtherSpaceAboveOrBelow>
+            </extension>
           </FrameFloor>
         </FrameFloors>
         <Slabs>
@@ -477,28 +487,28 @@
             <RValue>4.4</RValue>
           </Door>
           <Door>
-            <SystemIdentifier id='DoorOnUnratedHeatedSpace'/>
-            <AttachedToWall idref='WallUnratedHeatedSpace'/>
+            <SystemIdentifier id='DoorOnWallOtherHeatedSpace'/>
+            <AttachedToWall idref='WallOtherHeatedSpace'/>
             <Area>40.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
-            <SystemIdentifier id='DoorOnNonFreezingFndWall'/>
-            <AttachedToWall idref='FoundationWall1'/>
+            <SystemIdentifier id='DoorOnFoundationWallOtherNonFreezingSpace'/>
+            <AttachedToWall idref='FoundationWallOtherNonFreezingSpace'/>
             <Area>40.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
-            <SystemIdentifier id='DoorOnOtherUnit'/>
-            <AttachedToWall idref='WallAdiabatic'/>
+            <SystemIdentifier id='DoorOnWallOtherHousingUnit'/>
+            <AttachedToWall idref='WallOtherHousingUnit'/>
             <Area>40.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
-            <SystemIdentifier id='DoorAttic'/>
+            <SystemIdentifier id='DoorOnWallAtticLivingWall'/>
             <AttachedToWall idref='WallAtticLivingWall'/>
             <Area>10.0</Area>
             <Azimuth>0</Azimuth>

--- a/hpxml-measures/workflow/sample_files/base-enclosure-beds-1.xml
+++ b/hpxml-measures/workflow/sample_files/base-enclosure-beds-1.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-enclosure-beds-2.xml
+++ b/hpxml-measures/workflow/sample_files/base-enclosure-beds-2.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-enclosure-beds-4.xml
+++ b/hpxml-measures/workflow/sample_files/base-enclosure-beds-4.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-enclosure-beds-5.xml
+++ b/hpxml-measures/workflow/sample_files/base-enclosure-beds-5.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-enclosure-garage.xml
+++ b/hpxml-measures/workflow/sample_files/base-enclosure-garage.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-enclosure-infil-cfm50.xml
+++ b/hpxml-measures/workflow/sample_files/base-enclosure-infil-cfm50.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-enclosure-infil-natural-ach.xml
+++ b/hpxml-measures/workflow/sample_files/base-enclosure-infil-natural-ach.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-enclosure-other-heated-space.xml
+++ b/hpxml-measures/workflow/sample_files/base-enclosure-other-heated-space.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>
@@ -86,7 +87,7 @@
             </Insulation>
           </Wall>
           <Wall>
-            <SystemIdentifier id='OtherHeatedSpaceWall'/>
+            <SystemIdentifier id='WallOtherHeatedSpace'/>
             <ExteriorAdjacentTo>other heated space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <WallType>
@@ -96,31 +97,37 @@
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
-              <SystemIdentifier id='OtherHeatedSpaceWallInsulation'/>
+              <SystemIdentifier id='WallOtherHeatedSpaceInsulation'/>
               <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
             </Insulation>
           </Wall>
         </Walls>
         <FrameFloors>
           <FrameFloor>
-            <SystemIdentifier id='FloorBelowOtherHousingUnit'/>
-            <ExteriorAdjacentTo>other housing unit above</ExteriorAdjacentTo>
-            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
-            <Area>1350.0</Area>
-            <Insulation>
-              <SystemIdentifier id='FloorBelowOtherHousingUnitInsulation'/>
-              <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
-            </Insulation>
-          </FrameFloor>
-          <FrameFloor>
-            <SystemIdentifier id='FloorOtherHeatedSpace'/>
+            <SystemIdentifier id='FloorBelowOtherHeatedSpace'/>
             <ExteriorAdjacentTo>other heated space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <Area>1350.0</Area>
             <Insulation>
-              <SystemIdentifier id='FloorOtherHeatedSpaceInsulation'/>
+              <SystemIdentifier id='FloorBelowOtherHeatedSpaceInsulation'/>
               <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
             </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>above</OtherSpaceAboveOrBelow>
+            </extension>
+          </FrameFloor>
+          <FrameFloor>
+            <SystemIdentifier id='FloorAboveOtherHeatedSpace'/>
+            <ExteriorAdjacentTo>other heated space</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <Area>1350.0</Area>
+            <Insulation>
+              <SystemIdentifier id='FloorAboveOtherHeatedSpaceInsulation'/>
+              <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
+            </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>below</OtherSpaceAboveOrBelow>
+            </extension>
           </FrameFloor>
         </FrameFloors>
         <Windows>
@@ -197,8 +204,8 @@
             <RValue>4.4</RValue>
           </Door>
           <Door>
-            <SystemIdentifier id='DoorOnOtherHeatedSpaceWall'/>
-            <AttachedToWall idref='OtherHeatedSpaceWall'/>
+            <SystemIdentifier id='DoorOnWallOtherHeatedSpace'/>
+            <AttachedToWall idref='WallOtherHeatedSpace'/>
             <Area>40.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>

--- a/hpxml-measures/workflow/sample_files/base-enclosure-other-housing-unit.xml
+++ b/hpxml-measures/workflow/sample_files/base-enclosure-other-housing-unit.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>
@@ -86,7 +87,7 @@
             </Insulation>
           </Wall>
           <Wall>
-            <SystemIdentifier id='OtherHousingUnitWall'/>
+            <SystemIdentifier id='WallOtherHousingUnit'/>
             <ExteriorAdjacentTo>other housing unit</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <WallType>
@@ -96,7 +97,7 @@
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
-              <SystemIdentifier id='OtherHousingUnitWallInsulation'/>
+              <SystemIdentifier id='WallOtherHousingUnitInsulation'/>
               <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
             </Insulation>
           </Wall>
@@ -104,23 +105,29 @@
         <FrameFloors>
           <FrameFloor>
             <SystemIdentifier id='FloorBelowOtherHousingUnit'/>
-            <ExteriorAdjacentTo>other housing unit above</ExteriorAdjacentTo>
+            <ExteriorAdjacentTo>other housing unit</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <Area>1350.0</Area>
             <Insulation>
               <SystemIdentifier id='FloorBelowOtherHousingUnitInsulation'/>
               <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
             </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>above</OtherSpaceAboveOrBelow>
+            </extension>
           </FrameFloor>
           <FrameFloor>
             <SystemIdentifier id='FloorAboveOtherHousingUnit'/>
-            <ExteriorAdjacentTo>other housing unit below</ExteriorAdjacentTo>
+            <ExteriorAdjacentTo>other housing unit</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <Area>1350.0</Area>
             <Insulation>
               <SystemIdentifier id='FloorAboveOtherHousingUnitInsulation'/>
               <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
             </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>below</OtherSpaceAboveOrBelow>
+            </extension>
           </FrameFloor>
         </FrameFloors>
         <Windows>
@@ -197,8 +204,8 @@
             <RValue>4.4</RValue>
           </Door>
           <Door>
-            <SystemIdentifier id='DoorOnOtherHousingUnitWall'/>
-            <AttachedToWall idref='OtherHousingUnitWall'/>
+            <SystemIdentifier id='DoorOnWallOtherHousingUnit'/>
+            <AttachedToWall idref='WallOtherHousingUnit'/>
             <Area>40.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>

--- a/hpxml-measures/workflow/sample_files/base-enclosure-other-multifamily-buffer-space.xml
+++ b/hpxml-measures/workflow/sample_files/base-enclosure-other-multifamily-buffer-space.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>
@@ -86,7 +87,7 @@
             </Insulation>
           </Wall>
           <Wall>
-            <SystemIdentifier id='OtherMultifamilyBufferSpaceWall'/>
+            <SystemIdentifier id='WallOtherMultifamilyBufferSpace'/>
             <ExteriorAdjacentTo>other multifamily buffer space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <WallType>
@@ -96,31 +97,37 @@
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
-              <SystemIdentifier id='OtherMultifamilyBufferSpaceWallInsulation'/>
+              <SystemIdentifier id='WallOtherMultifamilyBufferSpaceInsulation'/>
               <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
             </Insulation>
           </Wall>
         </Walls>
         <FrameFloors>
           <FrameFloor>
-            <SystemIdentifier id='FloorBelowOtherHousingUnit'/>
-            <ExteriorAdjacentTo>other housing unit above</ExteriorAdjacentTo>
-            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
-            <Area>1350.0</Area>
-            <Insulation>
-              <SystemIdentifier id='FloorBelowOtherHousingUnitInsulation'/>
-              <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
-            </Insulation>
-          </FrameFloor>
-          <FrameFloor>
-            <SystemIdentifier id='FloorOtherMultifamilyBufferSpace'/>
+            <SystemIdentifier id='FloorBelowOtherMultifamilyBufferSpace'/>
             <ExteriorAdjacentTo>other multifamily buffer space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <Area>1350.0</Area>
             <Insulation>
-              <SystemIdentifier id='FloorOtherMultifamilyBufferSpaceInsulation'/>
+              <SystemIdentifier id='FloorBelowOtherMultifamilyBufferSpaceInsulation'/>
               <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
             </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>above</OtherSpaceAboveOrBelow>
+            </extension>
+          </FrameFloor>
+          <FrameFloor>
+            <SystemIdentifier id='FloorAboveOtherMultifamilyBufferSpace'/>
+            <ExteriorAdjacentTo>other multifamily buffer space</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <Area>1350.0</Area>
+            <Insulation>
+              <SystemIdentifier id='FloorAboveOtherMultifamilyBufferSpaceInsulation'/>
+              <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
+            </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>below</OtherSpaceAboveOrBelow>
+            </extension>
           </FrameFloor>
         </FrameFloors>
         <Windows>
@@ -197,8 +204,8 @@
             <RValue>4.4</RValue>
           </Door>
           <Door>
-            <SystemIdentifier id='DoorOnOtherMultifamilyBufferSpaceWall'/>
-            <AttachedToWall idref='OtherMultifamilyBufferSpaceWall'/>
+            <SystemIdentifier id='DoorOnWallOtherMultifamilyBufferSpace'/>
+            <AttachedToWall idref='WallOtherMultifamilyBufferSpace'/>
             <Area>40.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>

--- a/hpxml-measures/workflow/sample_files/base-enclosure-other-non-freezing-space.xml
+++ b/hpxml-measures/workflow/sample_files/base-enclosure-other-non-freezing-space.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>
@@ -86,7 +87,7 @@
             </Insulation>
           </Wall>
           <Wall>
-            <SystemIdentifier id='OtherNonFreezingSpaceWall'/>
+            <SystemIdentifier id='WallOtherNonFreezingSpace'/>
             <ExteriorAdjacentTo>other non-freezing space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <WallType>
@@ -96,31 +97,37 @@
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
-              <SystemIdentifier id='OtherNonFreezingSpaceWallInsulation'/>
+              <SystemIdentifier id='WallOtherNonFreezingSpaceInsulation'/>
               <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
             </Insulation>
           </Wall>
         </Walls>
         <FrameFloors>
           <FrameFloor>
-            <SystemIdentifier id='FloorBelowOtherHousingUnit'/>
-            <ExteriorAdjacentTo>other housing unit above</ExteriorAdjacentTo>
-            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
-            <Area>1350.0</Area>
-            <Insulation>
-              <SystemIdentifier id='FloorBelowOtherHousingUnitInsulation'/>
-              <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
-            </Insulation>
-          </FrameFloor>
-          <FrameFloor>
-            <SystemIdentifier id='FloorOtherNonFreezingSpace'/>
+            <SystemIdentifier id='FloorBelowOtherNonFreezingSpace'/>
             <ExteriorAdjacentTo>other non-freezing space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <Area>1350.0</Area>
             <Insulation>
-              <SystemIdentifier id='FloorOtherNonFreezingSpaceInsulation'/>
+              <SystemIdentifier id='FloorBelowOtherNonFreezingSpaceInsulation'/>
               <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
             </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>above</OtherSpaceAboveOrBelow>
+            </extension>
+          </FrameFloor>
+          <FrameFloor>
+            <SystemIdentifier id='FloorAboveOtherNonFreezingSpace'/>
+            <ExteriorAdjacentTo>other non-freezing space</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <Area>1350.0</Area>
+            <Insulation>
+              <SystemIdentifier id='FloorAboveOtherNonFreezingSpaceInsulation'/>
+              <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
+            </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>below</OtherSpaceAboveOrBelow>
+            </extension>
           </FrameFloor>
         </FrameFloors>
         <Windows>
@@ -197,8 +204,8 @@
             <RValue>4.4</RValue>
           </Door>
           <Door>
-            <SystemIdentifier id='DoorOnOtherNonFreezingSpaceWall'/>
-            <AttachedToWall idref='OtherNonFreezingSpaceWall'/>
+            <SystemIdentifier id='DoorOnWallOtherNonFreezingSpace'/>
+            <AttachedToWall idref='WallOtherNonFreezingSpace'/>
             <Area>40.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>

--- a/hpxml-measures/workflow/sample_files/base-enclosure-overhangs.xml
+++ b/hpxml-measures/workflow/sample_files/base-enclosure-overhangs.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-enclosure-skylights.xml
+++ b/hpxml-measures/workflow/sample_files/base-enclosure-skylights.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-enclosure-split-surfaces.xml
+++ b/hpxml-measures/workflow/sample_files/base-enclosure-split-surfaces.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-enclosure-walltypes.xml
+++ b/hpxml-measures/workflow/sample_files/base-enclosure-walltypes.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-enclosure-windows-interior-shading.xml
+++ b/hpxml-measures/workflow/sample_files/base-enclosure-windows-interior-shading.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-enclosure-windows-none.xml
+++ b/hpxml-measures/workflow/sample_files/base-enclosure-windows-none.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-foundation-ambient.xml
+++ b/hpxml-measures/workflow/sample_files/base-foundation-ambient.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-foundation-complex.xml
+++ b/hpxml-measures/workflow/sample_files/base-foundation-complex.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-foundation-conditioned-basement-slab-insulation.xml
+++ b/hpxml-measures/workflow/sample_files/base-foundation-conditioned-basement-slab-insulation.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-foundation-conditioned-basement-wall-interior-insulation.xml
+++ b/hpxml-measures/workflow/sample_files/base-foundation-conditioned-basement-wall-interior-insulation.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-foundation-multiple.xml
+++ b/hpxml-measures/workflow/sample_files/base-foundation-multiple.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-foundation-slab.xml
+++ b/hpxml-measures/workflow/sample_files/base-foundation-slab.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-foundation-unconditioned-basement-above-grade.xml
+++ b/hpxml-measures/workflow/sample_files/base-foundation-unconditioned-basement-above-grade.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-foundation-unconditioned-basement-assembly-r.xml
+++ b/hpxml-measures/workflow/sample_files/base-foundation-unconditioned-basement-assembly-r.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-foundation-unconditioned-basement-wall-insulation.xml
+++ b/hpxml-measures/workflow/sample_files/base-foundation-unconditioned-basement-wall-insulation.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-foundation-unconditioned-basement.xml
+++ b/hpxml-measures/workflow/sample_files/base-foundation-unconditioned-basement.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-foundation-unvented-crawlspace.xml
+++ b/hpxml-measures/workflow/sample_files/base-foundation-unvented-crawlspace.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-foundation-vented-crawlspace.xml
+++ b/hpxml-measures/workflow/sample_files/base-foundation-vented-crawlspace.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-foundation-walkout-basement.xml
+++ b/hpxml-measures/workflow/sample_files/base-foundation-walkout-basement.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-air-to-air-heat-pump-1-speed.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-air-to-air-heat-pump-1-speed.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-air-to-air-heat-pump-2-speed.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-air-to-air-heat-pump-2-speed.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-air-to-air-heat-pump-var-speed.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-air-to-air-heat-pump-var-speed.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-boiler-elec-only.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-boiler-elec-only.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-boiler-gas-central-ac-1-speed.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-boiler-gas-central-ac-1-speed.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-boiler-gas-only.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-boiler-gas-only.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-boiler-oil-only.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-boiler-oil-only.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-boiler-propane-only.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-boiler-propane-only.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-boiler-wood-only.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-boiler-wood-only.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-central-ac-only-1-speed.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-central-ac-only-1-speed.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-central-ac-only-2-speed.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-central-ac-only-2-speed.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-central-ac-only-var-speed.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-central-ac-only-var-speed.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-central-ac-plus-air-to-air-heat-pump-heating.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-central-ac-plus-air-to-air-heat-pump-heating.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-dse.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-dse.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-1-speed-electric.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-1-speed-electric.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-1-speed.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-1-speed.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-2-speed.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-2-speed.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-var-speed.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-var-speed.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-dual-fuel-mini-split-heat-pump-ducted.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-dual-fuel-mini-split-heat-pump-ducted.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-ducts-leakage-percent.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-ducts-leakage-percent.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-elec-resistance-only.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-elec-resistance-only.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-evap-cooler-furnace-gas.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-evap-cooler-furnace-gas.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-evap-cooler-only-ducted.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-evap-cooler-only-ducted.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-evap-cooler-only.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-evap-cooler-only.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-flowrate.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-flowrate.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-furnace-elec-central-ac-1-speed.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-furnace-elec-central-ac-1-speed.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-furnace-elec-only.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-furnace-elec-only.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-furnace-gas-central-ac-2-speed.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-furnace-gas-central-ac-2-speed.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-furnace-gas-central-ac-var-speed.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-furnace-gas-central-ac-var-speed.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-furnace-gas-only.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-furnace-gas-only.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-furnace-gas-room-ac.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-furnace-gas-room-ac.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-furnace-oil-only.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-furnace-oil-only.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-furnace-propane-only.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-furnace-propane-only.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-furnace-wood-only.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-furnace-wood-only.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-furnace-x3-dse.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-furnace-x3-dse.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-ground-to-air-heat-pump.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-ground-to-air-heat-pump.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-ideal-air.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-ideal-air.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-mini-split-heat-pump-ducted-cooling-only.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-mini-split-heat-pump-ducted-cooling-only.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-mini-split-heat-pump-ducted-heating-only.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-mini-split-heat-pump-ducted-heating-only.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-mini-split-heat-pump-ducted.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-mini-split-heat-pump-ducted.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-mini-split-heat-pump-ductless-no-backup.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-mini-split-heat-pump-ductless-no-backup.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-mini-split-heat-pump-ductless.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-mini-split-heat-pump-ductless.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-multiple.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-multiple.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-multiple2.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-multiple2.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-none-no-fuel-access.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-none-no-fuel-access.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
           </FuelTypesAvailable>

--- a/hpxml-measures/workflow/sample_files/base-hvac-none.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-none.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-portable-heater-electric-only.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-portable-heater-electric-only.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-programmable-thermostat.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-programmable-thermostat.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-room-ac-only-33percent.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-room-ac-only-33percent.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-room-ac-only.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-room-ac-only.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-setpoints.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-setpoints.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-stove-oil-only.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-stove-oil-only.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-stove-wood-only.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-stove-wood-only.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-stove-wood-pellets-only.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-stove-wood-pellets-only.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-undersized.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-undersized.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-wall-furnace-elec-only.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-wall-furnace-elec-only.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-wall-furnace-propane-only.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-wall-furnace-propane-only.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-hvac-wall-furnace-wood-only.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-wall-furnace-wood-only.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-location-baltimore-md.xml
+++ b/hpxml-measures/workflow/sample_files/base-location-baltimore-md.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-location-dallas-tx.xml
+++ b/hpxml-measures/workflow/sample_files/base-location-dallas-tx.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-location-duluth-mn.xml
+++ b/hpxml-measures/workflow/sample_files/base-location-duluth-mn.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-location-epw-filepath-AMY-2012.xml
+++ b/hpxml-measures/workflow/sample_files/base-location-epw-filepath-AMY-2012.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-location-epw-filepath.xml
+++ b/hpxml-measures/workflow/sample_files/base-location-epw-filepath.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-location-miami-fl.xml
+++ b/hpxml-measures/workflow/sample_files/base-location-miami-fl.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-mechvent-balanced.xml
+++ b/hpxml-measures/workflow/sample_files/base-mechvent-balanced.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-mechvent-bath-kitchen-fans.xml
+++ b/hpxml-measures/workflow/sample_files/base-mechvent-bath-kitchen-fans.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-mechvent-cfis-dse.xml
+++ b/hpxml-measures/workflow/sample_files/base-mechvent-cfis-dse.xml
@@ -331,39 +331,25 @@
           <HVACDistribution>
             <SystemIdentifier id='HVACDistribution'/>
             <DistributionSystemType>
-              <AirDistribution>
-                <DuctLeakageMeasurement>
-                  <DuctType>supply</DuctType>
-                  <DuctLeakage>
-                    <Units>CFM25</Units>
-                    <Value>75.0</Value>
-                    <TotalOrToOutside>to outside</TotalOrToOutside>
-                  </DuctLeakage>
-                </DuctLeakageMeasurement>
-                <DuctLeakageMeasurement>
-                  <DuctType>return</DuctType>
-                  <DuctLeakage>
-                    <Units>CFM25</Units>
-                    <Value>25.0</Value>
-                    <TotalOrToOutside>to outside</TotalOrToOutside>
-                  </DuctLeakage>
-                </DuctLeakageMeasurement>
-                <Ducts>
-                  <DuctType>supply</DuctType>
-                  <DuctInsulationRValue>4.0</DuctInsulationRValue>
-                  <DuctLocation>attic - unvented</DuctLocation>
-                  <DuctSurfaceArea>150.0</DuctSurfaceArea>
-                </Ducts>
-                <Ducts>
-                  <DuctType>return</DuctType>
-                  <DuctInsulationRValue>0.0</DuctInsulationRValue>
-                  <DuctLocation>attic - unvented</DuctLocation>
-                  <DuctSurfaceArea>50.0</DuctSurfaceArea>
-                </Ducts>
-              </AirDistribution>
+              <Other>DSE</Other>
             </DistributionSystemType>
+            <AnnualHeatingDistributionSystemEfficiency>0.8</AnnualHeatingDistributionSystemEfficiency>
+            <AnnualCoolingDistributionSystemEfficiency>0.7</AnnualCoolingDistributionSystemEfficiency>
           </HVACDistribution>
         </HVAC>
+        <MechanicalVentilation>
+          <VentilationFans>
+            <VentilationFan>
+              <SystemIdentifier id='MechanicalVentilation'/>
+              <FanType>central fan integrated supply</FanType>
+              <TestedFlowRate>330.0</TestedFlowRate>
+              <HoursInOperation>8.0</HoursInOperation>
+              <UsedForWholeBuildingVentilation>true</UsedForWholeBuildingVentilation>
+              <FanPower>300.0</FanPower>
+              <AttachedToHVACDistributionSystem idref='HVACDistribution'/>
+            </VentilationFan>
+          </VentilationFans>
+        </MechanicalVentilation>
         <WaterHeating>
           <WaterHeatingSystem>
             <SystemIdentifier id='WaterHeater'/>
@@ -414,9 +400,9 @@
         <ClothesDryer>
           <SystemIdentifier id='ClothesDryer'/>
           <Location>living space</Location>
-          <FuelType>fuel oil</FuelType>
-          <CombinedEnergyFactor>3.3</CombinedEnergyFactor>
-          <ControlType>moisture</ControlType>
+          <FuelType>electricity</FuelType>
+          <CombinedEnergyFactor>3.73</CombinedEnergyFactor>
+          <ControlType>timer</ControlType>
         </ClothesDryer>
         <Dishwasher>
           <SystemIdentifier id='Dishwasher'/>
@@ -436,7 +422,7 @@
         <CookingRange>
           <SystemIdentifier id='Range'/>
           <Location>living space</Location>
-          <FuelType>fuel oil</FuelType>
+          <FuelType>electricity</FuelType>
           <IsInduction>false</IsInduction>
         </CookingRange>
         <Oven>

--- a/hpxml-measures/workflow/sample_files/base-mechvent-cfis-evap-cooler-only-ducted.xml
+++ b/hpxml-measures/workflow/sample_files/base-mechvent-cfis-evap-cooler-only-ducted.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-mechvent-cfis.xml
+++ b/hpxml-measures/workflow/sample_files/base-mechvent-cfis.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-mechvent-erv-atre-asre.xml
+++ b/hpxml-measures/workflow/sample_files/base-mechvent-erv-atre-asre.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-mechvent-erv.xml
+++ b/hpxml-measures/workflow/sample_files/base-mechvent-erv.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-mechvent-exhaust-rated-flow-rate.xml
+++ b/hpxml-measures/workflow/sample_files/base-mechvent-exhaust-rated-flow-rate.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-mechvent-exhaust.xml
+++ b/hpxml-measures/workflow/sample_files/base-mechvent-exhaust.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-mechvent-hrv-asre.xml
+++ b/hpxml-measures/workflow/sample_files/base-mechvent-hrv-asre.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-mechvent-hrv.xml
+++ b/hpxml-measures/workflow/sample_files/base-mechvent-hrv.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-mechvent-supply.xml
+++ b/hpxml-measures/workflow/sample_files/base-mechvent-supply.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-misc-ceiling-fans.xml
+++ b/hpxml-measures/workflow/sample_files/base-misc-ceiling-fans.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-misc-defaults2.xml
+++ b/hpxml-measures/workflow/sample_files/base-misc-defaults2.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-misc-neighbor-shading.xml
+++ b/hpxml-measures/workflow/sample_files/base-misc-neighbor-shading.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-misc-runperiod-1-month.xml
+++ b/hpxml-measures/workflow/sample_files/base-misc-runperiod-1-month.xml
@@ -23,6 +23,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-misc-timestep-10-mins.xml
+++ b/hpxml-measures/workflow/sample_files/base-misc-timestep-10-mins.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-misc-usage-multiplier.xml
+++ b/hpxml-measures/workflow/sample_files/base-misc-usage-multiplier.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-misc-whole-house-fan.xml
+++ b/hpxml-measures/workflow/sample_files/base-misc-whole-house-fan.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base-pv.xml
+++ b/hpxml-measures/workflow/sample_files/base-pv.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/base.xml
+++ b/hpxml-measures/workflow/sample_files/base.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-autosize.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-air-to-air-heat-pump-1-speed-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-air-to-air-heat-pump-1-speed-autosize.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-air-to-air-heat-pump-2-speed-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-air-to-air-heat-pump-2-speed-autosize.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-air-to-air-heat-pump-var-speed-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-air-to-air-heat-pump-var-speed-autosize.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-boiler-elec-only-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-boiler-elec-only-autosize.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-boiler-gas-central-ac-1-speed-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-boiler-gas-central-ac-1-speed-autosize.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-boiler-gas-only-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-boiler-gas-only-autosize.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-central-ac-only-1-speed-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-central-ac-only-1-speed-autosize.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-central-ac-only-2-speed-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-central-ac-only-2-speed-autosize.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-central-ac-only-var-speed-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-central-ac-only-var-speed-autosize.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-central-ac-plus-air-to-air-heat-pump-heating-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-central-ac-plus-air-to-air-heat-pump-heating-autosize.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-dual-fuel-air-to-air-heat-pump-1-speed-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-dual-fuel-air-to-air-heat-pump-1-speed-autosize.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-dual-fuel-mini-split-heat-pump-ducted-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-dual-fuel-mini-split-heat-pump-ducted-autosize.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-elec-resistance-only-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-elec-resistance-only-autosize.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-evap-cooler-furnace-gas-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-evap-cooler-furnace-gas-autosize.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-furnace-elec-only-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-furnace-elec-only-autosize.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-furnace-gas-central-ac-2-speed-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-furnace-gas-central-ac-2-speed-autosize.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-furnace-gas-central-ac-var-speed-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-furnace-gas-central-ac-var-speed-autosize.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-furnace-gas-only-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-furnace-gas-only-autosize.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-furnace-gas-room-ac-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-furnace-gas-room-ac-autosize.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-ground-to-air-heat-pump-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-ground-to-air-heat-pump-autosize.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-mini-split-heat-pump-ducted-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-mini-split-heat-pump-ducted-autosize.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-room-ac-only-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-room-ac-only-autosize.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-stove-oil-only-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-stove-oil-only-autosize.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-wall-furnace-elec-only-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-wall-furnace-elec-only-autosize.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-wall-furnace-propane-only-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-wall-furnace-propane-only-autosize.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/hvac_base/base-hvac-furnace-gas-central-ac-2-speed-base.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_base/base-hvac-furnace-gas-central-ac-2-speed-base.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/appliances-location-unconditioned-space.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/appliances-location-unconditioned-space.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/attached-multifamily-window-outside-condition.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/attached-multifamily-window-outside-condition.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>
@@ -143,7 +144,7 @@
             </Insulation>
           </Wall>
           <Wall>
-            <SystemIdentifier id='WallUnratedHeatedSpace'/>
+            <SystemIdentifier id='WallOtherHeatedSpace'/>
             <ExteriorAdjacentTo>other heated space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <WallType>
@@ -153,12 +154,12 @@
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
-              <SystemIdentifier id='WallUnratedHeatedSpaceInsulation'/>
+              <SystemIdentifier id='WallOtherHeatedSpaceInsulation'/>
               <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
             </Insulation>
           </Wall>
           <Wall>
-            <SystemIdentifier id='WallMultifamilyBuffer'/>
+            <SystemIdentifier id='WallOtherMultifamilyBufferSpace'/>
             <ExteriorAdjacentTo>other multifamily buffer space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <WallType>
@@ -168,12 +169,12 @@
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
-              <SystemIdentifier id='WallMultifamilyBufferInsulation'/>
+              <SystemIdentifier id='WallOtherMultifamilyBufferSpaceInsulation'/>
               <AssemblyEffectiveRValue>22.3</AssemblyEffectiveRValue>
             </Insulation>
           </Wall>
           <Wall>
-            <SystemIdentifier id='WallNonFreezingSpace'/>
+            <SystemIdentifier id='WallOtherNonFreezingSpace'/>
             <ExteriorAdjacentTo>other non-freezing space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <WallType>
@@ -183,12 +184,12 @@
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
-              <SystemIdentifier id='WallNonFreezingSpaceInsulation'/>
+              <SystemIdentifier id='WallOtherNonFreezingSpaceInsulation'/>
               <AssemblyEffectiveRValue>23.0</AssemblyEffectiveRValue>
             </Insulation>
           </Wall>
           <Wall>
-            <SystemIdentifier id='WallAdiabatic'/>
+            <SystemIdentifier id='WallOtherHousingUnit'/>
             <ExteriorAdjacentTo>other housing unit</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <WallType>
@@ -198,7 +199,7 @@
             <SolarAbsorptance>0.7</SolarAbsorptance>
             <Emittance>0.92</Emittance>
             <Insulation>
-              <SystemIdentifier id='WallAdiabaticInsulation'/>
+              <SystemIdentifier id='WallOtherHousingUnitInsulation'/>
               <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
             </Insulation>
           </Wall>
@@ -248,7 +249,7 @@
             </Insulation>
           </FoundationWall>
           <FoundationWall>
-            <SystemIdentifier id='FoundationWall1'/>
+            <SystemIdentifier id='FoundationWallOtherNonFreezingSpace'/>
             <ExteriorAdjacentTo>other non-freezing space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
             <Height>8.0</Height>
@@ -256,7 +257,7 @@
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>7.0</DepthBelowGrade>
             <Insulation>
-              <SystemIdentifier id='FoundationWall1Insulation'/>
+              <SystemIdentifier id='FoundationWallOtherNonFreezingSpaceInsulation'/>
               <Layer>
                 <InstallationType>continuous - exterior</InstallationType>
                 <NominalRValue>8.9</NominalRValue>
@@ -276,7 +277,7 @@
             </Insulation>
           </FoundationWall>
           <FoundationWall>
-            <SystemIdentifier id='FoundationWall2'/>
+            <SystemIdentifier id='FoundationWallOtherMultifamilyBufferSpace'/>
             <ExteriorAdjacentTo>other multifamily buffer space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
             <Height>4.0</Height>
@@ -284,7 +285,7 @@
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>3.0</DepthBelowGrade>
             <Insulation>
-              <SystemIdentifier id='FoundationWall2Insulation'/>
+              <SystemIdentifier id='FoundationWallOtherMultifamilyBufferSpaceInsulation'/>
               <Layer>
                 <InstallationType>continuous - exterior</InstallationType>
                 <NominalRValue>8.9</NominalRValue>
@@ -304,7 +305,7 @@
             </Insulation>
           </FoundationWall>
           <FoundationWall>
-            <SystemIdentifier id='FoundationWall3'/>
+            <SystemIdentifier id='FoundationWallOtherHeatedSpace'/>
             <ExteriorAdjacentTo>other heated space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>basement - conditioned</InteriorAdjacentTo>
             <Height>2.0</Height>
@@ -312,7 +313,7 @@
             <Thickness>8.0</Thickness>
             <DepthBelowGrade>1.0</DepthBelowGrade>
             <Insulation>
-              <SystemIdentifier id='FoundationWall3Insulation'/>
+              <SystemIdentifier id='FoundationWallOtherHeatedSpaceInsulation'/>
               <Layer>
                 <InstallationType>continuous - exterior</InstallationType>
                 <NominalRValue>8.9</NominalRValue>
@@ -344,34 +345,43 @@
             </Insulation>
           </FrameFloor>
           <FrameFloor>
-            <SystemIdentifier id='FloorNonFreezingSpace'/>
+            <SystemIdentifier id='FloorAboveNonFreezingSpace'/>
             <ExteriorAdjacentTo>other non-freezing space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <Area>1000.0</Area>
             <Insulation>
-              <SystemIdentifier id='FloorNonFreezingSpaceInsulation'/>
+              <SystemIdentifier id='FloorAboveNonFreezingSpaceInsulation'/>
               <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
             </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>below</OtherSpaceAboveOrBelow>
+            </extension>
           </FrameFloor>
           <FrameFloor>
-            <SystemIdentifier id='FloorMultifamilyBuffer'/>
+            <SystemIdentifier id='FloorAboveMultifamilyBuffer'/>
             <ExteriorAdjacentTo>other multifamily buffer space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <Area>200.0</Area>
             <Insulation>
-              <SystemIdentifier id='FloorMultifamilyBufferInsulation'/>
+              <SystemIdentifier id='FloorAboveMultifamilyBufferInsulation'/>
               <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
             </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>below</OtherSpaceAboveOrBelow>
+            </extension>
           </FrameFloor>
           <FrameFloor>
-            <SystemIdentifier id='FloorUnratedHeatedSpace'/>
+            <SystemIdentifier id='FloorAboveOtherHeatedSpace'/>
             <ExteriorAdjacentTo>other heated space</ExteriorAdjacentTo>
             <InteriorAdjacentTo>living space</InteriorAdjacentTo>
             <Area>150.0</Area>
             <Insulation>
-              <SystemIdentifier id='FloorUnratedHeatedSpaceInsulation'/>
+              <SystemIdentifier id='FloorAboveOtherHeatedSpaceInsulation'/>
               <AssemblyEffectiveRValue>2.1</AssemblyEffectiveRValue>
             </Insulation>
+            <extension>
+              <OtherSpaceAboveOrBelow>below</OtherSpaceAboveOrBelow>
+            </extension>
           </FrameFloor>
         </FrameFloors>
         <Slabs>
@@ -416,7 +426,7 @@
               <WinterShadingCoefficient>0.85</WinterShadingCoefficient>
             </InteriorShading>
             <FractionOperable>0.67</FractionOperable>
-            <AttachedToWall idref='WallMultifamilyBuffer'/>
+            <AttachedToWall idref='WallOtherMultifamilyBufferSpace'/>
           </Window>
           <Window>
             <SystemIdentifier id='WindowSouth'/>
@@ -477,28 +487,28 @@
             <RValue>4.4</RValue>
           </Door>
           <Door>
-            <SystemIdentifier id='DoorOnUnratedHeatedSpace'/>
-            <AttachedToWall idref='WallUnratedHeatedSpace'/>
+            <SystemIdentifier id='DoorOnWallOtherHeatedSpace'/>
+            <AttachedToWall idref='WallOtherHeatedSpace'/>
             <Area>40.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
-            <SystemIdentifier id='DoorOnNonFreezingFndWall'/>
-            <AttachedToWall idref='FoundationWall1'/>
+            <SystemIdentifier id='DoorOnFoundationWallOtherNonFreezingSpace'/>
+            <AttachedToWall idref='FoundationWallOtherNonFreezingSpace'/>
             <Area>40.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
-            <SystemIdentifier id='DoorOnOtherUnit'/>
-            <AttachedToWall idref='WallAdiabatic'/>
+            <SystemIdentifier id='DoorOnWallOtherHousingUnit'/>
+            <AttachedToWall idref='WallOtherHousingUnit'/>
             <Area>40.0</Area>
             <Azimuth>0</Azimuth>
             <RValue>4.4</RValue>
           </Door>
           <Door>
-            <SystemIdentifier id='DoorAttic'/>
+            <SystemIdentifier id='DoorOnWallAtticLivingWall'/>
             <AttachedToWall idref='WallAtticLivingWall'/>
             <Area>10.0</Area>
             <Azimuth>0</Azimuth>

--- a/hpxml-measures/workflow/sample_files/invalid_files/cfis-with-hydronic-distribution.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/cfis-with-hydronic-distribution.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/clothes-dryer-location.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/clothes-dryer-location.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/clothes-washer-location.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/clothes-washer-location.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/cooking-range-location.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/cooking-range-location.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/dhw-frac-load-served.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/dhw-frac-load-served.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/dishwasher-location.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/dishwasher-location.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/duct-location-unconditioned-space.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/duct-location-unconditioned-space.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/duct-location.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/duct-location.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/duplicate-id.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/duplicate-id.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/enclosure-attic-missing-roof.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/enclosure-attic-missing-roof.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/enclosure-basement-missing-exterior-foundation-wall.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/enclosure-basement-missing-exterior-foundation-wall.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/enclosure-basement-missing-slab.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/enclosure-basement-missing-slab.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/enclosure-garage-missing-exterior-wall.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/enclosure-garage-missing-exterior-wall.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/enclosure-garage-missing-roof-ceiling.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/enclosure-garage-missing-roof-ceiling.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/enclosure-garage-missing-slab.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/enclosure-garage-missing-slab.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/enclosure-living-missing-ceiling-roof.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/enclosure-living-missing-ceiling-roof.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/enclosure-living-missing-exterior-wall.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/enclosure-living-missing-exterior-wall.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/enclosure-living-missing-floor-slab.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/enclosure-living-missing-floor-slab.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/heat-pump-mixed-fixed-and-autosize-capacities.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/heat-pump-mixed-fixed-and-autosize-capacities.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/heat-pump-mixed-fixed-and-autosize-capacities2.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/heat-pump-mixed-fixed-and-autosize-capacities2.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/hvac-distribution-multiple-attached-cooling.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/hvac-distribution-multiple-attached-cooling.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/hvac-distribution-multiple-attached-heating.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/hvac-distribution-multiple-attached-heating.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/hvac-distribution-return-duct-leakage-missing.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/hvac-distribution-return-duct-leakage-missing.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/hvac-dse-multiple-attached-cooling.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/hvac-dse-multiple-attached-cooling.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/hvac-dse-multiple-attached-heating.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/hvac-dse-multiple-attached-heating.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/hvac-frac-load-served.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/hvac-frac-load-served.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/hvac-invalid-distribution-system-type.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/hvac-invalid-distribution-system-type.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/invalid-epw-filepath.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/invalid-epw-filepath.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/invalid-neighbor-shading-azimuth.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/invalid-neighbor-shading-azimuth.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/invalid-relatedhvac-desuperheater.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/invalid-relatedhvac-desuperheater.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/invalid-relatedhvac-dhw-indirect.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/invalid-relatedhvac-dhw-indirect.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/invalid-runperiod.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/invalid-runperiod.xml
@@ -23,6 +23,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/invalid-timestep.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/invalid-timestep.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/invalid-window-height.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/invalid-window-height.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/invalid-window-interior-shading.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/invalid-window-interior-shading.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/invalid-wmo.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/invalid-wmo.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/lighting-fractions.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/lighting-fractions.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/missing-elements.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/missing-elements.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/net-area-negative-roof.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/net-area-negative-roof.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/net-area-negative-wall.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/net-area-negative-wall.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/orphaned-hvac-distribution.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/orphaned-hvac-distribution.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/refrigerator-location.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/refrigerator-location.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/repeated-relatedhvac-desuperheater.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/repeated-relatedhvac-desuperheater.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/repeated-relatedhvac-dhw-indirect.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/repeated-relatedhvac-dhw-indirect.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/slab-zero-exposed-perimeter.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/slab-zero-exposed-perimeter.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/solar-thermal-system-with-combi-tankless.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/solar-thermal-system-with-combi-tankless.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/solar-thermal-system-with-desuperheater.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/solar-thermal-system-with-desuperheater.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/solar-thermal-system-with-dhw-indirect.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/solar-thermal-system-with-dhw-indirect.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/unattached-cfis.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/unattached-cfis.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/unattached-door.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/unattached-door.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/unattached-hvac-distribution.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/unattached-hvac-distribution.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/unattached-skylight.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/unattached-skylight.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/unattached-solar-thermal-system.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/unattached-solar-thermal-system.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/unattached-window.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/unattached-window.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/water-heater-location-other.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/water-heater-location-other.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/hpxml-measures/workflow/sample_files/invalid_files/water-heater-location.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/water-heater-location.xml
@@ -21,6 +21,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/rulesets/301EnergyRatingIndexRuleset/measure.rb
+++ b/rulesets/301EnergyRatingIndexRuleset/measure.rb
@@ -1,16 +1,23 @@
 # frozen_string_literal: true
 
-# see the URL below for information on how to write OpenStudio measures
-# http://nrel.github.io/OpenStudio-user-documentation/reference/measure_writing_guide/
-
 require 'openstudio'
 require 'pathname'
 require 'csv'
-require_relative 'resources/301'
-require_relative 'resources/301validator'
+require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/airflow'
 require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/constants'
+require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/constructions'
+require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/geometry'
+require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/hotwater_appliances'
+require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/hpxml'
+require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/hvac'
+require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/lighting'
+require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/misc_loads'
+require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/unit_conversions'
+require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/waterheater'
 require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/weather'
 require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/xmlhelper'
+require_relative 'resources/301'
+require_relative 'resources/301validator'
 
 # start the measure
 class EnergyRatingIndex301Measure < OpenStudio::Measure::ModelMeasure

--- a/rulesets/301EnergyRatingIndexRuleset/measure.rb
+++ b/rulesets/301EnergyRatingIndexRuleset/measure.rb
@@ -3,6 +3,7 @@
 require 'openstudio'
 require 'pathname'
 require 'csv'
+require 'oga'
 require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/airflow'
 require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/constants'
 require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/constructions'

--- a/rulesets/301EnergyRatingIndexRuleset/measure.xml
+++ b/rulesets/301EnergyRatingIndexRuleset/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>energy_rating_index_301_measure</name>
   <uid>02a31992-9a16-4945-bb51-e99209f7193b</uid>
-  <version_id>59e81c77-6b0f-4602-bfa3-611a0f589388</version_id>
-  <version_modified>20200512T023241Z</version_modified>
+  <version_id>5c70b2ef-ea93-495f-bb18-9649429b37b4</version_id>
+  <version_modified>20200513T204204Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>EnergyRatingIndex301Measure</class_name>
   <display_name>Apply Energy Rating Index Ruleset</display_name>
@@ -101,17 +101,6 @@
       <checksum>04ED80FC</checksum>
     </file>
     <file>
-      <version>
-        <software_program>OpenStudio</software_program>
-        <identifier>2.1.1</identifier>
-        <min_compatible>2.1.1</min_compatible>
-      </version>
-      <filename>measure.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>script</usage_type>
-      <checksum>975256B5</checksum>
-    </file>
-    <file>
       <filename>test_lighting.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -124,18 +113,6 @@
       <checksum>A7676D61</checksum>
     </file>
     <file>
-      <filename>301validator.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>3837D731</checksum>
-    </file>
-    <file>
-      <filename>301.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>5CA34E39</checksum>
-    </file>
-    <file>
       <filename>test_enclosure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -146,6 +123,29 @@
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
       <checksum>0EAF44C0</checksum>
+    </file>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>2.1.1</identifier>
+        <min_compatible>2.1.1</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>2D3966A4</checksum>
+    </file>
+    <file>
+      <filename>301validator.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>71C37B7D</checksum>
+    </file>
+    <file>
+      <filename>301.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>3CB0277A</checksum>
     </file>
   </files>
 </measure>

--- a/rulesets/301EnergyRatingIndexRuleset/measure.xml
+++ b/rulesets/301EnergyRatingIndexRuleset/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>energy_rating_index_301_measure</name>
   <uid>02a31992-9a16-4945-bb51-e99209f7193b</uid>
-  <version_id>5c70b2ef-ea93-495f-bb18-9649429b37b4</version_id>
-  <version_modified>20200513T204204Z</version_modified>
+  <version_id>63ce2b00-2b35-439a-8346-3f7b2b1fd7f2</version_id>
+  <version_modified>20200513T214510Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>EnergyRatingIndex301Measure</class_name>
   <display_name>Apply Energy Rating Index Ruleset</display_name>
@@ -125,17 +125,6 @@
       <checksum>0EAF44C0</checksum>
     </file>
     <file>
-      <version>
-        <software_program>OpenStudio</software_program>
-        <identifier>2.1.1</identifier>
-        <min_compatible>2.1.1</min_compatible>
-      </version>
-      <filename>measure.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>script</usage_type>
-      <checksum>2D3966A4</checksum>
-    </file>
-    <file>
       <filename>301validator.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -146,6 +135,17 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>3CB0277A</checksum>
+    </file>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>2.1.1</identifier>
+        <min_compatible>2.1.1</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>1C53FE88</checksum>
     </file>
   </files>
 </measure>

--- a/rulesets/301EnergyRatingIndexRuleset/resources/301.rb
+++ b/rulesets/301EnergyRatingIndexRuleset/resources/301.rb
@@ -1,16 +1,5 @@
 # frozen_string_literal: true
 
-require_relative '../../../hpxml-measures/HPXMLtoOpenStudio/resources/airflow'
-require_relative '../../../hpxml-measures/HPXMLtoOpenStudio/resources/constants'
-require_relative '../../../hpxml-measures/HPXMLtoOpenStudio/resources/constructions'
-require_relative '../../../hpxml-measures/HPXMLtoOpenStudio/resources/geometry'
-require_relative '../../../hpxml-measures/HPXMLtoOpenStudio/resources/hotwater_appliances'
-require_relative '../../../hpxml-measures/HPXMLtoOpenStudio/resources/hpxml'
-require_relative '../../../hpxml-measures/HPXMLtoOpenStudio/resources/lighting'
-require_relative '../../../hpxml-measures/HPXMLtoOpenStudio/resources/misc_loads'
-require_relative '../../../hpxml-measures/HPXMLtoOpenStudio/resources/unit_conversions'
-require_relative '../../../hpxml-measures/HPXMLtoOpenStudio/resources/waterheater'
-
 class EnergyRatingIndex301Ruleset
   def self.apply_ruleset(hpxml, calc_type, weather)
     # Global variables
@@ -239,6 +228,7 @@ class EnergyRatingIndex301Ruleset
 
     new_hpxml.site.fuels = orig_hpxml.site.fuels
     new_hpxml.site.shelter_coefficient = Airflow.get_default_shelter_coefficient()
+    new_hpxml.site.site_type = HPXML::SiteTypeSuburban
 
     new_hpxml.building_occupancy.number_of_residents = Geometry.get_occupancy_default_num(@nbeds)
 
@@ -263,6 +253,7 @@ class EnergyRatingIndex301Ruleset
 
     new_hpxml.site.fuels = orig_hpxml.site.fuels
     new_hpxml.site.shelter_coefficient = Airflow.get_default_shelter_coefficient()
+    new_hpxml.site.site_type = HPXML::SiteTypeSuburban
 
     new_hpxml.building_occupancy.number_of_residents = Geometry.get_occupancy_default_num(@nbeds)
 
@@ -287,6 +278,7 @@ class EnergyRatingIndex301Ruleset
 
     new_hpxml.site.fuels = orig_hpxml.site.fuels
     new_hpxml.site.shelter_coefficient = Airflow.get_default_shelter_coefficient()
+    new_hpxml.site.site_type = HPXML::SiteTypeSuburban
 
     new_hpxml.building_occupancy.number_of_residents = Geometry.get_occupancy_default_num(@nbeds)
 
@@ -785,7 +777,8 @@ class EnergyRatingIndex301Ruleset
                                  interior_adjacent_to: orig_frame_floor.interior_adjacent_to.gsub('unvented', 'vented'),
                                  area: orig_frame_floor.area,
                                  insulation_id: orig_frame_floor.insulation_id,
-                                 insulation_assembly_r_value: insulation_assembly_r_value)
+                                 insulation_assembly_r_value: insulation_assembly_r_value,
+                                 other_space_above_or_below: orig_frame_floor.other_space_above_or_below)
     end
   end
 
@@ -799,7 +792,8 @@ class EnergyRatingIndex301Ruleset
                                  interior_adjacent_to: orig_frame_floor.interior_adjacent_to,
                                  area: orig_frame_floor.area,
                                  insulation_id: orig_frame_floor.insulation_id,
-                                 insulation_assembly_r_value: orig_frame_floor.insulation_assembly_r_value)
+                                 insulation_assembly_r_value: orig_frame_floor.insulation_assembly_r_value,
+                                 other_space_above_or_below: orig_frame_floor.other_space_above_or_below)
     end
   end
 
@@ -851,7 +845,8 @@ class EnergyRatingIndex301Ruleset
                                  interior_adjacent_to: orig_frame_floor.interior_adjacent_to.gsub('unvented', 'vented'),
                                  area: orig_frame_floor.area,
                                  insulation_id: orig_frame_floor.insulation_id,
-                                 insulation_assembly_r_value: insulation_assembly_r_value)
+                                 insulation_assembly_r_value: insulation_assembly_r_value,
+                                 other_space_above_or_below: orig_frame_floor.other_space_above_or_below)
     end
   end
 
@@ -865,7 +860,8 @@ class EnergyRatingIndex301Ruleset
                                  interior_adjacent_to: orig_frame_floor.interior_adjacent_to,
                                  area: orig_frame_floor.area,
                                  insulation_id: orig_frame_floor.insulation_id,
-                                 insulation_assembly_r_value: orig_frame_floor.insulation_assembly_r_value)
+                                 insulation_assembly_r_value: orig_frame_floor.insulation_assembly_r_value,
+                                 other_space_above_or_below: orig_frame_floor.other_space_above_or_below)
     end
   end
 

--- a/rulesets/301EnergyRatingIndexRuleset/resources/301validator.rb
+++ b/rulesets/301EnergyRatingIndexRuleset/resources/301validator.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'oga'
-
 class EnergyRatingIndex301Validator
   def self.run_validator(hpxml_doc)
     # A hash of hashes that defines the XML elements used by the ERI HPXML Use Case.
@@ -197,13 +195,18 @@ class EnergyRatingIndex301Validator
       # [FrameFloor]
       '/HPXML/Building/BuildingDetails/Enclosure/FrameFloors/FrameFloor' => {
         'SystemIdentifier' => one, # Required by HPXML schema
-        'ExteriorAdjacentTo[text()="outside" or text()="attic - vented" or text()="attic - unvented" or text()="basement - conditioned" or text()="basement - unconditioned" or text()="crawlspace - vented" or text()="crawlspace - unvented" or text()="garage" or text()="other housing unit above" or text()="other housing unit below"]' => one,
+        'ExteriorAdjacentTo[text()="outside" or text()="attic - vented" or text()="attic - unvented" or text()="basement - conditioned" or text()="basement - unconditioned" or text()="crawlspace - vented" or text()="crawlspace - unvented" or text()="garage" or text()="other housing unit"]' => one, # See [FrameFloorAdjacentToOther]
         'InteriorAdjacentTo[text()="living space" or text()="attic - vented" or text()="attic - unvented" or text()="basement - conditioned" or text()="basement - unconditioned" or text()="crawlspace - vented" or text()="crawlspace - unvented" or text()="garage"]' => one,
         'Area' => one,
         'Insulation/SystemIdentifier' => one, # Required by HPXML schema
         'Insulation/AssemblyEffectiveRValue' => one,
       },
 
+      ## [FrameFloorAdjacentToOther]
+      '/HPXML/Building/BuildingDetails/Enclosure/FrameFloors/FrameFloor[ExteriorAdjacentTo[text()="other housing unit" or text()="other heated space" or text()="other multifamily buffer space" or text()="other non-freezing space"]]' => {
+        'extension/OtherSpaceAboveOrBelow[text()="above" or text()="below"]' => one,
+      },
+      
       # [Slab]
       '/HPXML/Building/BuildingDetails/Enclosure/Slabs/Slab' => {
         'SystemIdentifier' => one, # Required by HPXML schema

--- a/rulesets/301EnergyRatingIndexRuleset/resources/301validator.rb
+++ b/rulesets/301EnergyRatingIndexRuleset/resources/301validator.rb
@@ -206,7 +206,7 @@ class EnergyRatingIndex301Validator
       '/HPXML/Building/BuildingDetails/Enclosure/FrameFloors/FrameFloor[ExteriorAdjacentTo[text()="other housing unit" or text()="other heated space" or text()="other multifamily buffer space" or text()="other non-freezing space"]]' => {
         'extension/OtherSpaceAboveOrBelow[text()="above" or text()="below"]' => one,
       },
-      
+
       # [Slab]
       '/HPXML/Building/BuildingDetails/Enclosure/Slabs/Slab' => {
         'SystemIdentifier' => one, # Required by HPXML schema

--- a/tasks.rb
+++ b/tasks.rb
@@ -1201,6 +1201,7 @@ def create_sample_hpxmls
                   'base-hvac-wall-furnace-wood-only.xml',
                   'base-location-epw-filepath-AMY-2012.xml',
                   'base-mechvent-bath-kitchen-fans.xml',
+                  'base-mechvent-cfis-dse.xml',
                   'base-mechvent-cfis-evap-cooler-only-ducted.xml',
                   'base-mechvent-exhaust-rated-flow-rate.xml',
                   'base-misc-defaults.xml',

--- a/tasks.rb
+++ b/tasks.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 def create_test_hpxmls
-  require_relative 'hpxml-measures/HPXMLtoOpenStudio/resources/hpxml'
-  require_relative 'hpxml-measures/HPXMLtoOpenStudio/resources/hotwater_appliances'
-  require_relative 'hpxml-measures/HPXMLtoOpenStudio/resources/lighting'
-
   this_dir = File.dirname(__FILE__)
   tests_dir = File.join(this_dir, 'workflow/tests')
 
@@ -1094,8 +1090,6 @@ def get_eri_version(hpxml)
 end
 
 def create_sample_hpxmls
-  require_relative 'hpxml-measures/HPXMLtoOpenStudio/resources/constants'
-
   # Copy sample files from hpxml-measures subtree
   puts 'Copying sample files...'
   FileUtils.rm_f(Dir.glob('workflow/sample_files/*.xml'))
@@ -1353,7 +1347,12 @@ if ARGV[0].to_sym == :update_version
 end
 
 if ARGV[0].to_sym == :update_measures
+  require 'oga'
+  require_relative 'hpxml-measures/HPXMLtoOpenStudio/resources/constants'
+  require_relative 'hpxml-measures/HPXMLtoOpenStudio/resources/hotwater_appliances'
   require_relative 'hpxml-measures/HPXMLtoOpenStudio/resources/hpxml'
+  require_relative 'hpxml-measures/HPXMLtoOpenStudio/resources/lighting'
+  require_relative 'hpxml-measures/HPXMLtoOpenStudio/resources/xmlhelper'
 
   # Prevent NREL error regarding U: drive when not VPNed in
   ENV['HOME'] = 'C:' if !ENV['HOME'].nil? && ENV['HOME'].start_with?('U:')

--- a/workflow/energy_rating_index.rb
+++ b/workflow/energy_rating_index.rb
@@ -10,6 +10,7 @@ require 'csv'
 require 'pathname'
 require 'fileutils'
 require 'parallel'
+require 'oga'
 require File.join(File.dirname(__FILE__), 'design.rb')
 require_relative '../hpxml-measures/HPXMLtoOpenStudio/resources/constants'
 require_relative '../hpxml-measures/HPXMLtoOpenStudio/resources/hpxml'

--- a/workflow/energy_rating_index.rb
+++ b/workflow/energy_rating_index.rb
@@ -467,6 +467,9 @@ end
 
 def cache_weather
   # Process all epw files through weather.rb and serialize objects
+  require_relative '../hpxml-measures/HPXMLtoOpenStudio/resources/materials'
+  require_relative '../hpxml-measures/HPXMLtoOpenStudio/resources/psychrometrics'
+  require_relative '../hpxml-measures/HPXMLtoOpenStudio/resources/unit_conversions'
   require_relative '../hpxml-measures/HPXMLtoOpenStudio/resources/weather'
 
   # OpenStudio::Logger.instance.standardOutLogger.setLogLevel(OpenStudio::Fatal)

--- a/workflow/sample_files/base-appliances-gas.xml
+++ b/workflow/sample_files/base-appliances-gas.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-appliances-modified.xml
+++ b/workflow/sample_files/base-appliances-modified.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-appliances-oil.xml
+++ b/workflow/sample_files/base-appliances-oil.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-appliances-propane.xml
+++ b/workflow/sample_files/base-appliances-propane.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-atticroof-cathedral.xml
+++ b/workflow/sample_files/base-atticroof-cathedral.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-atticroof-conditioned.xml
+++ b/workflow/sample_files/base-atticroof-conditioned.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-atticroof-flat.xml
+++ b/workflow/sample_files/base-atticroof-flat.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-atticroof-radiant-barrier.xml
+++ b/workflow/sample_files/base-atticroof-radiant-barrier.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-atticroof-unvented-insulated-roof.xml
+++ b/workflow/sample_files/base-atticroof-unvented-insulated-roof.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-atticroof-vented.xml
+++ b/workflow/sample_files/base-atticroof-vented.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-combi-tankless.xml
+++ b/workflow/sample_files/base-dhw-combi-tankless.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-desuperheater-hpwh.xml
+++ b/workflow/sample_files/base-dhw-desuperheater-hpwh.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-desuperheater.xml
+++ b/workflow/sample_files/base-dhw-desuperheater.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-dwhr.xml
+++ b/workflow/sample_files/base-dhw-dwhr.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-indirect-dse.xml
+++ b/workflow/sample_files/base-dhw-indirect-dse.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-indirect-standbyloss.xml
+++ b/workflow/sample_files/base-dhw-indirect-standbyloss.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-indirect.xml
+++ b/workflow/sample_files/base-dhw-indirect.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-jacket-gas.xml
+++ b/workflow/sample_files/base-dhw-jacket-gas.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-low-flow-fixtures.xml
+++ b/workflow/sample_files/base-dhw-low-flow-fixtures.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-multiple.xml
+++ b/workflow/sample_files/base-dhw-multiple.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-none.xml
+++ b/workflow/sample_files/base-dhw-none.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-recirc-demand.xml
+++ b/workflow/sample_files/base-dhw-recirc-demand.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-recirc-manual.xml
+++ b/workflow/sample_files/base-dhw-recirc-manual.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-recirc-nocontrol.xml
+++ b/workflow/sample_files/base-dhw-recirc-nocontrol.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-recirc-temperature.xml
+++ b/workflow/sample_files/base-dhw-recirc-temperature.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-recirc-timer.xml
+++ b/workflow/sample_files/base-dhw-recirc-timer.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-solar-direct-evacuated-tube.xml
+++ b/workflow/sample_files/base-dhw-solar-direct-evacuated-tube.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-solar-direct-flat-plate.xml
+++ b/workflow/sample_files/base-dhw-solar-direct-flat-plate.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-solar-direct-ics.xml
+++ b/workflow/sample_files/base-dhw-solar-direct-ics.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-solar-fraction.xml
+++ b/workflow/sample_files/base-dhw-solar-fraction.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-solar-indirect-flat-plate.xml
+++ b/workflow/sample_files/base-dhw-solar-indirect-flat-plate.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-solar-thermosyphon-flat-plate.xml
+++ b/workflow/sample_files/base-dhw-solar-thermosyphon-flat-plate.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-tank-gas.xml
+++ b/workflow/sample_files/base-dhw-tank-gas.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-tank-heat-pump.xml
+++ b/workflow/sample_files/base-dhw-tank-heat-pump.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-tank-oil.xml
+++ b/workflow/sample_files/base-dhw-tank-oil.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-tank-propane.xml
+++ b/workflow/sample_files/base-dhw-tank-propane.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-tankless-electric.xml
+++ b/workflow/sample_files/base-dhw-tankless-electric.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-tankless-gas.xml
+++ b/workflow/sample_files/base-dhw-tankless-gas.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-tankless-oil.xml
+++ b/workflow/sample_files/base-dhw-tankless-oil.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-tankless-propane.xml
+++ b/workflow/sample_files/base-dhw-tankless-propane.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-dhw-uef.xml
+++ b/workflow/sample_files/base-dhw-uef.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-enclosure-2stories-garage.xml
+++ b/workflow/sample_files/base-enclosure-2stories-garage.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-enclosure-2stories.xml
+++ b/workflow/sample_files/base-enclosure-2stories.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-enclosure-beds-1.xml
+++ b/workflow/sample_files/base-enclosure-beds-1.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-enclosure-beds-2.xml
+++ b/workflow/sample_files/base-enclosure-beds-2.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-enclosure-beds-4.xml
+++ b/workflow/sample_files/base-enclosure-beds-4.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-enclosure-beds-5.xml
+++ b/workflow/sample_files/base-enclosure-beds-5.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-enclosure-garage.xml
+++ b/workflow/sample_files/base-enclosure-garage.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-enclosure-infil-cfm50.xml
+++ b/workflow/sample_files/base-enclosure-infil-cfm50.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-enclosure-infil-natural-ach.xml
+++ b/workflow/sample_files/base-enclosure-infil-natural-ach.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-enclosure-overhangs.xml
+++ b/workflow/sample_files/base-enclosure-overhangs.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-enclosure-skylights.xml
+++ b/workflow/sample_files/base-enclosure-skylights.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-enclosure-split-surfaces.xml
+++ b/workflow/sample_files/base-enclosure-split-surfaces.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-enclosure-walltypes.xml
+++ b/workflow/sample_files/base-enclosure-walltypes.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-foundation-ambient.xml
+++ b/workflow/sample_files/base-foundation-ambient.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-foundation-conditioned-basement-slab-insulation.xml
+++ b/workflow/sample_files/base-foundation-conditioned-basement-slab-insulation.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-foundation-conditioned-basement-wall-interior-insulation.xml
+++ b/workflow/sample_files/base-foundation-conditioned-basement-wall-interior-insulation.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-foundation-multiple.xml
+++ b/workflow/sample_files/base-foundation-multiple.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-foundation-slab.xml
+++ b/workflow/sample_files/base-foundation-slab.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-foundation-unconditioned-basement-above-grade.xml
+++ b/workflow/sample_files/base-foundation-unconditioned-basement-above-grade.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-foundation-unconditioned-basement-assembly-r.xml
+++ b/workflow/sample_files/base-foundation-unconditioned-basement-assembly-r.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-foundation-unconditioned-basement-wall-insulation.xml
+++ b/workflow/sample_files/base-foundation-unconditioned-basement-wall-insulation.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-foundation-unconditioned-basement.xml
+++ b/workflow/sample_files/base-foundation-unconditioned-basement.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-foundation-unvented-crawlspace.xml
+++ b/workflow/sample_files/base-foundation-unvented-crawlspace.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-foundation-vented-crawlspace.xml
+++ b/workflow/sample_files/base-foundation-vented-crawlspace.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-foundation-walkout-basement.xml
+++ b/workflow/sample_files/base-foundation-walkout-basement.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-air-to-air-heat-pump-1-speed.xml
+++ b/workflow/sample_files/base-hvac-air-to-air-heat-pump-1-speed.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-air-to-air-heat-pump-2-speed.xml
+++ b/workflow/sample_files/base-hvac-air-to-air-heat-pump-2-speed.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-air-to-air-heat-pump-var-speed.xml
+++ b/workflow/sample_files/base-hvac-air-to-air-heat-pump-var-speed.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-boiler-elec-only.xml
+++ b/workflow/sample_files/base-hvac-boiler-elec-only.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-boiler-gas-central-ac-1-speed.xml
+++ b/workflow/sample_files/base-hvac-boiler-gas-central-ac-1-speed.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-boiler-gas-only.xml
+++ b/workflow/sample_files/base-hvac-boiler-gas-only.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-boiler-oil-only.xml
+++ b/workflow/sample_files/base-hvac-boiler-oil-only.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-boiler-propane-only.xml
+++ b/workflow/sample_files/base-hvac-boiler-propane-only.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-central-ac-only-1-speed.xml
+++ b/workflow/sample_files/base-hvac-central-ac-only-1-speed.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-central-ac-only-2-speed.xml
+++ b/workflow/sample_files/base-hvac-central-ac-only-2-speed.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-central-ac-only-var-speed.xml
+++ b/workflow/sample_files/base-hvac-central-ac-only-var-speed.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-dse.xml
+++ b/workflow/sample_files/base-hvac-dse.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-1-speed-electric.xml
+++ b/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-1-speed-electric.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-1-speed.xml
+++ b/workflow/sample_files/base-hvac-dual-fuel-air-to-air-heat-pump-1-speed.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-ducts-leakage-exemption.xml
+++ b/workflow/sample_files/base-hvac-ducts-leakage-exemption.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-ducts-leakage-total.xml
+++ b/workflow/sample_files/base-hvac-ducts-leakage-total.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-elec-resistance-only.xml
+++ b/workflow/sample_files/base-hvac-elec-resistance-only.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-evap-cooler-furnace-gas.xml
+++ b/workflow/sample_files/base-hvac-evap-cooler-furnace-gas.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-evap-cooler-only-ducted.xml
+++ b/workflow/sample_files/base-hvac-evap-cooler-only-ducted.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-evap-cooler-only.xml
+++ b/workflow/sample_files/base-hvac-evap-cooler-only.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-furnace-elec-central-ac-1-speed.xml
+++ b/workflow/sample_files/base-hvac-furnace-elec-central-ac-1-speed.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-furnace-elec-only.xml
+++ b/workflow/sample_files/base-hvac-furnace-elec-only.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-furnace-gas-central-ac-2-speed.xml
+++ b/workflow/sample_files/base-hvac-furnace-gas-central-ac-2-speed.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-furnace-gas-central-ac-var-speed.xml
+++ b/workflow/sample_files/base-hvac-furnace-gas-central-ac-var-speed.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-furnace-gas-only.xml
+++ b/workflow/sample_files/base-hvac-furnace-gas-only.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-furnace-gas-room-ac.xml
+++ b/workflow/sample_files/base-hvac-furnace-gas-room-ac.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-furnace-oil-only.xml
+++ b/workflow/sample_files/base-hvac-furnace-oil-only.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-furnace-propane-only.xml
+++ b/workflow/sample_files/base-hvac-furnace-propane-only.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-ground-to-air-heat-pump.xml
+++ b/workflow/sample_files/base-hvac-ground-to-air-heat-pump.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-mini-split-heat-pump-ducted-cooling-only.xml
+++ b/workflow/sample_files/base-hvac-mini-split-heat-pump-ducted-cooling-only.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-mini-split-heat-pump-ducted-heating-only.xml
+++ b/workflow/sample_files/base-hvac-mini-split-heat-pump-ducted-heating-only.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-mini-split-heat-pump-ducted.xml
+++ b/workflow/sample_files/base-hvac-mini-split-heat-pump-ducted.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-mini-split-heat-pump-ductless.xml
+++ b/workflow/sample_files/base-hvac-mini-split-heat-pump-ductless.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-multiple.xml
+++ b/workflow/sample_files/base-hvac-multiple.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-multiple2.xml
+++ b/workflow/sample_files/base-hvac-multiple2.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-none-no-fuel-access.xml
+++ b/workflow/sample_files/base-hvac-none-no-fuel-access.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
           </FuelTypesAvailable>

--- a/workflow/sample_files/base-hvac-none.xml
+++ b/workflow/sample_files/base-hvac-none.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-programmable-thermostat.xml
+++ b/workflow/sample_files/base-hvac-programmable-thermostat.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-room-ac-only-33percent.xml
+++ b/workflow/sample_files/base-hvac-room-ac-only-33percent.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-room-ac-only.xml
+++ b/workflow/sample_files/base-hvac-room-ac-only.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-setpoints.xml
+++ b/workflow/sample_files/base-hvac-setpoints.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-stove-oil-only.xml
+++ b/workflow/sample_files/base-hvac-stove-oil-only.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-wall-furnace-elec-only.xml
+++ b/workflow/sample_files/base-hvac-wall-furnace-elec-only.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-hvac-wall-furnace-propane-only.xml
+++ b/workflow/sample_files/base-hvac-wall-furnace-propane-only.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-location-baltimore-md.xml
+++ b/workflow/sample_files/base-location-baltimore-md.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-location-dallas-tx.xml
+++ b/workflow/sample_files/base-location-dallas-tx.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-location-duluth-mn.xml
+++ b/workflow/sample_files/base-location-duluth-mn.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-location-epw-filepath.xml
+++ b/workflow/sample_files/base-location-epw-filepath.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-location-miami-fl.xml
+++ b/workflow/sample_files/base-location-miami-fl.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-mechvent-balanced.xml
+++ b/workflow/sample_files/base-mechvent-balanced.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-mechvent-cfis.xml
+++ b/workflow/sample_files/base-mechvent-cfis.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-mechvent-erv-atre-asre.xml
+++ b/workflow/sample_files/base-mechvent-erv-atre-asre.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-mechvent-erv.xml
+++ b/workflow/sample_files/base-mechvent-erv.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-mechvent-exhaust.xml
+++ b/workflow/sample_files/base-mechvent-exhaust.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-mechvent-hrv-asre.xml
+++ b/workflow/sample_files/base-mechvent-hrv-asre.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-mechvent-hrv.xml
+++ b/workflow/sample_files/base-mechvent-hrv.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-mechvent-supply.xml
+++ b/workflow/sample_files/base-mechvent-supply.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-misc-ceiling-fans.xml
+++ b/workflow/sample_files/base-misc-ceiling-fans.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-misc-whole-house-fan.xml
+++ b/workflow/sample_files/base-misc-whole-house-fan.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-pv.xml
+++ b/workflow/sample_files/base-pv.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-version-2014.xml
+++ b/workflow/sample_files/base-version-2014.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-version-2014A.xml
+++ b/workflow/sample_files/base-version-2014A.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-version-2014AD.xml
+++ b/workflow/sample_files/base-version-2014AD.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-version-2014ADE.xml
+++ b/workflow/sample_files/base-version-2014ADE.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-version-2014ADEG.xml
+++ b/workflow/sample_files/base-version-2014ADEG.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base-version-2014ADEGL.xml
+++ b/workflow/sample_files/base-version-2014ADEGL.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/base.xml
+++ b/workflow/sample_files/base.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/invalid_files/dhw-frac-load-served.xml
+++ b/workflow/sample_files/invalid_files/dhw-frac-load-served.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/invalid_files/hvac-ducts-leakage-exemption-pre-addendum-d.xml
+++ b/workflow/sample_files/invalid_files/hvac-ducts-leakage-exemption-pre-addendum-d.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/invalid_files/hvac-ducts-leakage-total-pre-addendum-l.xml
+++ b/workflow/sample_files/invalid_files/hvac-ducts-leakage-total-pre-addendum-l.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/invalid_files/hvac-frac-load-served.xml
+++ b/workflow/sample_files/invalid_files/hvac-frac-load-served.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/invalid_files/invalid-epw-filepath.xml
+++ b/workflow/sample_files/invalid_files/invalid-epw-filepath.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/invalid_files/invalid-wmo.xml
+++ b/workflow/sample_files/invalid_files/invalid-wmo.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/sample_files/invalid_files/missing-elements.xml
+++ b/workflow/sample_files/invalid_files/missing-elements.xml
@@ -24,6 +24,7 @@
     <BuildingDetails>
       <BuildingSummary>
         <Site>
+          <SiteType>suburban</SiteType>
           <FuelTypesAvailable>
             <Fuel>electricity</Fuel>
             <Fuel>natural gas</Fuel>

--- a/workflow/tests/energy_rating_index_test.rb
+++ b/workflow/tests/energy_rating_index_test.rb
@@ -6,13 +6,15 @@ require 'openstudio/ruleset/ShowRunnerOutput'
 require 'minitest/autorun'
 require 'fileutils'
 require 'csv'
-require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/xmlhelper'
+require 'oga'
 require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/constants'
-require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/unit_conversions'
 require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/hotwater_appliances'
+require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/hpxml'
 require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/hvac_sizing'
-require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/misc_loads'
 require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/meta_measure'
+require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/misc_loads'
+require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/unit_conversions'
+require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/xmlhelper'
 
 class EnergyRatingIndexTest < Minitest::Test
   def before_setup


### PR DESCRIPTION
## Pull Request Description

For FrameFloors, removes the "other housing unit above" and "other housing unit below" enumerations. Instead, FrameFloors in MF/attached buildings that are adjacent to "other housing unit" must now have an `extension/OtherSpaceAboveOrBelow` property set to either "above" or "below".

Also includes some runtime performance improvements for all platforms.

Also fixes a workflow error if a home has both a dual-fuel heat pump and an air-source heat pump.

## Checklist

Not all may apply:

- [x] OS-HPXML git subtree has been pulled
- [x] 301validator.rb has been updated (reference EPvalidator.rb)
- [x] Documentation has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
