### PR TITLE
Unrated Heated Space Ref home R-value

### DIFF
--- a/hpxml-measures/HPXMLtoOpenStudio/measure.xml
+++ b/hpxml-measures/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>3c7c0ccd-fed5-446c-be62-2b81d97dd302</version_id>
-  <version_modified>20200620T022320Z</version_modified>
+  <version_id>d54826d8-449e-4b3d-af72-c098713534f5</version_id>
+  <version_modified>20200623T193639Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -522,16 +522,16 @@
       <checksum>818691B8</checksum>
     </file>
     <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>BC595AAD</checksum>
-    </file>
-    <file>
       <filename>hotwater_appliances.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>0587A09F</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>A3FD7ABA</checksum>
     </file>
   </files>
 </measure>

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -1468,7 +1468,7 @@ class HPXML < Object
     end
 
     def is_thermal_boundary
-      HPXML::is_thermal_boundary(self)
+      return HPXML::is_thermal_boundary(self)
     end
 
     def is_exterior_thermal_boundary
@@ -1584,7 +1584,7 @@ class HPXML < Object
     end
 
     def is_thermal_boundary
-      HPXML::is_thermal_boundary(self)
+      return HPXML::is_thermal_boundary(self)
     end
 
     def is_exterior_thermal_boundary
@@ -1719,7 +1719,7 @@ class HPXML < Object
     end
 
     def is_thermal_boundary
-      HPXML::is_thermal_boundary(self)
+      return HPXML::is_thermal_boundary(self)
     end
 
     def is_exterior_thermal_boundary
@@ -1861,7 +1861,7 @@ class HPXML < Object
     end
 
     def is_thermal_boundary
-      HPXML::is_thermal_boundary(self)
+      return HPXML::is_thermal_boundary(self)
     end
 
     def is_exterior_thermal_boundary
@@ -1958,7 +1958,7 @@ class HPXML < Object
     end
 
     def is_thermal_boundary
-      HPXML::is_thermal_boundary(self)
+      return HPXML::is_thermal_boundary(self)
     end
 
     def is_exterior_thermal_boundary
@@ -2093,7 +2093,7 @@ class HPXML < Object
     end
 
     def is_thermal_boundary
-      HPXML::is_thermal_boundary(wall)
+      return HPXML::is_thermal_boundary(wall)
     end
 
     def is_exterior_thermal_boundary
@@ -2218,7 +2218,7 @@ class HPXML < Object
     end
 
     def is_thermal_boundary
-      HPXML::is_thermal_boundary(roof)
+      return HPXML::is_thermal_boundary(roof)
     end
 
     def is_exterior_thermal_boundary
@@ -2318,7 +2318,7 @@ class HPXML < Object
     end
 
     def is_thermal_boundary
-      HPXML::is_thermal_boundary(wall)
+      return HPXML::is_thermal_boundary(wall)
     end
 
     def is_exterior_thermal_boundary
@@ -4723,15 +4723,13 @@ class HPXML < Object
     # Note: Insulated foundation walls of, e.g., unconditioned spaces return false.
     def self.is_adjacent_to_conditioned(adjacent_to)
       if [HPXML::LocationLivingSpace,
-          HPXML::LocationBasementConditioned].include? adjacent_to
+          HPXML::LocationBasementConditioned,
+          HPXML::LocationOtherHousingUnit,
+          HPXML::LocationOtherHeatedSpace].include? adjacent_to
         return true
+      else
+        return false
       end
-
-      return false
-    end
-
-    if surface.exterior_adjacent_to == HPXML::LocationOtherHousingUnit
-      return false # adiabatic
     end
 
     interior_conditioned = is_adjacent_to_conditioned(surface.interior_adjacent_to)

--- a/rulesets/301EnergyRatingIndexRuleset/tests/test_enclosure.rb
+++ b/rulesets/301EnergyRatingIndexRuleset/tests/test_enclosure.rb
@@ -297,23 +297,47 @@ class ERIEnclosureTest < MiniTest::Test
     hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentReferenceHome)
     _check_walls(hpxml, 2355.52, 16.67, 0.75, 0.9)
 
-    hpxml_name = 'base-enclosure-other-housing-unit.xml'
+    hpxml_names = ['base-enclosure-other-housing-unit.xml',
+                   'base-enclosure-other-heated-space.xml']
 
-    # Rated Home
-    hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIRatedHome)
-    _check_walls(hpxml, 1200, (23.0 * 420 + 4.0 * 780) / 1200, 0.7, 0.92)
+    hpxml_names.each do |hpxml_name|
+      # Rated Home
+      hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIRatedHome)
+      _check_walls(hpxml, 1200, (23.0 * 420 + 4.0 * 780) / 1200, 0.7, 0.92)
 
-    # Reference Home
-    hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIReferenceHome)
-    _check_walls(hpxml, 1200, (16.67 * 420 + 4.0 * 780) / 1200, 0.75, 0.9)
+      # Reference Home
+      hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIReferenceHome)
+      _check_walls(hpxml, 1200, (16.67 * 420 + 4.0 * 780) / 1200, 0.75, 0.9)
 
-    # IAD Home
-    hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentDesign)
-    _check_walls(hpxml, 2355.52, 23.0, 0.7, 0.92)
+      # IAD Home
+      hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentDesign)
+      _check_walls(hpxml, 2355.52, 23.0, 0.7, 0.92)
 
-    # IAD Reference Home
-    hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentReferenceHome)
-    _check_walls(hpxml, 2355.52, 16.67, 0.75, 0.9)
+      # IAD Reference Home
+      hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentReferenceHome)
+      _check_walls(hpxml, 2355.52, 16.67, 0.75, 0.9)
+    end
+
+    hpxml_names = ['base-enclosure-other-multifamily-buffer-space.xml',
+                   'base-enclosure-other-non-freezing-space.xml']
+
+    hpxml_names.each do |hpxml_name|
+      # Rated Home
+      hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIRatedHome)
+      _check_walls(hpxml, 1200, 23.0, 0.7, 0.92)
+
+      # Reference Home
+      hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIReferenceHome)
+      _check_walls(hpxml, 1200, 16.67, 0.75, 0.9)
+
+      # IAD Home
+      hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentDesign)
+      _check_walls(hpxml, 2355.52, 23.0, 0.7, 0.92)
+
+      # IAD Reference Home
+      hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentReferenceHome)
+      _check_walls(hpxml, 2355.52, 16.67, 0.75, 0.9)
+    end
 
     hpxml_name = 'base-enclosure-garage.xml'
 
@@ -557,6 +581,50 @@ class ERIEnclosureTest < MiniTest::Test
     # IAD Reference Home
     hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentReferenceHome)
     _check_floors(hpxml, 2400, (33.33 * 1200 + 30.3 * 1200) / 2400)
+
+    hpxml_names = ['base-enclosure-other-housing-unit.xml',
+                   'base-enclosure-other-heated-space.xml']
+
+    hpxml_names.each do |hpxml_name|
+      # Rated Home
+      hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIRatedHome)
+      _check_floors(hpxml, 2700, 2.1)
+
+      # Reference Home
+      hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIReferenceHome)
+      _check_floors(hpxml, 2700, 2.1)
+
+      # IAD Home
+      hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentDesign)
+      _check_floors(hpxml, 2400, (2.1 * 1200 + 30.3 * 1200) / 2400)
+
+      # IAD Reference Home
+      hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentReferenceHome)
+      _check_floors(hpxml, 2400, (2.1 * 1200 + 30.3 * 1200) / 2400)
+    end
+
+    hpxml_names = ['base-enclosure-other-multifamily-buffer-space.xml',
+                   'base-enclosure-other-non-freezing-space.xml']
+
+    hpxml_names.each do |hpxml_name|
+      # Rated Home
+      hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIRatedHome)
+      _check_floors(hpxml, 2700, 18.7)
+
+      # Reference Home
+      hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIReferenceHome)
+      _check_floors(hpxml, 2700, (33.33 * 1350 + 30.3 * 1350) / 2700)
+
+      # IAD Home
+      hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentDesign)
+      puts hpxml.frame_floors.to_s
+      _check_floors(hpxml, 2400, (18.7 * 1200 + 30.3 * 1200) / 2400)
+
+      # IAD Reference Home
+      hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentReferenceHome)
+      puts hpxml.frame_floors.to_s
+      _check_floors(hpxml, 2400, (33.3 * 1200 + 30.3 * 1200) / 2400)
+    end
   end
 
   def test_enclosure_slabs


### PR DESCRIPTION
## Pull Request Description

Exclude surfaces between conditioned space and Unrated Heated Space from Table 4.2.2(2) insulation values.

## Checklist

Not all may apply:

- [ ] OS-HPXML git subtree has been pulled
- [ ] 301 ruleset and unit tests have been updated
- [ ] 301validator.rb has been updated (reference EPvalidator.rb)
- [ ] Workflow tests have been updated
- [ ] Documentation has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
