### PR TITLE
More misc HVAC

### DIFF
--- a/docs/source/software_connection.rst
+++ b/docs/source/software_connection.rst
@@ -277,17 +277,18 @@ PortableHeater                                                                  
 Fireplace                                                                               <any>              Percent                  (required)
 ==================  ==============  ==================================================  =================  =======================  ===============
 
-For shared boilers (i.e., serving multiple dwelling units), additional elements are required:
+For all systems, the ``ElectricAuxiliaryEnergy`` element may be provided if available.
+For shared boilers (i.e., serving multiple dwelling units), the electric auxiliary energy can alternatively be calculated using the following inputs:
 
-- ``NumberofUnitsServed``: Number of units served by the shared system
 - ``extension/SharedLoopWatts``: Shared pump power [W]
+- ``NumberofUnitsServed``: Number of units served by the shared system
 - ``extension/FanCoilWatts``: In-unit fan coil power [W]
 
-For shared boilers connected to a water loop heat pump, additional elements are required:
+If electric auxiliary energy is not provided (nor calculated for shared boilers), it is defaulted per `ANSI/RESNET/ICC 301-2019 <https://codes.iccsafe.org/content/RESNETICC3012019>`_.
 
-- ``extension/WaterLoopHeatPump/AnnualHeatingEfficiency[Units="COP"]/Value``: WLHP heating efficiency
+For shared boilers connected to a water loop heat pump, an additional element is required:
 
-For non-shared systems, the ``ElectricAuxiliaryEnergy`` element may be provided if available.
+- ``extension/WaterLoopHeatPump/AnnualHeatingEfficiency[Units="COP"]/Value``: WLHP rated heating efficiency
 
 HPXML Cooling Systems
 *********************
@@ -326,14 +327,14 @@ For shared chillers connected to a fan coil, additional elements are required:
 For shared chillers connected to a water loop heat pump, additional elements are required:
 
 - ``extension/WaterLoopHeatPump/CoolingCapacity``: WLHP cooling capacity [Btu/hr]
-- ``extension/WaterLoopHeatPump/AnnualCoolingEfficiency[Units="EER"]/Value``: WLHP cooling efficiency
+- ``extension/WaterLoopHeatPump/AnnualCoolingEfficiency[Units="EER"]/Value``: WLHP rated cooling efficiency
 
 For shared cooling towers (which must always be connected to a water loop heat pump), additional elements are required:
 
 - ``NumberofUnitsServed``: Number of units served by the shared system
 - ``extension/SharedLoopWatts``: Total of the pumping and fan power serving the system [W]
 - ``extension/WaterLoopHeatPump/CoolingCapacity``: WLHP cooling capacity [Btu/hr]
-- ``extension/WaterLoopHeatPump/AnnualCoolingEfficiency[Units="EER"]/Value``: WLHP cooling efficiency
+- ``extension/WaterLoopHeatPump/AnnualCoolingEfficiency[Units="EER"]/Value``: WLHP rated cooling efficiency
 
 HPXML Heat Pumps
 ****************
@@ -352,6 +353,10 @@ mini-split                     AirDistribution or DSE (optional)  electricity   
 ground-to-air  false           AirDistribution or DSE             electricity   EER                      COP                      (optional)
 ground-to-air  true            AirDistribution or DSE             electricity   EER                      COP                      (optional)
 =============  ==============  =================================  ============  =======================  =======================  ===========================  ==================
+
+Ground-to-air heat pumps also have an additional input:
+
+- ``extension/PumpPowerWattsPerTon``: Ground loop circulator pump power during operation of the heat pump in Watts/ton of cooling capacity.
 
 Air-to-air heat pumps can also have the ``CompressorType`` specified; if not provided, it is assumed as follows:
 

--- a/hpxml-measures/HPXMLtoOpenStudio/measure.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/measure.rb
@@ -297,7 +297,7 @@ class OSModel
 
     add_airflow(runner, model, weather, spaces)
     add_hvac_sizing(runner, model, weather, spaces)
-    add_fuel_heating_eae(runner, model)
+    add_furnace_eae(runner, model)
     add_photovoltaics(runner, model)
     add_additional_properties(runner, model, hpxml_path)
     add_component_loads_output(runner, model, spaces)
@@ -2512,13 +2512,13 @@ class OSModel
     HVACSizing.apply(model, runner, weather, spaces, @hpxml, @infil_volume, @nbeds, @min_neighbor_distance, @debug)
   end
 
-  def self.add_fuel_heating_eae(runner, model)
+  def self.add_furnace_eae(runner, model)
     # Needs to come after HVAC sizing (needs heating capacity and airflow rate)
     # FUTURE: Could remove this method and simplify everything if we could autosize via the HPXML file
 
     @hpxml.heating_systems.each do |heating_system|
       next unless heating_system.fraction_heat_load_served > 0
-      next unless [HPXML::HVACTypeFurnace, HPXML::HVACTypeWallFurnace, HPXML::HVACTypeFloorFurnace, HPXML::HVACTypeStove, HPXML::HVACTypeBoiler].include? heating_system.heating_system_type
+      next unless [HPXML::HVACTypeFurnace, HPXML::HVACTypeWallFurnace, HPXML::HVACTypeFloorFurnace, HPXML::HVACTypeStove].include? heating_system.heating_system_type
       next unless heating_system.heating_system_fuel != HPXML::FuelTypeElectricity
 
       HVAC.apply_eae_to_heating_fan(runner, @hvac_map[heating_system.id], heating_system)

--- a/hpxml-measures/HPXMLtoOpenStudio/measure.xml
+++ b/hpxml-measures/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>4ac6b2e0-1631-49e9-ab54-45e7b33c059c</version_id>
-  <version_modified>20200831T213407Z</version_modified>
+  <version_id>a63a155f-1672-46b5-918b-3c2744f7a22b</version_id>
+  <version_modified>20200901T150344Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -546,12 +546,6 @@
       <checksum>3968B0E8</checksum>
     </file>
     <file>
-      <filename>hpxml_defaults.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>1AB9B048</checksum>
-    </file>
-    <file>
       <filename>test_defaults.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -564,10 +558,16 @@
       <checksum>BEFA5E91</checksum>
     </file>
     <file>
+      <filename>hpxml_defaults.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>5F8FAC88</checksum>
+    </file>
+    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>EDEAC065</checksum>
+      <checksum>2B46B197</checksum>
     </file>
   </files>
 </measure>

--- a/hpxml-measures/HPXMLtoOpenStudio/measure.xml
+++ b/hpxml-measures/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>89ca7a91-ca10-4db6-83d8-ffda184a2754</version_id>
-  <version_modified>20200831T202509Z</version_modified>
+  <version_id>4ac6b2e0-1631-49e9-ab54-45e7b33c059c</version_id>
+  <version_modified>20200831T213407Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -567,7 +567,7 @@
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>2B569EB3</checksum>
+      <checksum>EDEAC065</checksum>
     </file>
   </files>
 </measure>

--- a/hpxml-measures/HPXMLtoOpenStudio/measure.xml
+++ b/hpxml-measures/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>a63a155f-1672-46b5-918b-3c2744f7a22b</version_id>
-  <version_modified>20200901T150344Z</version_modified>
+  <version_id>f8a70038-32f1-4346-b5b9-6fbac83b5e1a</version_id>
+  <version_modified>20200901T182158Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -546,12 +546,6 @@
       <checksum>3968B0E8</checksum>
     </file>
     <file>
-      <filename>test_defaults.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>2C14CFBD</checksum>
-    </file>
-    <file>
       <filename>EPvalidator.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -568,6 +562,12 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>2B46B197</checksum>
+    </file>
+    <file>
+      <filename>test_defaults.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>9D8FA00F</checksum>
     </file>
   </files>
 </measure>

--- a/hpxml-measures/HPXMLtoOpenStudio/measure.xml
+++ b/hpxml-measures/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>adfcf73d-652f-4926-aea9-123b93f9ceb5</version_id>
-  <version_modified>20200827T201958Z</version_modified>
+  <version_id>89ca7a91-ca10-4db6-83d8-ffda184a2754</version_id>
+  <version_modified>20200831T202509Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -367,12 +367,6 @@
       <checksum>7DAA5F02</checksum>
     </file>
     <file>
-      <filename>schedules.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>830C5D1B</checksum>
-    </file>
-    <file>
       <filename>geometry.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -493,52 +487,16 @@
       <checksum>5C352E25</checksum>
     </file>
     <file>
-      <filename>hpxml_defaults.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>F58F08B9</checksum>
-    </file>
-    <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>248BBC2E</checksum>
-    </file>
-    <file>
       <filename>airflow.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>BC675290</checksum>
     </file>
     <file>
-      <filename>hvac_sizing.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>3AE712A9</checksum>
-    </file>
-    <file>
-      <filename>test_defaults.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>6C302852</checksum>
-    </file>
-    <file>
       <filename>test_hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
       <checksum>AA4E8BA5</checksum>
-    </file>
-    <file>
-      <filename>hvac.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>6454A307</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>971F57E5</checksum>
     </file>
     <file>
       <filename>HPXMLDataTypes.xsd</filename>
@@ -553,6 +511,18 @@
       <checksum>DB4F58D2</checksum>
     </file>
     <file>
+      <filename>schedules.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>A346F8E6</checksum>
+    </file>
+    <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>CF39E025</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.1.1</identifier>
@@ -561,13 +531,43 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>F4CB408B</checksum>
+      <checksum>4B59EB8A</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>2AB9083A</checksum>
+    </file>
+    <file>
+      <filename>hvac_sizing.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>3968B0E8</checksum>
+    </file>
+    <file>
+      <filename>hpxml_defaults.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>1AB9B048</checksum>
+    </file>
+    <file>
+      <filename>test_defaults.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>2C14CFBD</checksum>
     </file>
     <file>
       <filename>EPvalidator.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>4B1D214B</checksum>
+      <checksum>BEFA5E91</checksum>
+    </file>
+    <file>
+      <filename>hvac.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>2B569EB3</checksum>
     </file>
   </files>
 </measure>

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/EPvalidator.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/EPvalidator.rb
@@ -400,12 +400,12 @@ class EnergyPlusValidator
         '../../../../BuildingSummary/BuildingConstruction[ResidentialFacilityType[text()="single-family attached" or text()="apartment unit"]]' => one,
         '../../HVACDistribution[DistributionSystemType/HydronicDistribution[HydronicDistributionType[text()="radiator" or text()="baseboard" or text()="radiant floor" or text()="radiant ceiling"]] | DistributionSystemType/HydronicAndAirDistribution[HydronicAndAirDistributionType[text()="fan coil" or text()="water loop heat pump"]]]' => one, # See [HVACDistribution] or [SharedBoilerType=FanCoil] or [SharedBoilerType=WLHP]
         'NumberofUnitsServed' => one,
-        'extension/SharedLoopWatts' => one,
+        'ElectricAuxiliaryEnergy | extension/SharedLoopWatts' => zero_or_one,
       },
 
       ## [SharedBoilerType=FanCoil]
       '/HPXML/Building/BuildingDetails/Systems/HVAC/HVACPlant/HeatingSystem[HeatingSystemType/Boiler and IsSharedSystem="true" and //HydronicAndAirDistributionType[text()="fan coil"]]' => {
-        'extension/FanCoilWatts' => one,
+        'ElectricAuxiliaryEnergy | extension/FanCoilWatts' => zero_or_one,
       },
 
       ## [SharedBoilerType=WLHP]
@@ -569,6 +569,8 @@ class EnergyPlusValidator
         'BackupHeatingSwitchoverTemperature' => zero,
         'AnnualCoolingEfficiency[Units="EER"]/Value' => one,
         'AnnualHeatingEfficiency[Units="COP"]/Value' => one,
+        'extension/PumpPowerWattsPerTon' => zero_or_one,
+        'extension/FanPowerWattsPerCFM' => zero_or_one,
       },
 
       ## [GSHPType=SharedLoop]

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/constants.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/constants.rb
@@ -465,6 +465,10 @@ class Constants
     return __method__.to_s
   end
 
+  def self.SizingInfoHVACPumpPower
+    return __method__.to_s
+  end
+
   def self.SizingInfoHVACSystemIsDucted # Only needed for optionally ducted systems
     return __method__.to_s
   end

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -2761,8 +2761,8 @@ class HPXML < Object
              :backup_heating_efficiency_percent, :backup_heating_efficiency_afue,
              :backup_heating_switchover_temp, :fraction_heat_load_served, :fraction_cool_load_served,
              :cooling_efficiency_seer, :cooling_efficiency_eer, :heating_efficiency_hspf,
-             :heating_efficiency_cop, :energy_star, :seed_id, :is_shared_system,
-             :number_of_units_served, :shared_loop_watts]
+             :heating_efficiency_cop, :energy_star, :seed_id, :pump_watts_per_ton, :fan_watts_per_cfm,
+             :is_shared_system, :number_of_units_served, :shared_loop_watts]
     attr_accessor(*ATTRS)
 
     def distribution_system
@@ -2855,8 +2855,10 @@ class HPXML < Object
       end
 
       HPXML::add_extension(parent: heat_pump,
-                           extensions: { 'SeedId' => @seed_id,
-                                         'SharedLoopWatts' => to_float_or_nil(@shared_loop_watts) })
+                           extensions: { 'PumpPowerWattsPerTon' => to_float_or_nil(@pump_watts_per_ton),
+                                         'FanPowerWattsPerCFM' => to_float_or_nil(@fan_watts_per_cfm),
+                                         'SharedLoopWatts' => to_float_or_nil(@shared_loop_watts),
+                                         'SeedId' => @seed_id })
     end
 
     def from_oga(heat_pump)
@@ -2892,6 +2894,8 @@ class HPXML < Object
         @heating_efficiency_cop = to_float_or_nil(XMLHelper.get_value(heat_pump, "AnnualHeatingEfficiency[Units='#{UnitsCOP}']/Value"))
       end
       @energy_star = XMLHelper.get_values(heat_pump, 'ThirdPartyCertification').include?('Energy Star')
+      @pump_watts_per_ton = to_float_or_nil(XMLHelper.get_value(heat_pump, 'extension/PumpPowerWattsPerTon'))
+      @fan_watts_per_cfm = to_float_or_nil(XMLHelper.get_value(heat_pump, 'extension/FanPowerWattsPerCFM'))
       @seed_id = XMLHelper.get_value(heat_pump, 'extension/SeedId')
       @shared_loop_watts = to_float_or_nil(XMLHelper.get_value(heat_pump, 'extension/SharedLoopWatts'))
     end

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
@@ -254,7 +254,7 @@ class HPXMLDefaults
       next unless heating_system.heating_system_type == HPXML::HVACTypeBoiler
       next unless heating_system.electric_auxiliary_energy.nil?
 
-      heating_system.electric_auxiliary_energy = HVAC.get_default_eae(heating_system, nil)
+      heating_system.electric_auxiliary_energy = HVAC.get_electric_auxiliary_energy(heating_system)
     end
 
     # Default AC/HP sensible heat ratio

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/hpxml_defaults.rb
@@ -249,6 +249,14 @@ class HPXMLDefaults
       heat_pump.compressor_type = HVAC.get_default_compressor_type(heat_pump.cooling_efficiency_seer)
     end
 
+    # Default boiler EAE
+    hpxml.heating_systems.each do |heating_system|
+      next unless heating_system.heating_system_type == HPXML::HVACTypeBoiler
+      next unless heating_system.electric_auxiliary_energy.nil?
+
+      heating_system.electric_auxiliary_energy = HVAC.get_default_eae(heating_system, nil)
+    end
+
     # Default AC/HP sensible heat ratio
     hpxml.cooling_systems.each do |cooling_system|
       next unless cooling_system.cooling_shr.nil?
@@ -282,6 +290,18 @@ class HPXMLDefaults
         heat_pump.cooling_shr = 0.73
       elsif heat_pump.heat_pump_type == HPXML::HVACTypeHeatPumpGroundToAir
         heat_pump.cooling_shr = 0.732
+      end
+    end
+
+    # Default GSHP pump/fan power
+    hpxml.heat_pumps.each do |heat_pump|
+      next unless heat_pump.heat_pump_type == HPXML::HVACTypeHeatPumpGroundToAir
+
+      if heat_pump.fan_watts_per_cfm.nil?
+        heat_pump.fan_watts_per_cfm = HVAC.get_default_gshp_fan_power()
+      end
+      if heat_pump.pump_watts_per_ton.nil?
+        heat_pump.pump_watts_per_ton = HVAC.get_default_gshp_pump_power()
       end
     end
 

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/hvac.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/hvac.rb
@@ -1568,7 +1568,7 @@ class HVAC
       if eae.nil?
         htg_coil = unitary_system.heatingCoil.get.to_CoilHeatingGas.get
         htg_capacity = UnitConversions.convert(htg_coil.nominalCapacity.get, 'W', 'kBtu/hr')
-        eae = get_default_eae(heating_system, htg_capacity)
+        eae = get_electric_auxiliary_energy(heating_system, htg_capacity)
       end
       elec_power = eae / 2.08 # W
 
@@ -2066,12 +2066,14 @@ class HVAC
     return ef_input, water_removal_rate_input
   end
 
-  def self.get_default_eae(heating_system, furnace_capacity_kbtuh)
-    # From ANSI/RESNET/ICC 301-2019 Standard
+  def self.get_electric_auxiliary_energy(heating_system, furnace_capacity_kbtuh = nil)
+    # Get boiler/furnace EAE
+
     if not heating_system.electric_auxiliary_energy.nil?
       return heating_system.electric_auxiliary_energy
     end
 
+    # From ANSI/RESNET/ICC 301-2019 Standard
     fuel = heating_system.heating_system_fuel
 
     if heating_system.heating_system_type == HPXML::HVACTypeBoiler
@@ -4297,7 +4299,7 @@ class HVAC
                              fraction_cool_load_served: 0.0)
 
         # Boiler
-        heating_system.electric_auxiliary_energy = get_default_eae(heating_system, nil)
+        heating_system.electric_auxiliary_energy = get_electric_auxiliary_energy(heating_system)
         heating_system.fraction_heat_load_served = fraction_heat_load_served * (1.0 - 1.0 / heating_system.wlhp_heating_efficiency_cop)
         heating_system.distribution_system_idref = "#{heating_system.id}_Baseboard"
         hpxml.hvac_distributions.add(id: heating_system.distribution_system_idref,

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/hvac.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/hvac.rb
@@ -2072,7 +2072,6 @@ class HVAC
       return heating_system.electric_auxiliary_energy
     end
 
-    load_frac = heating_system.fraction_heat_load_served
     fuel = heating_system.heating_system_fuel
 
     if heating_system.heating_system_type == HPXML::HVACTypeBoiler
@@ -2117,8 +2116,7 @@ class HVAC
         end
 
         # ANSI/RESNET/ICC 301-2019 Equation 4.4-5
-        eae = ((sp_kw / n_dweq) + aux_in) * 2080.0
-        return eae * load_frac # kWh/yr
+        return ((sp_kw / n_dweq) + aux_in) * 2080.0 # kWh/yr
 
       else # In-unit boilers
 
@@ -2127,7 +2125,7 @@ class HVAC
             HPXML::FuelTypeElectricity,
             HPXML::FuelTypeWoodCord,
             HPXML::FuelTypeWoodPellets].include? fuel
-          return 170.0 * load_frac # kWh/yr
+          return 170.0 # kWh/yr
         elsif [HPXML::FuelTypeOil,
                HPXML::FuelTypeOil1,
                HPXML::FuelTypeOil2,
@@ -2139,7 +2137,7 @@ class HVAC
                HPXML::FuelTypeCoalAnthracite,
                HPXML::FuelTypeCoalBituminous,
                HPXML::FuelTypeCoke].include? fuel
-          return 330.0 * load_frac # kWh/yr
+          return 330.0 # kWh/yr
         end
 
       end
@@ -2151,7 +2149,7 @@ class HVAC
           HPXML::FuelTypeElectricity,
           HPXML::FuelTypeWoodCord,
           HPXML::FuelTypeWoodPellets].include? fuel
-        return (149.0 + 10.3 * furnace_capacity_kbtuh) * load_frac # kWh/yr
+        return 149.0 + 10.3 * furnace_capacity_kbtuh # kWh/yr
       elsif [HPXML::FuelTypeOil,
              HPXML::FuelTypeOil1,
              HPXML::FuelTypeOil2,
@@ -2163,7 +2161,7 @@ class HVAC
              HPXML::FuelTypeCoalAnthracite,
              HPXML::FuelTypeCoalBituminous,
              HPXML::FuelTypeCoke].include? fuel
-        return (439.0 + 5.5 * furnace_capacity_kbtuh) * load_frac # kWh/yr
+        return 439.0 + 5.5 * furnace_capacity_kbtuh # kWh/yr
       end
 
     end

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/hvac.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/hvac.rb
@@ -757,8 +757,6 @@ class HVAC
     fluid_type = Constants.FluidPropyleneGlycol
     frac_glycol = 0.3
     design_delta_t = 10.0
-    pump_head = 50.0
-    fan_power_installed = 0.5 # W/cfm
     chw_design = [85.0, weather.design.CoolingDrybulb - 15.0, weather.data.AnnualAvgDrybulb + 10.0].max # Temperature of water entering indoor coil,use 85F as lower bound
     if fluid_type == Constants.FluidWater
       hw_design = [45.0, weather.design.HeatingDrybulb + 35.0, weather.data.AnnualAvgDrybulb - 10.0].max # Temperature of fluid entering indoor coil, use 45F as lower bound for water
@@ -807,6 +805,7 @@ class HVAC
     gshp_cool_power_fT_coeff = convert_curve_gshp(cool_power_ft_spec, false)
     gshp_cool_SH_fT_coeff = convert_curve_gshp(cool_SH_ft_spec, false)
 
+    # FUTURE: Reconcile these adjustments with ANSI/RESNET/ICC 301-2019 Section 4.4.5
     fan_adjust_kw = UnitConversions.convert(400.0, 'Btu/hr', 'ton') * UnitConversions.convert(1.0, 'cfm', 'm^3/s') * 1000.0 * 0.35 * 249.0 / 300.0 # Adjustment per ISO 13256-1 Internal pressure drop across heat pump assumed to be 0.5 in. w.g.
     pump_adjust_kw = UnitConversions.convert(3.0, 'Btu/hr', 'ton') * UnitConversions.convert(1.0, 'gal/min', 'm^3/s') * 1000.0 * 6.0 * 2990.0 / 3000.0 # Adjustment per ISO 13256-1 Internal Pressure drop across heat pump coil assumed to be 11ft w.g.
     cooling_eir = UnitConversions.convert((1.0 - heat_pump.cooling_efficiency_eer * (fan_adjust_kw + pump_adjust_kw)) / (heat_pump.cooling_efficiency_eer * (1.0 + UnitConversions.convert(fan_adjust_kw, 'Wh', 'Btu'))), 'Wh', 'Btu')
@@ -919,10 +918,11 @@ class HVAC
 
     # Pump
 
+    # Pump power set in hvac_sizing.rb
     pump = OpenStudio::Model::PumpVariableSpeed.new(model)
     pump.setName(obj_name + ' pump')
-    pump.setRatedPumpHead(pump_head)
-    pump.setMotorEfficiency(0.77 * 0.6)
+    pump.setMotorEfficiency(0.85)
+    pump.setRatedPumpHead(20000)
     pump.setFractionofMotorInefficienciestoFluidStream(0)
     pump.setCoefficient1ofthePartLoadPerformanceCurve(0)
     pump.setCoefficient2ofthePartLoadPerformanceCurve(1)
@@ -949,7 +949,7 @@ class HVAC
 
     # Fan
 
-    fan = create_supply_fan(model, obj_name, 1, fan_power_installed)
+    fan = create_supply_fan(model, obj_name, 1, heat_pump.fan_watts_per_cfm)
     hvac_map[heat_pump.id] += disaggregate_fan_or_pump(model, fan, htg_coil, clg_coil, htg_supp_coil)
 
     # Unitary System
@@ -996,6 +996,7 @@ class HVAC
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoGSHPUTubeSpacingType, u_tube_spacing_type)
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoHVACCoolType, Constants.ObjectNameGroundSourceHeatPump)
     air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoHVACHeatType, Constants.ObjectNameGroundSourceHeatPump)
+    air_loop_unitary.additionalProperties.setFeature(Constants.SizingInfoHVACPumpPower, heat_pump.pump_watts_per_ton)
   end
 
   def self.apply_water_loop_to_air_heat_pump(model, runner, heat_pump,
@@ -1095,10 +1096,13 @@ class HVAC
 
     # Pump
 
+    pump_w = heating_system.electric_auxiliary_energy / 2.08
     pump = OpenStudio::Model::PumpVariableSpeed.new(model)
     pump.setName(obj_name + ' hydronic pump')
+    pump.setRatedPowerConsumption(pump_w)
+    pump.setMotorEfficiency(0.85)
     pump.setRatedPumpHead(20000)
-    pump.setMotorEfficiency(0.9)
+    pump.setRatedFlowRate(calc_pump_rated_flow_rate(0.75, pump_w, pump.ratedPumpHead))
     pump.setFractionofMotorInefficienciestoFluidStream(0)
     pump.setCoefficient1ofthePartLoadPerformanceCurve(0)
     pump.setCoefficient2ofthePartLoadPerformanceCurve(1)
@@ -1143,7 +1147,7 @@ class HVAC
     boiler.setParasiticElectricLoad(0)
     plant_loop.addSupplyBranchForComponent(boiler)
     hvac_map[heating_system.id] << boiler
-    hvac_map[heating_system.id] += disaggregate_fan_or_pump(model, pump, boiler, nil, nil)
+    set_pump_power_ems_program(model, pump_w, pump, boiler)
 
     if is_condensing && oat_reset_enabled
       setpoint_manager_oar = OpenStudio::Model::SetpointManagerOutdoorAirReset.new(model)
@@ -1211,6 +1215,7 @@ class HVAC
       zone_hvac.setMaximumOutdoorAirFlowRate(0.0)
       zone_hvac.addToThermalZone(control_zone)
       hvac_map[heating_system.id] << zone_hvac
+      hvac_map[heating_system.id] += disaggregate_fan_or_pump(model, pump, zone_hvac, nil, nil)
     else
       # Heating Coil
       htg_coil = OpenStudio::Model::CoilHeatingWaterBaseboard.new(model)
@@ -1227,6 +1232,7 @@ class HVAC
       zone_hvac.setName(obj_name + ' baseboard')
       zone_hvac.addToThermalZone(control_zone)
       hvac_map[heating_system.id] << zone_hvac
+      hvac_map[heating_system.id] += disaggregate_fan_or_pump(model, pump, zone_hvac, nil, nil)
     end
 
     control_zone.setSequentialHeatingFractionSchedule(zone_hvac, get_sequential_load_schedule(model, sequential_heat_load_frac))
@@ -1549,71 +1555,40 @@ class HVAC
 
     eae = heating_system.electric_auxiliary_energy
 
-    if heating_system.heating_system_type == HPXML::HVACTypeBoiler
+    unitary_systems = []
+    hvac_objects.each do |hvac_object|
+      if hvac_object.is_a? OpenStudio::Model::AirLoopHVAC # Furnace
+        unitary_systems << get_unitary_system_from_air_loop_hvac(hvac_object)
+      elsif hvac_object.is_a? OpenStudio::Model::AirLoopHVACUnitarySystem # WallFurnace/FloorFurnace/Stove
+        unitary_systems << hvac_object
+      end
+    end
 
+    unitary_systems.each do |unitary_system|
       if eae.nil?
-        eae = get_default_eae(heating_system, nil)
-      end
-
-      elec_power = (eae / 2.08) # W
-
-      hvac_objects.each do |hvac_object|
-        next unless hvac_object.is_a? OpenStudio::Model::PlantLoop
-
-        hvac_object.components.each do |plc|
-          if plc.to_BoilerHotWater.is_initialized
-            boiler = plc.to_BoilerHotWater.get
-            boiler.setParasiticElectricLoad(0.0)
-          elsif plc.to_PumpVariableSpeed.is_initialized
-            pump = plc.to_PumpVariableSpeed.get
-            pump_eff = 0.9
-            pump_gpm = UnitConversions.convert(pump.ratedFlowRate.get, 'm^3/s', 'gal/min')
-            pump_w_gpm = elec_power / pump_gpm # W/gpm
-            pump.setRatedPowerConsumption(elec_power)
-            pump.setRatedPumpHead(calc_pump_head(pump_eff, pump_w_gpm))
-            pump.setMotorEfficiency(1.0)
-          end
-        end
-      end
-
-    else # Furnace/WallFurnace/FloorFurnace/Stove
-
-      unitary_systems = []
-      hvac_objects.each do |hvac_object|
-        if hvac_object.is_a? OpenStudio::Model::AirLoopHVAC # Furnace
-          unitary_systems << get_unitary_system_from_air_loop_hvac(hvac_object)
-        elsif hvac_object.is_a? OpenStudio::Model::AirLoopHVACUnitarySystem # WallFurnace/FloorFurnace/Stove
-          unitary_systems << hvac_object
-        end
-      end
-
-      unitary_systems.each do |unitary_system|
-        if eae.nil?
-          htg_coil = unitary_system.heatingCoil.get.to_CoilHeatingGas.get
-          htg_capacity = UnitConversions.convert(htg_coil.nominalCapacity.get, 'W', 'kBtu/hr')
-          eae = get_default_eae(heating_system, htg_capacity)
-        end
-        elec_power = eae / 2.08 # W
-
         htg_coil = unitary_system.heatingCoil.get.to_CoilHeatingGas.get
-        htg_coil.setParasiticElectricLoad(0.0)
-
-        htg_cfm = UnitConversions.convert(unitary_system.supplyAirFlowRateDuringHeatingOperation.get, 'm^3/s', 'cfm')
-
-        fan = unitary_system.supplyFan.get.to_FanOnOff.get
-        if elec_power > 0
-          fan_eff = 0.75 # Overall Efficiency of the Fan, Motor and Drive
-          fan_w_cfm = elec_power / htg_cfm # W/cfm
-          fan.setFanEfficiency(fan_eff)
-          fan.setPressureRise(calc_fan_pressure_rise(fan_eff, fan_w_cfm))
-        else
-          fan.setFanEfficiency(1)
-          fan.setPressureRise(0)
-        end
-        fan.setMotorEfficiency(1.0)
-        fan.setMotorInAirstreamFraction(1.0)
+        htg_capacity = UnitConversions.convert(htg_coil.nominalCapacity.get, 'W', 'kBtu/hr')
+        eae = get_default_eae(heating_system, htg_capacity)
       end
+      elec_power = eae / 2.08 # W
 
+      htg_coil = unitary_system.heatingCoil.get.to_CoilHeatingGas.get
+      htg_coil.setParasiticElectricLoad(0.0)
+
+      htg_cfm = UnitConversions.convert(unitary_system.supplyAirFlowRateDuringHeatingOperation.get, 'm^3/s', 'cfm')
+
+      fan = unitary_system.supplyFan.get.to_FanOnOff.get
+      if elec_power > 0
+        fan_eff = 0.75 # Overall Efficiency of the Fan, Motor and Drive
+        fan_w_cfm = elec_power / htg_cfm # W/cfm
+        fan.setFanEfficiency(fan_eff)
+        fan.setPressureRise(calc_fan_pressure_rise(fan_eff, fan_w_cfm))
+      else
+        fan.setFanEfficiency(1)
+        fan.setPressureRise(0)
+      end
+      fan.setMotorEfficiency(1.0)
+      fan.setMotorInAirstreamFraction(1.0)
     end
   end
 
@@ -1741,6 +1716,55 @@ class HVAC
 
   private
 
+  def self.set_pump_power_ems_program(model, pump_w, pump, heating_object)
+    # EMS is used to set the pump power.
+    # Without EMS, the pump power will vary according to the plant loop part load ratio
+    # (based on flow rate) rather than the boiler part load ratio (based on load).
+
+    # Sensors
+    if heating_object.is_a? OpenStudio::Model::BoilerHotWater
+      heating_plr_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Boiler Part Load Ratio')
+      heating_plr_sensor.setName("#{heating_object.name} plr s")
+      heating_plr_sensor.setKeyName(heating_object.name.to_s)
+    elsif heating_object.is_a? OpenStudio::Model::AirLoopHVACUnitarySystem
+      heating_plr_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Unitary System Part Load Ratio')
+      heating_plr_sensor.setName("#{heating_object.name} plr s")
+      heating_plr_sensor.setKeyName(heating_object.name.to_s)
+    end
+
+    pump_mfr_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Pump Mass Flow Rate')
+    pump_mfr_sensor.setName("#{pump.name} mfr s")
+    pump_mfr_sensor.setKeyName(pump.name.to_s)
+
+    # Internal variable
+    pump_rated_mfr_var = OpenStudio::Model::EnergyManagementSystemInternalVariable.new(model, 'Pump Maximum Mass Flow Rate')
+    pump_rated_mfr_var.setName("#{pump.name} rated mfr")
+    pump_rated_mfr_var.setInternalDataIndexKeyName(pump.name.to_s)
+
+    # Actuator
+    pump_pressure_rise_act = OpenStudio::Model::EnergyManagementSystemActuator.new(pump, 'Pump', 'Pump Pressure Rise')
+    pump_pressure_rise_act.setName("#{pump.name} pressure rise act")
+
+    # Program
+    # See https://bigladdersoftware.com/epx/docs/9-3/ems-application-guide/hvac-systems-001.html#pump
+    pump_program = OpenStudio::Model::EnergyManagementSystemProgram.new(model)
+    pump_program.setName("#{pump.name} power program")
+    pump_program.addLine("Set heating_plr = #{heating_plr_sensor.name}")
+    pump_program.addLine("Set pump_total_eff = #{pump_rated_mfr_var.name} / 1000 * #{pump.ratedPumpHead} / #{pump.ratedPowerConsumption.get}")
+    pump_program.addLine("Set pump_vfr = #{pump_mfr_sensor.name} / 1000")
+    pump_program.addLine('If pump_vfr > 0')
+    pump_program.addLine("  Set #{pump_pressure_rise_act.name} = #{pump_w} * heating_plr * pump_total_eff / pump_vfr")
+    pump_program.addLine('Else')
+    pump_program.addLine("  Set #{pump_pressure_rise_act.name} = 0")
+    pump_program.addLine('EndIf')
+
+    # Calling Point
+    pump_program_calling_manager = OpenStudio::Model::EnergyManagementSystemProgramCallingManager.new(model)
+    pump_program_calling_manager.setName("#{pump.name} power program calling manager")
+    pump_program_calling_manager.setCallingPoint('EndOfSystemTimestepBeforeHVACReporting')
+    pump_program_calling_manager.addProgram(pump_program)
+  end
+
   def self.disaggregate_fan_or_pump(model, fan_or_pump, htg_object, clg_object, backup_htg_object)
     # Disaggregate into heating/cooling output energy use.
 
@@ -1779,10 +1803,10 @@ class HVAC
       var = "Heating Coil #{EPlus.output_fuel_map(EPlus::FuelTypeElectricity)} Energy"
       if htg_object.is_a? OpenStudio::Model::CoilHeatingGas
         var = "Heating Coil #{EPlus.output_fuel_map(htg_object.fuelType)} Energy"
-      elsif htg_object.is_a? OpenStudio::Model::BoilerHotWater
-        var = 'Boiler Heating Energy'
-      elsif htg_object.is_a? OpenStudio::Model::CoilHeatingWater
-        var = 'Heating Coil Heating Energy'
+      elsif htg_object.is_a? OpenStudio::Model::ZoneHVACBaseboardConvectiveWater
+        var = 'Baseboard Total Heating Energy'
+      elsif htg_object.is_a? OpenStudio::Model::ZoneHVACFourPipeFanCoil
+        var = 'Fan Coil Heating Energy'
       end
 
       htg_object_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, var)
@@ -2044,31 +2068,47 @@ class HVAC
 
   def self.get_default_eae(heating_system, furnace_capacity_kbtuh)
     # From ANSI/RESNET/ICC 301-2019 Standard
+    if not heating_system.electric_auxiliary_energy.nil?
+      return heating_system.electric_auxiliary_energy
+    end
 
     load_frac = heating_system.fraction_heat_load_served
     fuel = heating_system.heating_system_fuel
 
     if heating_system.heating_system_type == HPXML::HVACTypeBoiler
       if heating_system.is_shared_system
-        # FUTURE: Allow defaulting based on ANSI/RESNET/ICC 301-2019 Table 4.5.2(5)
-        sp_kw = UnitConversions.convert(heating_system.shared_loop_watts, 'W', 'kW')
-        n_dweq = heating_system.number_of_units_served.to_f
-
         distribution_system = heating_system.distribution_system
         distribution_type = distribution_system.distribution_system_type
 
         if distribution_type == HPXML::HVACDistributionTypeHydronic
           # Shared boiler w/ baseboard/radiators/etc
-          aux_in = 0.0
+          if heating_system.shared_loop_watts.nil?
+            return 220.0 # kWh/yr, per ANSI/RESNET/ICC 301-2019 Table 4.5.2(5)
+          else
+            sp_kw = UnitConversions.convert(heating_system.shared_loop_watts, 'W', 'kW')
+            n_dweq = heating_system.number_of_units_served.to_f
+            aux_in = 0.0
+          end
         elsif distribution_type == HPXML::HVACDistributionTypeHydronicAndAir
           hydronic_and_air_type = distribution_system.hydronic_and_air_type
           if hydronic_and_air_type == HPXML::HydronicAndAirTypeFanCoil
             # Shared boiler w/ fan coil
-            aux_in = UnitConversions.convert(heating_system.fan_coil_watts, 'W', 'kW')
+            if heating_system.shared_loop_watts.nil? || heating_system.fan_coil_watts.nil?
+              return 438.0 # kWh/yr, per ANSI/RESNET/ICC 301-2019 Table 4.5.2(5)
+            else
+              sp_kw = UnitConversions.convert(heating_system.shared_loop_watts, 'W', 'kW')
+              n_dweq = heating_system.number_of_units_served.to_f
+              aux_in = UnitConversions.convert(heating_system.fan_coil_watts, 'W', 'kW')
+            end
           elsif hydronic_and_air_type == HPXML::HydronicAndAirTypeWaterLoopHeatPump
             # Shared boiler w/ WLHP
-            # ANSI/RESNET/ICC 301-2019 Section 4.4.7.2
-            aux_in = 0.0
+            if heating_system.shared_loop_watts.nil?
+              return 265.0 # kWh/yr, per ANSI/RESNET/ICC 301-2019 Table 4.5.2(5)
+            else
+              sp_kw = UnitConversions.convert(heating_system.shared_loop_watts, 'W', 'kW')
+              n_dweq = heating_system.number_of_units_served.to_f
+              aux_in = 0.0 # ANSI/RESNET/ICC 301-2019 Section 4.4.7.2
+            end
           else
             fail "Unexpected distribution type '#{hydronic_and_air_type}' for shared boiler."
           end
@@ -2083,7 +2123,10 @@ class HVAC
       else # In-unit boilers
 
         if [HPXML::FuelTypeNaturalGas,
-            HPXML::FuelTypePropane].include? fuel
+            HPXML::FuelTypePropane,
+            HPXML::FuelTypeElectricity,
+            HPXML::FuelTypeWoodCord,
+            HPXML::FuelTypeWoodPellets].include? fuel
           return 170.0 * load_frac # kWh/yr
         elsif [HPXML::FuelTypeOil,
                HPXML::FuelTypeOil1,
@@ -2091,7 +2134,11 @@ class HVAC
                HPXML::FuelTypeOil4,
                HPXML::FuelTypeOil5or6,
                HPXML::FuelTypeDiesel,
-               HPXML::FuelTypeKerosene].include? fuel
+               HPXML::FuelTypeKerosene,
+               HPXML::FuelTypeCoal,
+               HPXML::FuelTypeCoalAnthracite,
+               HPXML::FuelTypeCoalBituminous,
+               HPXML::FuelTypeCoke].include? fuel
           return 330.0 * load_frac # kWh/yr
         end
 
@@ -2100,7 +2147,10 @@ class HVAC
 
       # Furnaces
       if [HPXML::FuelTypeNaturalGas,
-          HPXML::FuelTypePropane].include? fuel
+          HPXML::FuelTypePropane,
+          HPXML::FuelTypeElectricity,
+          HPXML::FuelTypeWoodCord,
+          HPXML::FuelTypeWoodPellets].include? fuel
         return (149.0 + 10.3 * furnace_capacity_kbtuh) * load_frac # kWh/yr
       elsif [HPXML::FuelTypeOil,
              HPXML::FuelTypeOil1,
@@ -2108,7 +2158,11 @@ class HVAC
              HPXML::FuelTypeOil4,
              HPXML::FuelTypeOil5or6,
              HPXML::FuelTypeDiesel,
-             HPXML::FuelTypeKerosene].include? fuel
+             HPXML::FuelTypeKerosene,
+             HPXML::FuelTypeCoal,
+             HPXML::FuelTypeCoalAnthracite,
+             HPXML::FuelTypeCoalBituminous,
+             HPXML::FuelTypeCoke].include? fuel
         return (439.0 + 5.5 * furnace_capacity_kbtuh) * load_frac # kWh/yr
       end
 
@@ -3359,11 +3413,10 @@ class HVAC
     return fan_eff * fan_power / UnitConversions.convert(1.0, 'cfm', 'm^3/s') # Pa
   end
 
-  def self.calc_pump_head(pump_eff, pump_power)
-    # Calculate needed pump head to achieve a given pump power with an assumed efficiency.
-    # Previously we calculated the pump efficiency from an assumed pump head, which could lead to
-    # errors (pump efficiencies > 1).
-    return pump_eff * pump_power / UnitConversions.convert(1.0, 'gal/min', 'm^3/s') # Pa
+  def self.calc_pump_rated_flow_rate(pump_eff, pump_w, pump_head_pa)
+    # Calculate needed pump rated flow rate to achieve a given pump power with an assumed
+    # efficiency and pump head.
+    return pump_eff * pump_w / pump_head_pa # m3/s
   end
 
   def self.existing_equipment(model, thermal_zone, runner)
@@ -4113,6 +4166,16 @@ class HVAC
     secondary_duct_location = HPXML::LocationLivingSpace
 
     return primary_duct_location, secondary_duct_location
+  end
+
+  def self.get_default_gshp_pump_power()
+    return 30.0 # W/ton, per ANSI/RESNET/ICC 301-2019 Section 4.4.5 (closed loop)
+  end
+
+  def self.get_default_gshp_fan_power()
+    # Should this be 0.2 W/cfm per ANSI/RESNET/ICC 301-2019 Section 4.4.5? (or is 0.2 W/cfm
+    # interpreted as the _additional_ fan power beyond that captured in the rating test?)
+    return 0.5 # W/cfm
   end
 
   def self.apply_shared_systems(hpxml)

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/hvac_sizing.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/hvac_sizing.rb
@@ -2263,6 +2263,7 @@ class HVACSizing
         if hvac.GSHP_HXDTDesign.nil? || hvac.GSHP_HXCHWDesign.nil? || hvac.GSHP_HXHWDesign.nil?
           fail 'Could not find GSHP plant loop.'
         end
+        hvac.GSHP_PumpPower = get_feature(equip, Constants.SizingInfoHVACPumpPower, 'double')
 
       elsif not htg_coil.nil?
         fail "Unexpected heating coil: #{htg_coil.name}."
@@ -3098,8 +3099,11 @@ class HVACSizing
             next unless plc.to_PumpVariableSpeed.is_initialized
 
             # Pump
+            pump_w = hvac.GSHP_PumpPower * UnitConversions.convert(clg_coil.ratedTotalCoolingCapacity.get, 'W', 'ton')
             pump = plc.to_PumpVariableSpeed.get
-            pump.setRatedFlowRate(UnitConversions.convert(hvac_final_values.GSHP_Loop_flow, 'gal/min', 'm^3/s'))
+            pump.setRatedPowerConsumption(pump_w)
+            pump.setRatedFlowRate(HVAC.calc_pump_rated_flow_rate(0.75, pump_w, pump.ratedPumpHead))
+            HVAC.set_pump_power_ems_program(model, pump_w, pump, object)
           end
         end
 
@@ -3194,12 +3198,6 @@ class HVACSizing
           if component.to_BoilerHotWater.is_initialized
             boiler = component.to_BoilerHotWater.get
             boiler.setNominalCapacity(UnitConversions.convert(hvac_final_values.Heat_Capacity, 'Btu/hr', 'W'))
-          end
-
-          # Pump
-          if component.to_PumpVariableSpeed.is_initialized
-            pump = component.to_PumpVariableSpeed.get
-            pump.setRatedFlowRate(UnitConversions.convert(hvac_final_values.Heat_Capacity / 20.0 / 500.0, 'gal/min', 'm^3/s'))
           end
         end
 
@@ -3419,7 +3417,7 @@ class HVACInfo
                 :SHRRated, :CapacityRatioCooling, :CapacityRatioHeating,
                 :HeatingCapacityOffset, :OverSizeLimit, :OverSizeDelta, :FanspeedRatioCooling,
                 :BoilerDesignTemp, :CoilBF, :HeatingEIR, :CoolingEIR, :SizingSpeed,
-                :GSHP_HXVertical, :GSHP_HXDTDesign, :GSHP_HXCHWDesign, :GSHP_HXHWDesign,
+                :GSHP_PumpPower, :GSHP_HXVertical, :GSHP_HXDTDesign, :GSHP_HXCHWDesign, :GSHP_HXHWDesign,
                 :GSHP_BoreSpacing, :GSHP_BoreHoles, :GSHP_BoreDepth, :GSHP_BoreConfig, :GSHP_SpacingType,
                 :HeatingLoadFraction, :CoolingLoadFraction, :SupplyAirTemp, :LeavingAirTemp,
                 :EvapCoolerEffectiveness)

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/schedules.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/schedules.rb
@@ -316,15 +316,19 @@ class MonthWeekdayWeekendSchedule
     if year_description.isLeapYear
       leap_offset = 1
     end
+
     num_days_in_each_month = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
     num_days_in_each_month[@end_month] = @end_day_of_month
-    num_days_in_each_month.each_index { |i| i > 1 ? num_days_in_each_month[i] + leap_offset : num_days_in_each_month[i] }
+    num_days_in_each_month.each_index do |i|
+      num_days_in_each_month[i] += leap_offset if i == 2
+    end
     orig_day_startm = [0, 1, 32, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335]
+    orig_day_startm.each_index do |i|
+      orig_day_startm[i] += leap_offset if i > 2
+    end
     day_startm = orig_day_startm.map(&:clone)
     day_startm[@begin_month] = orig_day_startm[@begin_month] + @begin_day_of_month - 1
-    day_startm.each_index { |i| i > 1 ? day_startm[i] + leap_offset : day_startm[i] }
     day_endm = [orig_day_startm, num_days_in_each_month].transpose.map { |i| (i != [0, 0]) ? i.reduce(:+) - 1 : 0 }
-
     time = []
     for h in 1..24
       time[h] = OpenStudio::Time.new(0, h, 0, 0)

--- a/hpxml-measures/HPXMLtoOpenStudio/tests/test_defaults.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/tests/test_defaults.rb
@@ -311,6 +311,24 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     _test_default_boiler_values(hpxml_default, 220.0)
   end
 
+  def test_ground_source_heat_pumps
+    # Test inputs not overridden by defaults
+    hpxml_name = 'base-hvac-ground-to-air-heat-pump.xml'
+    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml.heat_pumps[0].pump_watts_per_ton = 9.9
+    hpxml.heat_pumps[0].fan_watts_per_cfm = 0.99
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_gshp_values(hpxml_default, 9.9, 0.99)
+
+    # Test defaults
+    hpxml.heat_pumps[0].pump_watts_per_ton = nil
+    hpxml.heat_pumps[0].fan_watts_per_cfm = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_gshp_values(hpxml_default, 30.0, 0.5)
+  end
+
   def test_hvac_distribution
     # Test inputs not overridden by defaults
     hpxml_name = 'base.xml'
@@ -1007,6 +1025,12 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
   def _test_default_boiler_values(hpxml, eae)
     heating_system = hpxml.heating_systems[0]
     assert_equal(eae, heating_system.electric_auxiliary_energy)
+  end
+
+  def _test_default_gshp_values(hpxml, pump_w_per_ton, fan_w_per_cfm)
+    heat_pump = hpxml.heat_pumps[0]
+    assert_equal(pump_w_per_ton, heat_pump.pump_watts_per_ton)
+    assert_equal(fan_w_per_cfm, heat_pump.fan_watts_per_cfm)
   end
 
   def _test_default_duct_values(hpxml, supply_locations, return_locations, supply_areas, return_areas, n_return_registers)

--- a/hpxml-measures/HPXMLtoOpenStudio/tests/test_defaults.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/tests/test_defaults.rb
@@ -263,7 +263,7 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     _test_default_skylight_values(hpxml_default, [1.0] * n_skylights, [1.0] * n_skylights)
   end
 
-  def test_hvac
+  def test_air_conditioners
     # Test inputs not overridden by defaults
     hpxml_name = 'base.xml'
     hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
@@ -271,14 +271,44 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     hpxml.cooling_systems[0].compressor_type = HPXML::HVACCompressorTypeVariableSpeed
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_cooling_system_values(hpxml_default, 0.88, HPXML::HVACCompressorTypeVariableSpeed)
-    _test_default_heating_system_values(hpxml_default)
+    _test_default_air_conditioner_values(hpxml_default, 0.88, HPXML::HVACCompressorTypeVariableSpeed)
 
     # Test defaults
-    hpxml = apply_hpxml_defaults('base-misc-defaults.xml')
+    hpxml = apply_hpxml_defaults('base.xml')
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
-    _test_default_cooling_system_values(hpxml_default, 0.73, HPXML::HVACCompressorTypeSingleStage)
+    _test_default_air_conditioner_values(hpxml_default, 0.73, HPXML::HVACCompressorTypeSingleStage)
+  end
+
+  def test_boilers
+    # Test inputs not overridden by defaults (in-unit boiler)
+    hpxml_name = 'base-hvac-boiler-gas-only.xml'
+    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml.heating_systems[0].electric_auxiliary_energy = 99.9
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_boiler_values(hpxml_default, 99.9)
+
+    # Test defaults w/ in-unit boiler
+    hpxml.heating_systems[0].electric_auxiliary_energy = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_boiler_values(hpxml_default, 170.0)
+
+    # Test inputs not overridden by defaults (shared boiler)
+    hpxml_name = 'base-hvac-shared-boiler-only-baseboard.xml'
+    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml.heating_systems[0].shared_loop_watts = nil
+    hpxml.heating_systems[0].electric_auxiliary_energy = 99.9
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_boiler_values(hpxml_default, 99.9)
+
+    # Test defaults w/ shared boiler
+    hpxml.heating_systems[0].electric_auxiliary_energy = nil
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+    hpxml_default = _test_measure()
+    _test_default_boiler_values(hpxml_default, 220.0)
   end
 
   def test_hvac_distribution
@@ -968,16 +998,15 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
     assert_equal(num_occupants, hpxml.building_occupancy.number_of_residents)
   end
 
-  def _test_default_cooling_system_values(hpxml, shr, compressor_type)
+  def _test_default_air_conditioner_values(hpxml, shr, compressor_type)
     cooling_system = hpxml.cooling_systems[0]
     assert_equal(shr, cooling_system.cooling_shr)
     assert_equal(compressor_type, cooling_system.compressor_type)
   end
 
-  def _test_default_heating_system_values(hpxml)
-  end
-
-  def _test_default_heat_pump_values(hpxml)
+  def _test_default_boiler_values(hpxml, eae)
+    heating_system = hpxml.heating_systems[0]
+    assert_equal(eae, heating_system.electric_auxiliary_energy)
   end
 
   def _test_default_duct_values(hpxml, supply_locations, return_locations, supply_areas, return_areas, n_return_registers)

--- a/hpxml-measures/SimulationOutputReport/measure.xml
+++ b/hpxml-measures/SimulationOutputReport/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>a23162fa-5367-41cb-aec0-b1010f6fccd4</version_id>
-  <version_modified>20200826T141556Z</version_modified>
+  <version_id>e4291992-5dcd-4e55-9c7a-0728eba54d3a</version_id>
+  <version_modified>20200828T151716Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -786,12 +786,6 @@
       <checksum>BFBDB9E1</checksum>
     </file>
     <file>
-      <filename>output_report_test.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>DE79CABB</checksum>
-    </file>
-    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.9.1</identifier>
@@ -801,6 +795,12 @@
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
       <checksum>7FB2080E</checksum>
+    </file>
+    <file>
+      <filename>output_report_test.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>F8791A06</checksum>
     </file>
   </files>
 </measure>

--- a/hpxml-measures/SimulationOutputReport/tests/output_report_test.rb
+++ b/hpxml-measures/SimulationOutputReport/tests/output_report_test.rb
@@ -695,6 +695,7 @@ class SimulationOutputReportTest < MiniTest::Test
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(8760, File.readlines(timeseries_csv).size - 2)
+    _check_for_zero_baseload_timeseries_value(timeseries_csv, ['Electricity: Refrigerator'])
   end
 
   def test_timeseries_daily_ALL
@@ -715,6 +716,7 @@ class SimulationOutputReportTest < MiniTest::Test
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(365, File.readlines(timeseries_csv).size - 2)
+    _check_for_zero_baseload_timeseries_value(timeseries_csv, ['Electricity: Refrigerator'])
   end
 
   def test_timeseries_monthly_ALL
@@ -735,6 +737,7 @@ class SimulationOutputReportTest < MiniTest::Test
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(12, File.readlines(timeseries_csv).size - 2)
+    _check_for_zero_baseload_timeseries_value(timeseries_csv, ['Electricity: Refrigerator'])
   end
 
   def test_timeseries_timestep_ALL_60min
@@ -755,6 +758,7 @@ class SimulationOutputReportTest < MiniTest::Test
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(8760, File.readlines(timeseries_csv).size - 2)
+    _check_for_zero_baseload_timeseries_value(timeseries_csv, ['Electricity: Refrigerator'])
   end
 
   def test_timeseries_timestep_ALL_10min
@@ -775,6 +779,7 @@ class SimulationOutputReportTest < MiniTest::Test
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(52560, File.readlines(timeseries_csv).size - 2)
+    _check_for_zero_baseload_timeseries_value(timeseries_csv, ['Electricity: Refrigerator'])
   end
 
   def test_timeseries_hourly_ALL_runperiod_Jan
@@ -795,6 +800,7 @@ class SimulationOutputReportTest < MiniTest::Test
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(31 * 24, File.readlines(timeseries_csv).size - 2)
+    _check_for_zero_baseload_timeseries_value(timeseries_csv, ['Electricity: Refrigerator'])
   end
 
   def test_timeseries_daily_ALL_runperiod_Jan
@@ -815,6 +821,7 @@ class SimulationOutputReportTest < MiniTest::Test
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(31, File.readlines(timeseries_csv).size - 2)
+    _check_for_zero_baseload_timeseries_value(timeseries_csv, ['Electricity: Refrigerator'])
   end
 
   def test_timeseries_monthly_ALL_runperiod_Jan
@@ -835,6 +842,7 @@ class SimulationOutputReportTest < MiniTest::Test
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(1, File.readlines(timeseries_csv).size - 2)
+    _check_for_zero_baseload_timeseries_value(timeseries_csv, ['Electricity: Refrigerator'])
   end
 
   def test_timeseries_timestep_ALL_60min_runperiod_Jan
@@ -855,6 +863,7 @@ class SimulationOutputReportTest < MiniTest::Test
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(31 * 24, File.readlines(timeseries_csv).size - 2)
+    _check_for_zero_baseload_timeseries_value(timeseries_csv, ['Electricity: Refrigerator'])
   end
 
   def test_timeseries_hourly_ALL_AMY_2012
@@ -875,6 +884,7 @@ class SimulationOutputReportTest < MiniTest::Test
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(8784, File.readlines(timeseries_csv).size - 2)
+    _check_for_zero_baseload_timeseries_value(timeseries_csv, ['Electricity: Refrigerator'])
   end
 
   def test_timeseries_daily_ALL_AMY_2012
@@ -895,6 +905,7 @@ class SimulationOutputReportTest < MiniTest::Test
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(366, File.readlines(timeseries_csv).size - 2)
+    _check_for_zero_baseload_timeseries_value(timeseries_csv, ['Electricity: Refrigerator'])
   end
 
   def test_timeseries_timestep_ALL_60min_AMY_2012
@@ -915,6 +926,7 @@ class SimulationOutputReportTest < MiniTest::Test
     actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
     assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(8784, File.readlines(timeseries_csv).size - 2)
+    _check_for_zero_baseload_timeseries_value(timeseries_csv, ['Electricity: Refrigerator'])
   end
 
   def test_eri_designs
@@ -1021,6 +1033,28 @@ class SimulationOutputReportTest < MiniTest::Test
     timeseries_cols.each do |col|
       avg_value = values[col].sum(0.0) / values[col].size
       assert_operator(avg_value, :!=, 0)
+    end
+  end
+
+  def _check_for_zero_baseload_timeseries_value(timeseries_csv, timeseries_cols)
+    # check that every day has non zero values for baseload equipment (e.g., refrigerator)
+    values = {}
+    timeseries_cols.each do |col|
+      values[col] = []
+    end
+    CSV.foreach(timeseries_csv, headers: true) do |row|
+      next if row['Time'].nil?
+
+      timeseries_cols.each do |col|
+        fail "Unexpected column: #{col}." if row[col].nil?
+
+        values[col] << Float(row[col])
+      end
+    end
+
+    timeseries_cols.each do |col|
+      has_no_zero_timeseries_value = !values[col].include?(0.0)
+      assert(has_no_zero_timeseries_value)
     end
   end
 end

--- a/hpxml-measures/docs/source/hpxml_to_openstudio.rst
+++ b/hpxml-measures/docs/source/hpxml_to_openstudio.rst
@@ -482,9 +482,8 @@ Fireplace                                                                       
 
 For all non-shared systems, ``HeatingCapacity`` may be provided; if not, the system will be auto-sized via ACCA Manual J/S.
 
-For non-shared systems, the ``ElectricAuxiliaryEnergy`` element may be provided if available.
-
-For shared boilers (i.e., serving multiple dwelling units), the electric auxiliary energy is calculated using the following equation from `ANSI/RESNET/ICC 301-2019 <https://codes.iccsafe.org/content/RESNETICC3012019>`_:
+For all systems, the ``ElectricAuxiliaryEnergy`` element may be provided if available.
+For shared boilers (i.e., serving multiple dwelling units), the electric auxiliary energy can alternatively be calculated as follows per `ANSI/RESNET/ICC 301-2019 <https://codes.iccsafe.org/content/RESNETICC3012019>`_:
 
   | :math:`EAE = (\frac{SP}{N_{dweq}} + aux_{in}) \cdot HLH`
   | where, 
@@ -492,6 +491,21 @@ For shared boilers (i.e., serving multiple dwelling units), the electric auxilia
   |   :math:`N_{dweq}` = Number of units served by the shared system, provided as ``NumberofUnitsServed``
   |   :math:`aux_{in}` = In-unit fan coil power [W], provided as ``extension/FanCoilWatts``
   |   :math:`HLH` = Annual heating load hours
+
+If electric auxiliary energy is not provided (nor calculated for shared boilers), it is defaulted per `ANSI/RESNET/ICC 301-2019 <https://codes.iccsafe.org/content/RESNETICC3012019>`_ as follows:
+
+============================================  ==============================
+System Type                                   Electric Auxiliary Energy
+============================================  ==============================
+Oil boiler                                    330
+Gas boiler (in-unit)                          170
+Gas boiler (shared, w/ baseboard)             220
+Gas boiler (shared, w/ water loop heat pump)  265
+Gas boiler (shared, w/ fan coil)              438
+Oil furnace                                   439 + 5.5 * Capacity (kBtu/h)
+Gas furnace                                   149 + 10.3 * Capacity (kBtu/h)
+Other                                         0
+============================================  ==============================
 
 For shared boilers connected to a water loop heat pump, the heat pump's heating COP must be provided as ``extension/WaterLoopHeatPump/AnnualHeatingEfficiency[Units="COP"]/Value``.
 
@@ -559,6 +573,11 @@ mini-split                     AirDistribution or DSE (optional)  electricity   
 ground-to-air  false           AirDistribution or DSE             electricity   EER                      COP                      (optional)
 ground-to-air  true            AirDistribution or DSE             electricity   EER                      COP                      (optional)
 =============  ==============  =================================  ============  =======================  =======================  ===========================  ==================
+
+Ground-to-air heat pumps also have a few other inputs:
+
+- ``extension/PumpPowerWattsPerTon``: Optional. Ground loop circulator pump power during operation of the heat pump in Watts/ton of cooling capacity. Defaults to 30 Watts per ton of cooling capacity per `ANSI/RESNET/ICC 301-2019 <https://codes.iccsafe.org/content/RESNETICC3012019>`_ for a closed loop system.
+- ``extension/FanPowerWattsPerCFM``: Optional. Blower fan power in Watts/cfm. Defaults to 0.5 W/cfm.
 
 Air-to-air heat pumps can also have the ``CompressorType`` specified; if not provided, it is assumed as follows:
 

--- a/hpxml-measures/tasks.rb
+++ b/hpxml-measures/tasks.rb
@@ -2919,7 +2919,8 @@ def set_hpxml_heat_pumps(hpxml_file, hpxml)
                          fraction_cool_load_served: 1,
                          heating_efficiency_cop: 3.6,
                          cooling_efficiency_eer: 16.6,
-                         cooling_shr: 0.73)
+                         cooling_shr: 0.73,
+                         pump_watts_per_ton: 30.0)
     if hpxml_file == 'base-hvac-shared-ground-loop-ground-to-air-heat-pump.xml'
       hpxml.heat_pumps[-1].is_shared_system = true
       hpxml.heat_pumps[-1].number_of_units_served = 6
@@ -2989,7 +2990,8 @@ def set_hpxml_heat_pumps(hpxml_file, hpxml)
                          fraction_cool_load_served: 0.2,
                          heating_efficiency_cop: 3.6,
                          cooling_efficiency_eer: 16.6,
-                         cooling_shr: 0.73)
+                         cooling_shr: 0.73,
+                         pump_watts_per_ton: 30.0)
     f = 1.0 - (1.0 - 0.25) / (47.0 + 5.0) * (47.0 - 17.0)
     hpxml.heat_pumps.add(id: 'HeatPump3',
                          heat_pump_type: HPXML::HVACTypeHeatPumpMiniSplit,
@@ -3035,7 +3037,8 @@ def set_hpxml_heat_pumps(hpxml_file, hpxml)
                          fraction_cool_load_served: 0.2,
                          heating_efficiency_cop: 3.6,
                          cooling_efficiency_eer: 16.6,
-                         cooling_shr: 0.73)
+                         cooling_shr: 0.73,
+                         pump_watts_per_ton: 30.0)
   elsif ['invalid_files/hvac-distribution-multiple-attached-heating.xml'].include? hpxml_file
     hpxml.heat_pumps[0].distribution_system_idref = 'HVACDistribution'
   elsif ['invalid_files/hvac-distribution-multiple-attached-cooling.xml'].include? hpxml_file

--- a/hpxml-measures/workflow/sample_files/base-dhw-desuperheater-gshp.xml
+++ b/hpxml-measures/workflow/sample_files/base-dhw-desuperheater-gshp.xml
@@ -327,6 +327,9 @@
                 <Units>COP</Units>
                 <Value>3.6</Value>
               </AnnualHeatingEfficiency>
+              <extension>
+                <PumpPowerWattsPerTon>30.0</PumpPowerWattsPerTon>
+              </extension>
             </HeatPump>
           </HVACPlant>
           <HVACControl>

--- a/hpxml-measures/workflow/sample_files/base-hvac-ground-to-air-heat-pump.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-ground-to-air-heat-pump.xml
@@ -327,6 +327,9 @@
                 <Units>COP</Units>
                 <Value>3.6</Value>
               </AnnualHeatingEfficiency>
+              <extension>
+                <PumpPowerWattsPerTon>30.0</PumpPowerWattsPerTon>
+              </extension>
             </HeatPump>
           </HVACPlant>
           <HVACControl>

--- a/hpxml-measures/workflow/sample_files/base-hvac-multiple.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-multiple.xml
@@ -479,6 +479,9 @@
                 <Units>COP</Units>
                 <Value>3.6</Value>
               </AnnualHeatingEfficiency>
+              <extension>
+                <PumpPowerWattsPerTon>30.0</PumpPowerWattsPerTon>
+              </extension>
             </HeatPump>
             <HeatPump>
               <SystemIdentifier id='HeatPump3'/>

--- a/hpxml-measures/workflow/sample_files/base-hvac-multiple2.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-multiple2.xml
@@ -437,6 +437,9 @@
                 <Units>COP</Units>
                 <Value>3.6</Value>
               </AnnualHeatingEfficiency>
+              <extension>
+                <PumpPowerWattsPerTon>30.0</PumpPowerWattsPerTon>
+              </extension>
             </HeatPump>
           </HVACPlant>
           <HVACControl>

--- a/hpxml-measures/workflow/sample_files/base-hvac-shared-ground-loop-ground-to-air-heat-pump.xml
+++ b/hpxml-measures/workflow/sample_files/base-hvac-shared-ground-loop-ground-to-air-heat-pump.xml
@@ -564,6 +564,7 @@
                 <Value>3.6</Value>
               </AnnualHeatingEfficiency>
               <extension>
+                <PumpPowerWattsPerTon>30.0</PumpPowerWattsPerTon>
                 <SharedLoopWatts>600.0</SharedLoopWatts>
               </extension>
             </HeatPump>

--- a/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-ground-to-air-heat-pump-autosize.xml
+++ b/hpxml-measures/workflow/sample_files/hvac_autosizing/base-hvac-ground-to-air-heat-pump-autosize.xml
@@ -324,6 +324,9 @@
                 <Units>COP</Units>
                 <Value>3.6</Value>
               </AnnualHeatingEfficiency>
+              <extension>
+                <PumpPowerWattsPerTon>30.0</PumpPowerWattsPerTon>
+              </extension>
             </HeatPump>
           </HVACPlant>
           <HVACControl>

--- a/hpxml-measures/workflow/sample_files/invalid_files/hvac-distribution-multiple-attached-cooling.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/hvac-distribution-multiple-attached-cooling.xml
@@ -479,6 +479,9 @@
                 <Units>COP</Units>
                 <Value>3.6</Value>
               </AnnualHeatingEfficiency>
+              <extension>
+                <PumpPowerWattsPerTon>30.0</PumpPowerWattsPerTon>
+              </extension>
             </HeatPump>
             <HeatPump>
               <SystemIdentifier id='HeatPump3'/>

--- a/hpxml-measures/workflow/sample_files/invalid_files/hvac-distribution-multiple-attached-heating.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/hvac-distribution-multiple-attached-heating.xml
@@ -479,6 +479,9 @@
                 <Units>COP</Units>
                 <Value>3.6</Value>
               </AnnualHeatingEfficiency>
+              <extension>
+                <PumpPowerWattsPerTon>30.0</PumpPowerWattsPerTon>
+              </extension>
             </HeatPump>
             <HeatPump>
               <SystemIdentifier id='HeatPump3'/>

--- a/hpxml-measures/workflow/sample_files/invalid_files/hvac-frac-load-served.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/hvac-frac-load-served.xml
@@ -479,6 +479,9 @@
                 <Units>COP</Units>
                 <Value>3.6</Value>
               </AnnualHeatingEfficiency>
+              <extension>
+                <PumpPowerWattsPerTon>30.0</PumpPowerWattsPerTon>
+              </extension>
             </HeatPump>
             <HeatPump>
               <SystemIdentifier id='HeatPump3'/>

--- a/hpxml-measures/workflow/sample_files/invalid_files/missing-duct-location.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/missing-duct-location.xml
@@ -479,6 +479,9 @@
                 <Units>COP</Units>
                 <Value>3.6</Value>
               </AnnualHeatingEfficiency>
+              <extension>
+                <PumpPowerWattsPerTon>30.0</PumpPowerWattsPerTon>
+              </extension>
             </HeatPump>
             <HeatPump>
               <SystemIdentifier id='HeatPump3'/>

--- a/hpxml-measures/workflow/tests/hpxml_translator_test.rb
+++ b/hpxml-measures/workflow/tests/hpxml_translator_test.rb
@@ -868,7 +868,7 @@ class HPXMLTest < MiniTest::Test
       end
 
       if htg_sys_type == HPXML::HVACTypeBoiler
-        next if hpxml.water_heating_systems.select { |wh| [HPXML::WaterHeaterTypeCombiStorage, HPXML::WaterHeaterTypeCombiTankless].include? wh.water_heater_type }.size == 0 # Skip combi systems
+        next if hpxml.water_heating_systems.select { |wh| [HPXML::WaterHeaterTypeCombiStorage, HPXML::WaterHeaterTypeCombiTankless].include? wh.water_heater_type }.size > 0 # Skip combi systems
 
         # Compare pump power from timeseries output
         query = "SELECT VariableValue FROM ReportVariableData WHERE ReportVariableDataDictionaryIndex IN (SELECT ReportVariableDataDictionaryIndex FROM ReportVariableDataDictionary WHERE VariableType='Avg' AND VariableName='Boiler Part Load Ratio' AND ReportingFrequency='Run Period')"

--- a/hpxml-measures/workflow/tests/hpxml_translator_test.rb
+++ b/hpxml-measures/workflow/tests/hpxml_translator_test.rb
@@ -864,7 +864,7 @@ class HPXMLTest < MiniTest::Test
         if htg_sys_type == HPXML::HVACTypeFurnace
           furnace_capacity_kbtuh = UnitConversions.convert(results['Capacity: Heating (W)'], 'W', 'kBtu/hr')
         end
-        hpxml_value = HVAC.get_default_eae(heating_system, furnace_capacity_kbtuh) / 2.08
+        hpxml_value = HVAC.get_electric_auxiliary_energy(heating_system, furnace_capacity_kbtuh) / 2.08
       end
 
       if htg_sys_type == HPXML::HVACTypeBoiler

--- a/hpxml-measures/workflow/tests/hpxml_translator_test.rb
+++ b/hpxml-measures/workflow/tests/hpxml_translator_test.rb
@@ -259,7 +259,11 @@ class HPXMLTest < MiniTest::Test
                    ['Baseboard Total Heating Energy', 'runperiod', '*'],
                    ['Boiler Heating Energy', 'runperiod', '*'],
                    ['Fluid Heat Exchanger Heat Transfer Energy', 'runperiod', '*'],
-                   ['Electric Equipment Electric Energy', 'runperiod', Constants.ObjectNameMechanicalVentilationHouseFanCFIS]]
+                   ['Electric Equipment Electric Energy', 'runperiod', Constants.ObjectNameMechanicalVentilationHouseFanCFIS],
+                   ['Boiler Part Load Ratio', 'runperiod', Constants.ObjectNameBoiler],
+                   ['Pump Electric Power', 'runperiod', Constants.ObjectNameBoiler + ' hydronic pump'],
+                   ['Unitary System Part Load Ratio', 'runperiod', Constants.ObjectNameGroundSourceHeatPump + ' unitary system'],
+                   ['Pump Electric Power', 'runperiod', Constants.ObjectNameGroundSourceHeatPump + ' pump']]
 
     # Run workflow
     workflow_start = Time.now
@@ -858,15 +862,21 @@ class HPXMLTest < MiniTest::Test
       else
         furnace_capacity_kbtuh = nil
         if htg_sys_type == HPXML::HVACTypeFurnace
-          query = "SELECT Value FROM TabularDataWithStrings WHERE ReportName='EquipmentSummary' AND ReportForString='Entire Facility' AND TableName='Heating Coils' AND RowName LIKE '%#{Constants.ObjectNameFurnace.upcase}%' AND ColumnName='Nominal Total Capacity' AND Units='W'"
-          furnace_capacity_kbtuh = UnitConversions.convert(sqlFile.execAndReturnFirstDouble(query).get, 'W', 'kBtu/hr')
+          furnace_capacity_kbtuh = UnitConversions.convert(results['Capacity: Heating (W)'], 'W', 'kBtu/hr')
         end
         hpxml_value = HVAC.get_default_eae(heating_system, furnace_capacity_kbtuh) / 2.08
       end
 
       if htg_sys_type == HPXML::HVACTypeBoiler
-        query = "SELECT Value FROM TabularDataWithStrings WHERE ReportName='EquipmentSummary' AND ReportForString='Entire Facility' AND TableName='Pumps' AND RowName LIKE '%#{Constants.ObjectNameBoiler.upcase}%' AND ColumnName='Electric Power' AND Units='W'"
-        sql_value = sqlFile.execAndReturnFirstDouble(query).get
+        next if hpxml.water_heating_systems.select { |wh| [HPXML::WaterHeaterTypeCombiStorage, HPXML::WaterHeaterTypeCombiTankless].include? wh.water_heater_type }.size == 0 # Skip combi systems
+
+        # Compare pump power from timeseries output
+        query = "SELECT VariableValue FROM ReportVariableData WHERE ReportVariableDataDictionaryIndex IN (SELECT ReportVariableDataDictionaryIndex FROM ReportVariableDataDictionary WHERE VariableType='Avg' AND VariableName='Boiler Part Load Ratio' AND ReportingFrequency='Run Period')"
+        avg_plr = sqlFile.execAndReturnFirstDouble(query).get
+        query = "SELECT VariableValue FROM ReportVariableData WHERE ReportVariableDataDictionaryIndex IN (SELECT ReportVariableDataDictionaryIndex FROM ReportVariableDataDictionary WHERE VariableType='Avg' AND VariableName='Pump Electric Power' AND ReportingFrequency='Run Period')"
+        avg_w = sqlFile.execAndReturnFirstDouble(query).get
+        sql_value = avg_w / avg_plr
+        assert_in_epsilon(sql_value, hpxml_value, 0.02)
       elsif htg_sys_type == HPXML::HVACTypeFurnace
         # Ratio fan power based on heating airflow rate divided by fan airflow rate since the
         # fan is sized based on cooling.
@@ -877,13 +887,30 @@ class HPXMLTest < MiniTest::Test
         sql_value_fan_airflow = sqlFile.execAndReturnFirstDouble(query_fan_airflow).get
         sql_value_htg_airflow = sqlFile.execAndReturnFirstDouble(query_htg_airflow).get
         sql_value *= sql_value_htg_airflow / sql_value_fan_airflow
+        assert_in_epsilon(hpxml_value, sql_value, 0.01)
       elsif (htg_sys_type == HPXML::HVACTypeStove) || (htg_sys_type == HPXML::HVACTypeWallFurnace) || (htg_sys_type == HPXML::HVACTypeFloorFurnace)
         query = "SELECT AVG(Value) FROM TabularDataWithStrings WHERE ReportName='EquipmentSummary' AND ReportForString='Entire Facility' AND TableName='Fans' AND RowName LIKE '%#{Constants.ObjectNameUnitHeater.upcase}%' AND ColumnName='Rated Electric Power' AND Units='W'"
         sql_value = sqlFile.execAndReturnFirstDouble(query).get
+        assert_in_epsilon(hpxml_value, sql_value, 0.01)
       else
         flunk "Unexpected heating system type '#{htg_sys_type}'."
       end
-      assert_in_epsilon(hpxml_value, sql_value, 0.01)
+    end
+
+    # HVAC Heat Pumps
+    num_hps = hpxml.heat_pumps.size
+    hpxml.heat_pumps.each do |heat_pump|
+      next unless heat_pump.fraction_heat_load_served > 0
+      next unless (num_hps == 1) && heat_pump.heat_pump_type == HPXML::HVACTypeHeatPumpGroundToAir
+
+      # Compare pump power from timeseries output
+      hpxml_value = heat_pump.pump_watts_per_ton * UnitConversions.convert(results['Capacity: Cooling (W)'], 'W', 'ton')
+      query = "SELECT VariableValue FROM ReportVariableData WHERE ReportVariableDataDictionaryIndex IN (SELECT ReportVariableDataDictionaryIndex FROM ReportVariableDataDictionary WHERE VariableType='Avg' AND VariableName='Unitary System Part Load Ratio' AND ReportingFrequency='Run Period')"
+      avg_plr = sqlFile.execAndReturnFirstDouble(query).get
+      query = "SELECT VariableValue FROM ReportVariableData WHERE ReportVariableDataDictionaryIndex IN (SELECT ReportVariableDataDictionaryIndex FROM ReportVariableDataDictionary WHERE VariableType='Avg' AND VariableName='Pump Electric Power' AND ReportingFrequency='Run Period')"
+      avg_w = sqlFile.execAndReturnFirstDouble(query).get
+      sql_value = avg_w / avg_plr
+      assert_in_epsilon(sql_value, hpxml_value, 0.02)
     end
 
     # HVAC Capacities

--- a/rulesets/301EnergyRatingIndexRuleset/measure.xml
+++ b/rulesets/301EnergyRatingIndexRuleset/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>energy_rating_index_301_measure</name>
   <uid>02a31992-9a16-4945-bb51-e99209f7193b</uid>
-  <version_id>3d0fcb5c-7f1a-4162-9090-b54d25f1eb24</version_id>
-  <version_modified>20200831T221155Z</version_modified>
+  <version_id>0f744b2d-1e44-4557-9e92-edca8a49b8e8</version_id>
+  <version_modified>20200901T003820Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>EnergyRatingIndex301Measure</class_name>
   <display_name>Apply Energy Rating Index Ruleset</display_name>
@@ -142,12 +142,6 @@
       <checksum>EA632310</checksum>
     </file>
     <file>
-      <filename>301.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>706DF0C3</checksum>
-    </file>
-    <file>
       <filename>301validator.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -158,6 +152,12 @@
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
       <checksum>43DFC8EB</checksum>
+    </file>
+    <file>
+      <filename>301.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>73ACFE04</checksum>
     </file>
   </files>
 </measure>

--- a/rulesets/301EnergyRatingIndexRuleset/measure.xml
+++ b/rulesets/301EnergyRatingIndexRuleset/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>energy_rating_index_301_measure</name>
   <uid>02a31992-9a16-4945-bb51-e99209f7193b</uid>
-  <version_id>0f744b2d-1e44-4557-9e92-edca8a49b8e8</version_id>
-  <version_modified>20200901T003820Z</version_modified>
+  <version_id>236adefb-bd92-4790-8b2f-79f2c9a87637</version_id>
+  <version_modified>20200901T150504Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>EnergyRatingIndex301Measure</class_name>
   <display_name>Apply Energy Rating Index Ruleset</display_name>
@@ -157,7 +157,7 @@
       <filename>301.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>73ACFE04</checksum>
+      <checksum>58B69F72</checksum>
     </file>
   </files>
 </measure>

--- a/rulesets/301EnergyRatingIndexRuleset/measure.xml
+++ b/rulesets/301EnergyRatingIndexRuleset/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>energy_rating_index_301_measure</name>
   <uid>02a31992-9a16-4945-bb51-e99209f7193b</uid>
-  <version_id>58f49681-f083-4220-a8c3-99ccde3a090d</version_id>
-  <version_modified>20200827T202107Z</version_modified>
+  <version_id>3d0fcb5c-7f1a-4162-9090-b54d25f1eb24</version_id>
+  <version_modified>20200831T221155Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>EnergyRatingIndex301Measure</class_name>
   <display_name>Apply Energy Rating Index Ruleset</display_name>
@@ -145,19 +145,19 @@
       <filename>301.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>5F5F9EDE</checksum>
-    </file>
-    <file>
-      <filename>test_hvac.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>56137E23</checksum>
+      <checksum>706DF0C3</checksum>
     </file>
     <file>
       <filename>301validator.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>654BA61C</checksum>
+      <checksum>A989CA39</checksum>
+    </file>
+    <file>
+      <filename>test_hvac.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>43DFC8EB</checksum>
     </file>
   </files>
 </measure>

--- a/rulesets/301EnergyRatingIndexRuleset/resources/301.rb
+++ b/rulesets/301EnergyRatingIndexRuleset/resources/301.rb
@@ -1180,6 +1180,9 @@ class EnergyRatingIndex301Ruleset
 
     # Retain heating system(s)
     orig_hpxml.heating_systems.each do |orig_heating_system|
+      if (orig_heating_system.heating_system_type == HPXML::HVACTypeBoiler) && orig_heating_system.electric_auxiliary_energy.nil?
+        orig_heating_system.electric_auxiliary_energy = HVAC.get_default_eae(orig_heating_system, nil)
+      end
       new_hpxml.heating_systems.add(id: orig_heating_system.id,
                                     is_shared_system: orig_heating_system.is_shared_system,
                                     number_of_units_served: orig_heating_system.number_of_units_served,
@@ -1254,6 +1257,7 @@ class EnergyRatingIndex301Ruleset
                                heating_efficiency_hspf: orig_heat_pump.heating_efficiency_hspf,
                                heating_efficiency_cop: orig_heat_pump.heating_efficiency_cop,
                                shared_loop_watts: orig_heat_pump.shared_loop_watts,
+                               pump_watts_per_ton: orig_heat_pump.pump_watts_per_ton,
                                seed_id: orig_heat_pump.seed_id.nil? ? orig_heat_pump.id : orig_heat_pump.seed_id)
     end
     # Add reference heat pump for residual load
@@ -2452,6 +2456,7 @@ class EnergyRatingIndex301Ruleset
                                   heating_efficiency_afue: 0.80,
                                   fraction_heat_load_served: load_frac,
                                   seed_id: seed_id)
+    new_hpxml.heating_systems[-1].electric_auxiliary_energy = HVAC.get_default_eae(new_hpxml.heating_systems[-1], nil)
   end
 
   def self.add_reference_heating_heat_pump(new_hpxml, load_frac, orig_system = nil)

--- a/rulesets/301EnergyRatingIndexRuleset/resources/301.rb
+++ b/rulesets/301EnergyRatingIndexRuleset/resources/301.rb
@@ -1180,10 +1180,8 @@ class EnergyRatingIndex301Ruleset
 
     # Retain heating system(s)
     orig_hpxml.heating_systems.each do |orig_heating_system|
-      if (orig_heating_system.heating_system_type == HPXML::HVACTypeBoiler) && orig_heating_system.electric_auxiliary_energy.nil?
-        # Convert to EAE
-        orig_heating_system.electric_auxiliary_energy = HVAC.get_default_eae(orig_heating_system, nil)
-        orig_heating_system.shared_loop_watts = nil
+      if (orig_heating_system.heating_system_type == HPXML::HVACTypeBoiler)
+        orig_heating_system.electric_auxiliary_energy = HVAC.get_electric_auxiliary_energy(orig_heating_system)
       end
       new_hpxml.heating_systems.add(id: orig_heating_system.id,
                                     is_shared_system: orig_heating_system.is_shared_system,
@@ -1197,8 +1195,6 @@ class EnergyRatingIndex301Ruleset
                                     fraction_heat_load_served: orig_heating_system.fraction_heat_load_served,
                                     electric_auxiliary_energy: orig_heating_system.electric_auxiliary_energy,
                                     heating_cfm: orig_heating_system.heating_cfm,
-                                    shared_loop_watts: orig_heating_system.shared_loop_watts,
-                                    fan_coil_watts: orig_heating_system.fan_coil_watts,
                                     wlhp_heating_efficiency_cop: orig_heating_system.wlhp_heating_efficiency_cop,
                                     seed_id: orig_heating_system.seed_id.nil? ? orig_heating_system.id : orig_heating_system.seed_id)
     end
@@ -2458,7 +2454,7 @@ class EnergyRatingIndex301Ruleset
                                   heating_efficiency_afue: 0.80,
                                   fraction_heat_load_served: load_frac,
                                   seed_id: seed_id)
-    new_hpxml.heating_systems[-1].electric_auxiliary_energy = HVAC.get_default_eae(new_hpxml.heating_systems[-1], nil)
+    new_hpxml.heating_systems[-1].electric_auxiliary_energy = HVAC.get_electric_auxiliary_energy(new_hpxml.heating_systems[-1])
   end
 
   def self.add_reference_heating_heat_pump(new_hpxml, load_frac, orig_system = nil)

--- a/rulesets/301EnergyRatingIndexRuleset/resources/301.rb
+++ b/rulesets/301EnergyRatingIndexRuleset/resources/301.rb
@@ -1181,7 +1181,9 @@ class EnergyRatingIndex301Ruleset
     # Retain heating system(s)
     orig_hpxml.heating_systems.each do |orig_heating_system|
       if (orig_heating_system.heating_system_type == HPXML::HVACTypeBoiler) && orig_heating_system.electric_auxiliary_energy.nil?
+        # Convert to EAE
         orig_heating_system.electric_auxiliary_energy = HVAC.get_default_eae(orig_heating_system, nil)
+        orig_heating_system.shared_loop_watts = nil
       end
       new_hpxml.heating_systems.add(id: orig_heating_system.id,
                                     is_shared_system: orig_heating_system.is_shared_system,

--- a/rulesets/301EnergyRatingIndexRuleset/resources/301validator.rb
+++ b/rulesets/301EnergyRatingIndexRuleset/resources/301validator.rb
@@ -359,12 +359,12 @@ class EnergyRatingIndex301Validator
         '../../../../BuildingSummary/BuildingConstruction[ResidentialFacilityType[text()="single-family attached" or text()="apartment unit"]]' => one,
         '../../HVACDistribution[DistributionSystemType/HydronicDistribution[HydronicDistributionType[text()="radiator" or text()="baseboard" or text()="radiant floor" or text()="radiant ceiling"]] | DistributionSystemType/HydronicAndAirDistribution[HydronicAndAirDistributionType[text()="fan coil" or text()="water loop heat pump"]]]' => one, # See [HVACDistribution] or [SharedBoilerType=FanCoil] or [SharedBoilerType=WLHP]
         'NumberofUnitsServed' => one,
-        'extension/SharedLoopWatts' => one,
+        'ElectricAuxiliaryEnergy | extension/SharedLoopWatts' => zero_or_one,
       },
 
       ## [SharedBoilerType=FanCoil]
       '/HPXML/Building/BuildingDetails/Systems/HVAC/HVACPlant/HeatingSystem[HeatingSystemType/Boiler and IsSharedSystem="true" and //HydronicAndAirDistributionType[text()="fan coil"]]' => {
-        'extension/FanCoilWatts' => one,
+        'ElectricAuxiliaryEnergy | extension/FanCoilWatts' => zero_or_one,
       },
 
       ## [SharedBoilerType=WLHP]
@@ -518,6 +518,7 @@ class EnergyRatingIndex301Validator
         'BackupHeatingSwitchoverTemperature' => zero,
         'AnnualCoolingEfficiency[Units="EER"]/Value' => one,
         'AnnualHeatingEfficiency[Units="COP"]/Value' => one,
+        'extension/PumpPowerWattsPerTon' => one,
       },
 
       ## [GSHPType=SharedLoop]

--- a/rulesets/301EnergyRatingIndexRuleset/tests/test_hvac.rb
+++ b/rulesets/301EnergyRatingIndexRuleset/tests/test_hvac.rb
@@ -82,7 +82,7 @@ class ERIHVACtest < MiniTest::Test
     # Rated Home
     calc_type = Constants.CalcTypeERIRatedHome
     hpxml = _test_measure(hpxml_name, calc_type)
-    _check_heating_system(hpxml, [HPXML::HVACTypeBoiler, HPXML::FuelTypeElectricity, nil, 1.0, nil])
+    _check_heating_system(hpxml, [HPXML::HVACTypeBoiler, HPXML::FuelTypeElectricity, nil, 1.0, nil, 170])
     _check_cooling_system(hpxml, [HPXML::HVACTypeCentralAirConditioner, HPXML::FuelTypeElectricity, HPXML::HVACCompressorTypeSingleStage, 13, 1.0, _dse(calc_type), nil])
     _check_heat_pump(hpxml)
     _check_thermostat(hpxml, HPXML::HVACControlTypeManual, 68, 78)
@@ -97,7 +97,7 @@ class ERIHVACtest < MiniTest::Test
                   Constants.CalcTypeERIIndexAdjustmentReferenceHome]
     calc_types.each do |calc_type|
       hpxml = _test_measure(hpxml_name, calc_type)
-      _check_heating_system(hpxml, [HPXML::HVACTypeBoiler, HPXML::FuelTypeNaturalGas, 0.80, 1.0, _dse(calc_type)])
+      _check_heating_system(hpxml, [HPXML::HVACTypeBoiler, HPXML::FuelTypeNaturalGas, 0.80, 1.0, _dse(calc_type), 170])
       _check_cooling_system(hpxml, [HPXML::HVACTypeCentralAirConditioner, HPXML::FuelTypeElectricity, HPXML::HVACCompressorTypeSingleStage, 13, 1.0, _dse(calc_type), nil])
       _check_heat_pump(hpxml)
       _check_thermostat(hpxml, HPXML::HVACControlTypeManual, 68, 78)
@@ -106,7 +106,7 @@ class ERIHVACtest < MiniTest::Test
     # Rated Home
     calc_type = Constants.CalcTypeERIRatedHome
     hpxml = _test_measure(hpxml_name, calc_type)
-    _check_heating_system(hpxml, [HPXML::HVACTypeBoiler, HPXML::FuelTypeNaturalGas, nil, 1.0, nil])
+    _check_heating_system(hpxml, [HPXML::HVACTypeBoiler, HPXML::FuelTypeNaturalGas, nil, 1.0, nil, 200])
     _check_cooling_system(hpxml, [HPXML::HVACTypeCentralAirConditioner, HPXML::FuelTypeElectricity, HPXML::HVACCompressorTypeSingleStage, 13, 1.0, _dse(calc_type), nil])
     _check_heat_pump(hpxml)
     _check_thermostat(hpxml, HPXML::HVACControlTypeManual, 68, 78)
@@ -154,7 +154,7 @@ class ERIHVACtest < MiniTest::Test
     # Rated Home
     calc_type = Constants.CalcTypeERIRatedHome
     hpxml = _test_measure(hpxml_name, calc_type)
-    _check_heating_system(hpxml, [HPXML::HVACTypeFurnace, HPXML::FuelTypeNaturalGas, nil, 1.0, nil])
+    _check_heating_system(hpxml, [HPXML::HVACTypeFurnace, HPXML::FuelTypeNaturalGas, nil, 1.0, nil, 700])
     _check_cooling_system(hpxml, [HPXML::HVACTypeCentralAirConditioner, HPXML::FuelTypeElectricity, HPXML::HVACCompressorTypeSingleStage, 13, 1.0, _dse(calc_type), nil])
     _check_heat_pump(hpxml)
     _check_thermostat(hpxml, HPXML::HVACControlTypeManual, 68, 78)
@@ -178,7 +178,7 @@ class ERIHVACtest < MiniTest::Test
     # Rated Home
     calc_type = Constants.CalcTypeERIRatedHome
     hpxml = _test_measure(hpxml_name, calc_type)
-    _check_heating_system(hpxml, [HPXML::HVACTypeStove, HPXML::FuelTypeOil, nil, 1.0, nil])
+    _check_heating_system(hpxml, [HPXML::HVACTypeStove, HPXML::FuelTypeOil, nil, 1.0, nil, 200])
     _check_cooling_system(hpxml, [HPXML::HVACTypeCentralAirConditioner, HPXML::FuelTypeElectricity, HPXML::HVACCompressorTypeSingleStage, 13, 1.0, _dse(calc_type), nil])
     _check_heat_pump(hpxml)
     _check_thermostat(hpxml, HPXML::HVACControlTypeManual, 68, 78)
@@ -202,7 +202,7 @@ class ERIHVACtest < MiniTest::Test
     # Rated Home
     calc_type = Constants.CalcTypeERIRatedHome
     hpxml = _test_measure(hpxml_name, calc_type)
-    _check_heating_system(hpxml, [HPXML::HVACTypeWallFurnace, HPXML::FuelTypeElectricity, nil, 1.0, nil])
+    _check_heating_system(hpxml, [HPXML::HVACTypeWallFurnace, HPXML::FuelTypeElectricity, nil, 1.0, nil, 200])
     _check_cooling_system(hpxml, [HPXML::HVACTypeCentralAirConditioner, HPXML::FuelTypeElectricity, HPXML::HVACCompressorTypeSingleStage, 13, 1.0, _dse(calc_type), nil])
     _check_heat_pump(hpxml)
     _check_thermostat(hpxml, HPXML::HVACControlTypeManual, 68, 78)
@@ -322,7 +322,7 @@ class ERIHVACtest < MiniTest::Test
     # Rated Home
     calc_type = Constants.CalcTypeERIRatedHome
     hpxml = _test_measure(hpxml_name, calc_type)
-    _check_heat_pump(hpxml, [HPXML::HVACTypeHeatPumpGroundToAir, HPXML::FuelTypeElectricity, nil, nil, nil, 1.0, 1.0, nil, 0.73, HPXML::FuelTypeElectricity, 1.0, nil])
+    _check_heat_pump(hpxml, [HPXML::HVACTypeHeatPumpGroundToAir, HPXML::FuelTypeElectricity, nil, nil, nil, 1.0, 1.0, nil, 0.73, HPXML::FuelTypeElectricity, 1.0, nil, 30])
     _check_cooling_system(hpxml)
     _check_heating_system(hpxml)
     _check_thermostat(hpxml, HPXML::HVACControlTypeManual, 68, 78)
@@ -518,7 +518,7 @@ class ERIHVACtest < MiniTest::Test
                             [HPXML::HVACTypeCentralAirConditioner, HPXML::FuelTypeElectricity, HPXML::HVACCompressorTypeSingleStage, 13, 0.2, _dse(calc_type), 0.73],
                             [HPXML::HVACTypeCentralAirConditioner, HPXML::FuelTypeElectricity, HPXML::HVACCompressorTypeSingleStage, 13, 0.2, _dse(calc_type), 0.73])
       _check_heating_system(hpxml, [HPXML::HVACTypeFurnace, HPXML::FuelTypeNaturalGas, 0.78, 0.1, _dse(calc_type)],
-                            [HPXML::HVACTypeBoiler, HPXML::FuelTypeNaturalGas, 0.8, 0.1, _dse(calc_type)],
+                            [HPXML::HVACTypeBoiler, HPXML::FuelTypeNaturalGas, 0.8, 0.1, _dse(calc_type), 170],
                             [HPXML::HVACTypeFurnace, HPXML::FuelTypeNaturalGas, 0.78, 0.1, _dse(calc_type)],
                             [HPXML::HVACTypeFurnace, HPXML::FuelTypeNaturalGas, 0.78, 0.1, _dse(calc_type)])
       _check_heat_pump(hpxml, [HPXML::HVACTypeHeatPumpAirToAir, HPXML::FuelTypeElectricity, HPXML::HVACCompressorTypeSingleStage, 7.7, nil, 0.1, 0.0, _dse(calc_type), nil, HPXML::FuelTypeElectricity, 1.0, nil],
@@ -536,14 +536,14 @@ class ERIHVACtest < MiniTest::Test
     _check_cooling_system(hpxml, [HPXML::HVACTypeCentralAirConditioner, HPXML::FuelTypeElectricity, nil, nil, 0.2, nil, 0.73],
                           [HPXML::HVACTypeRoomAirConditioner, HPXML::FuelTypeElectricity, nil, nil, 0.2, nil, 0.65])
     _check_heating_system(hpxml, [HPXML::HVACTypeFurnace, HPXML::FuelTypeElectricity, nil, 0.1, nil],
-                          [HPXML::HVACTypeFurnace, HPXML::FuelTypeNaturalGas, nil, 0.1, nil],
-                          [HPXML::HVACTypeBoiler, HPXML::FuelTypeElectricity, nil, 0.1, nil],
-                          [HPXML::HVACTypeBoiler, HPXML::FuelTypeNaturalGas, nil, 0.1, nil],
+                          [HPXML::HVACTypeFurnace, HPXML::FuelTypeNaturalGas, nil, 0.1, nil, 700],
+                          [HPXML::HVACTypeBoiler, HPXML::FuelTypeElectricity, nil, 0.1, nil, 170],
+                          [HPXML::HVACTypeBoiler, HPXML::FuelTypeNaturalGas, nil, 0.1, nil, 200],
                           [HPXML::HVACTypeElectricResistance, HPXML::FuelTypeElectricity, nil, 0.1, nil],
-                          [HPXML::HVACTypeStove, HPXML::FuelTypeOil, nil, 0.1, nil],
-                          [HPXML::HVACTypeWallFurnace, HPXML::FuelTypePropane, nil, 0.1, nil])
+                          [HPXML::HVACTypeStove, HPXML::FuelTypeOil, nil, 0.1, nil, 200],
+                          [HPXML::HVACTypeWallFurnace, HPXML::FuelTypePropane, nil, 0.1, nil, 200])
     _check_heat_pump(hpxml, [HPXML::HVACTypeHeatPumpAirToAir, HPXML::FuelTypeElectricity, nil, nil, nil, 0.1, 0.2, nil, 0.73, HPXML::FuelTypeElectricity, 1.0, nil],
-                     [HPXML::HVACTypeHeatPumpGroundToAir, HPXML::FuelTypeElectricity, nil, nil, nil, 0.1, 0.2, nil, 0.73, HPXML::FuelTypeElectricity, 1.0, nil],
+                     [HPXML::HVACTypeHeatPumpGroundToAir, HPXML::FuelTypeElectricity, nil, nil, nil, 0.1, 0.2, nil, 0.73, HPXML::FuelTypeElectricity, 1.0, nil, 30],
                      [HPXML::HVACTypeHeatPumpMiniSplit, HPXML::FuelTypeElectricity, nil, nil, nil, 0.1, 0.2, nil, 0.73, HPXML::FuelTypeElectricity, 1.0, nil])
     _check_thermostat(hpxml, HPXML::HVACControlTypeManual, 68, 78)
   end
@@ -593,7 +593,7 @@ class ERIHVACtest < MiniTest::Test
                   Constants.CalcTypeERIIndexAdjustmentReferenceHome]
     calc_types.each do |calc_type|
       hpxml = _test_measure(hpxml_name, calc_type)
-      _check_heating_system(hpxml, [HPXML::HVACTypeBoiler, HPXML::FuelTypeNaturalGas, 0.80, 1.0, _dse(calc_type), 1])
+      _check_heating_system(hpxml, [HPXML::HVACTypeBoiler, HPXML::FuelTypeNaturalGas, 0.80, 1.0, _dse(calc_type), 170, 1])
       _check_cooling_system(hpxml, [HPXML::HVACTypeCentralAirConditioner, HPXML::FuelTypeElectricity, HPXML::HVACCompressorTypeSingleStage, 13, 1.0, _dse(calc_type), nil])
       _check_heat_pump(hpxml)
       _check_thermostat(hpxml, HPXML::HVACControlTypeManual, 68, 78)
@@ -602,7 +602,7 @@ class ERIHVACtest < MiniTest::Test
     # Rated Home
     calc_type = Constants.CalcTypeERIRatedHome
     hpxml = _test_measure(hpxml_name, calc_type)
-    _check_heating_system(hpxml, [HPXML::HVACTypeBoiler, HPXML::FuelTypeNaturalGas, nil, 1.0, nil, 6])
+    _check_heating_system(hpxml, [HPXML::HVACTypeBoiler, HPXML::FuelTypeNaturalGas, nil, 1.0, nil, 208, 6])
     _check_cooling_system(hpxml, [HPXML::HVACTypeCentralAirConditioner, HPXML::FuelTypeElectricity, HPXML::HVACCompressorTypeSingleStage, 13, 1.0, _dse(calc_type), nil])
     _check_heat_pump(hpxml)
     _check_thermostat(hpxml, HPXML::HVACControlTypeManual, 68, 78)
@@ -617,7 +617,7 @@ class ERIHVACtest < MiniTest::Test
                   Constants.CalcTypeERIIndexAdjustmentReferenceHome]
     calc_types.each do |calc_type|
       hpxml = _test_measure(hpxml_name, calc_type)
-      _check_heating_system(hpxml, [HPXML::HVACTypeBoiler, HPXML::FuelTypeNaturalGas, 0.80, 1 - 1 / 4.4, _dse(calc_type), 1])
+      _check_heating_system(hpxml, [HPXML::HVACTypeBoiler, HPXML::FuelTypeNaturalGas, 0.80, 1 - 1 / 4.4, _dse(calc_type), 170, 1])
       _check_cooling_system(hpxml, [HPXML::HVACTypeCentralAirConditioner, HPXML::FuelTypeElectricity, HPXML::HVACCompressorTypeSingleStage, 13, 1.0, _dse(calc_type), nil])
       _check_heat_pump(hpxml, [HPXML::HVACTypeHeatPumpAirToAir, HPXML::FuelTypeElectricity, HPXML::HVACCompressorTypeSingleStage, 7.7, nil, 1 / 4.4, 0.0, _dse(calc_type), nil, HPXML::FuelTypeElectricity, 1.0, nil])
       _check_thermostat(hpxml, HPXML::HVACControlTypeManual, 68, 78)
@@ -626,7 +626,7 @@ class ERIHVACtest < MiniTest::Test
     # Rated Home
     calc_type = Constants.CalcTypeERIRatedHome
     hpxml = _test_measure(hpxml_name, calc_type)
-    _check_heating_system(hpxml, [HPXML::HVACTypeBoiler, HPXML::FuelTypeNaturalGas, nil, 1.0, nil, 6])
+    _check_heating_system(hpxml, [HPXML::HVACTypeBoiler, HPXML::FuelTypeNaturalGas, nil, 1.0, nil, 208, 6])
     _check_cooling_system(hpxml, [HPXML::HVACTypeCentralAirConditioner, HPXML::FuelTypeElectricity, HPXML::HVACCompressorTypeSingleStage, 13, 1.0, _dse(calc_type), nil])
     _check_heat_pump(hpxml)
     _check_thermostat(hpxml, HPXML::HVACControlTypeManual, 68, 78)
@@ -642,7 +642,7 @@ class ERIHVACtest < MiniTest::Test
     calc_types.each do |calc_type|
       hpxml = _test_measure(hpxml_name, calc_type)
       _check_cooling_system(hpxml, [HPXML::HVACTypeCentralAirConditioner, HPXML::FuelTypeElectricity, HPXML::HVACCompressorTypeSingleStage, 13, 1.0, _dse(calc_type), nil])
-      _check_heating_system(hpxml, [HPXML::HVACTypeFurnace, HPXML::FuelTypeNaturalGas, 0.78, 1.0, _dse(calc_type)])
+      _check_heating_system(hpxml, [HPXML::HVACTypeFurnace, HPXML::FuelTypeNaturalGas, 0.78, 1.0, _dse(calc_type), nil, 1])
       _check_heat_pump(hpxml)
       _check_thermostat(hpxml, HPXML::HVACControlTypeManual, 68, 78)
     end
@@ -666,7 +666,7 @@ class ERIHVACtest < MiniTest::Test
     calc_types.each do |calc_type|
       hpxml = _test_measure(hpxml_name, calc_type)
       _check_cooling_system(hpxml, [HPXML::HVACTypeCentralAirConditioner, HPXML::FuelTypeElectricity, HPXML::HVACCompressorTypeSingleStage, 13, 1.0, _dse(calc_type), nil])
-      _check_heating_system(hpxml, [HPXML::HVACTypeFurnace, HPXML::FuelTypeNaturalGas, 0.78, 1.0, _dse(calc_type)])
+      _check_heating_system(hpxml, [HPXML::HVACTypeFurnace, HPXML::FuelTypeNaturalGas, 0.78, 1.0, _dse(calc_type), nil, 1])
       _check_heat_pump(hpxml)
       _check_thermostat(hpxml, HPXML::HVACControlTypeManual, 68, 78)
     end
@@ -690,7 +690,7 @@ class ERIHVACtest < MiniTest::Test
     calc_types.each do |calc_type|
       hpxml = _test_measure(hpxml_name, calc_type)
       _check_cooling_system(hpxml, [HPXML::HVACTypeCentralAirConditioner, HPXML::FuelTypeElectricity, HPXML::HVACCompressorTypeSingleStage, 13, 1.0, _dse(calc_type), nil])
-      _check_heating_system(hpxml, [HPXML::HVACTypeFurnace, HPXML::FuelTypeNaturalGas, 0.78, 1.0, _dse(calc_type)])
+      _check_heating_system(hpxml, [HPXML::HVACTypeFurnace, HPXML::FuelTypeNaturalGas, 0.78, 1.0, _dse(calc_type), nil, 1])
       _check_heat_pump(hpxml)
       _check_thermostat(hpxml, HPXML::HVACControlTypeManual, 68, 78)
     end
@@ -722,7 +722,7 @@ class ERIHVACtest < MiniTest::Test
     # Rated Home
     calc_type = Constants.CalcTypeERIRatedHome
     hpxml = _test_measure(hpxml_name, calc_type)
-    _check_heat_pump(hpxml, [HPXML::HVACTypeHeatPumpGroundToAir, HPXML::FuelTypeElectricity, nil, nil, nil, 1.0, 1.0, nil, 0.73, HPXML::FuelTypeElectricity, 1.0, nil, 6])
+    _check_heat_pump(hpxml, [HPXML::HVACTypeHeatPumpGroundToAir, HPXML::FuelTypeElectricity, nil, nil, nil, 1.0, 1.0, nil, 0.73, HPXML::FuelTypeElectricity, 1.0, nil, 30, 6])
     _check_cooling_system(hpxml)
     _check_heating_system(hpxml)
     _check_thermostat(hpxml, HPXML::HVACControlTypeManual, 68, 78)
@@ -910,7 +910,7 @@ class ERIHVACtest < MiniTest::Test
   def _check_heating_system(hpxml, *systems)
     assert_equal(systems.size, hpxml.heating_systems.size)
     hpxml.heating_systems.each_with_index do |heating_system, idx|
-      systype, fueltype, afue, frac_load, dse, num_units_served = systems[idx]
+      systype, fueltype, afue, frac_load, dse, eae, num_units_served = systems[idx]
       if num_units_served.to_f > 1
         assert_equal(true, heating_system.is_shared_system)
         assert_equal(num_units_served, heating_system.number_of_units_served)
@@ -924,6 +924,11 @@ class ERIHVACtest < MiniTest::Test
         assert_equal(afue, heating_system.heating_efficiency_afue)
       end
       assert_equal(frac_load, heating_system.fraction_heat_load_served)
+      if eae.nil?
+        assert_nil(heating_system.electric_auxiliary_energy)
+      else
+        assert_in_epsilon(eae, heating_system.electric_auxiliary_energy, 0.01)
+      end
       dist_system = heating_system.distribution_system
       if dse.nil?
         assert(dist_system.nil? || dist_system.annual_heating_dse.nil?)
@@ -936,7 +941,7 @@ class ERIHVACtest < MiniTest::Test
   def _check_heat_pump(hpxml, *systems)
     assert_equal(systems.size, hpxml.heat_pumps.size)
     hpxml.heat_pumps.each_with_index do |heat_pump, idx|
-      systype, fueltype, comptype, hspf, seer, frac_load_heat, frac_load_cool, dse, shr, backup_fuel, backup_eff, backup_temp, num_units_served = systems[idx]
+      systype, fueltype, comptype, hspf, seer, frac_load_heat, frac_load_cool, dse, shr, backup_fuel, backup_eff, backup_temp, pump_w_per_ton, num_units_served = systems[idx]
       if num_units_served.to_f > 1
         assert_equal(true, heat_pump.is_shared_system)
         assert_equal(num_units_served, heat_pump.number_of_units_served)
@@ -985,6 +990,11 @@ class ERIHVACtest < MiniTest::Test
         assert_nil(heat_pump.backup_heating_switchover_temp)
       else
         assert_equal(backup_temp, heat_pump.backup_heating_switchover_temp)
+      end
+      if pump_w_per_ton.nil?
+        assert_nil(heat_pump.pump_watts_per_ton)
+      else
+        assert_equal(pump_w_per_ton, heat_pump.pump_watts_per_ton)
       end
     end
   end

--- a/workflow/sample_files/base-hvac-ground-to-air-heat-pump.xml
+++ b/workflow/sample_files/base-hvac-ground-to-air-heat-pump.xml
@@ -331,6 +331,9 @@
                 <Units>COP</Units>
                 <Value>3.6</Value>
               </AnnualHeatingEfficiency>
+              <extension>
+                <PumpPowerWattsPerTon>30.0</PumpPowerWattsPerTon>
+              </extension>
             </HeatPump>
           </HVACPlant>
           <HVACControl>

--- a/workflow/sample_files/base-hvac-multiple.xml
+++ b/workflow/sample_files/base-hvac-multiple.xml
@@ -485,6 +485,9 @@
                 <Units>COP</Units>
                 <Value>3.6</Value>
               </AnnualHeatingEfficiency>
+              <extension>
+                <PumpPowerWattsPerTon>30.0</PumpPowerWattsPerTon>
+              </extension>
             </HeatPump>
             <HeatPump>
               <SystemIdentifier id='HeatPump3'/>

--- a/workflow/sample_files/base-hvac-multiple2.xml
+++ b/workflow/sample_files/base-hvac-multiple2.xml
@@ -442,6 +442,9 @@
                 <Units>COP</Units>
                 <Value>3.6</Value>
               </AnnualHeatingEfficiency>
+              <extension>
+                <PumpPowerWattsPerTon>30.0</PumpPowerWattsPerTon>
+              </extension>
             </HeatPump>
           </HVACPlant>
           <HVACControl>

--- a/workflow/sample_files/base-hvac-shared-ground-loop-ground-to-air-heat-pump.xml
+++ b/workflow/sample_files/base-hvac-shared-ground-loop-ground-to-air-heat-pump.xml
@@ -560,6 +560,7 @@
                 <Value>3.6</Value>
               </AnnualHeatingEfficiency>
               <extension>
+                <PumpPowerWattsPerTon>30.0</PumpPowerWattsPerTon>
                 <SharedLoopWatts>600.0</SharedLoopWatts>
               </extension>
             </HeatPump>

--- a/workflow/sample_files/invalid_files/hvac-frac-load-served.xml
+++ b/workflow/sample_files/invalid_files/hvac-frac-load-served.xml
@@ -485,6 +485,9 @@
                 <Units>COP</Units>
                 <Value>3.6</Value>
               </AnnualHeatingEfficiency>
+              <extension>
+                <PumpPowerWattsPerTon>30.0</PumpPowerWattsPerTon>
+              </extension>
             </HeatPump>
             <HeatPump>
               <SystemIdentifier id='HeatPump3'/>


### PR DESCRIPTION
## Pull Request Description

- Allows shared boiler electric auxiliary energy to be entered (`ElectricAuxiliaryEnergy`) or defaulted (not provided), as alternatives to the option of calculating it based on shared loop power (`extension/SharedLoopWatts`).
- Adds `extension/PumpPowerWattsPerTon` as a required input for ground source heat pumps.

## Checklist

Not all may apply:

- [x] OS-HPXML git subtree has been pulled
- [x] 301 ruleset and unit tests have been updated
- [x] 301validator.rb has been updated (reference EPvalidator.rb)
- [ ] Workflow tests have been updated
- [x] Documentation has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
