### PR TITLE
301-2019 ceiling fan bugfix

### DIFF
--- a/hpxml-measures/HPXMLtoOpenStudio/tests/test_defaults.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/tests/test_defaults.rb
@@ -755,6 +755,8 @@ class HPXMLtoOpenStudioDefaultsTest < MiniTest::Test
   def test_ceiling_fans
     # Test inputs not overridden by defaults
     hpxml = _create_hpxml('base-lighting-ceiling-fans.xml')
+    hpxml.ceiling_fans[0].quantity = 2
+    hpxml.ceiling_fans[0].efficiency = 100
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
     hpxml_default = _test_measure()
     _test_default_ceiling_fan_values(hpxml_default, 2, 100)

--- a/hpxml-measures/tasks.rb
+++ b/hpxml-measures/tasks.rb
@@ -4690,7 +4690,7 @@ def set_hpxml_ceiling_fans(hpxml_file, hpxml)
   if ['base-lighting-ceiling-fans.xml'].include? hpxml_file
     hpxml.ceiling_fans.add(id: 'CeilingFan',
                            efficiency: 100,
-                           quantity: 2)
+                           quantity: 4)
   elsif ['base-misc-defaults.xml'].include? hpxml_file
     hpxml.ceiling_fans.add(id: 'CeilingFan',
                            efficiency: nil,

--- a/hpxml-measures/workflow/sample_files/base-lighting-ceiling-fans.xml
+++ b/hpxml-measures/workflow/sample_files/base-lighting-ceiling-fans.xml
@@ -545,7 +545,7 @@
             <FanSpeed>medium</FanSpeed>
             <Efficiency>100.0</Efficiency>
           </Airflow>
-          <Quantity>2</Quantity>
+          <Quantity>4</Quantity>
         </CeilingFan>
       </Lighting>
       <MiscLoads>

--- a/rulesets/301EnergyRatingIndexRuleset/measure.xml
+++ b/rulesets/301EnergyRatingIndexRuleset/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>energy_rating_index_301_measure</name>
   <uid>02a31992-9a16-4945-bb51-e99209f7193b</uid>
-  <version_id>8094909d-20c8-4090-9b0d-b9cbcde7aecc</version_id>
-  <version_modified>20201009T171132Z</version_modified>
+  <version_id>2bfd14d0-a532-4770-be74-6918e5b94e8f</version_id>
+  <version_modified>20201009T172822Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>EnergyRatingIndex301Measure</class_name>
   <display_name>Apply Energy Rating Index Ruleset</display_name>
@@ -154,16 +154,16 @@
       <checksum>ADC760F6</checksum>
     </file>
     <file>
-      <filename>test_lighting.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>BE66B0E3</checksum>
-    </file>
-    <file>
       <filename>301.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>5E28A77E</checksum>
+    </file>
+    <file>
+      <filename>test_lighting.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>27E4B3DE</checksum>
     </file>
   </files>
 </measure>

--- a/rulesets/301EnergyRatingIndexRuleset/measure.xml
+++ b/rulesets/301EnergyRatingIndexRuleset/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>energy_rating_index_301_measure</name>
   <uid>02a31992-9a16-4945-bb51-e99209f7193b</uid>
-  <version_id>79da0939-1c65-498c-986e-0bea90728b99</version_id>
-  <version_modified>20201001T010619Z</version_modified>
+  <version_id>8094909d-20c8-4090-9b0d-b9cbcde7aecc</version_id>
+  <version_modified>20201009T171132Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>EnergyRatingIndex301Measure</class_name>
   <display_name>Apply Energy Rating Index Ruleset</display_name>
@@ -95,12 +95,6 @@
       <checksum>6AF1052D</checksum>
     </file>
     <file>
-      <filename>test_lighting.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>BCA3CC8B</checksum>
-    </file>
-    <file>
       <filename>test_water_heating.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -154,16 +148,22 @@
       <checksum>6D824A43</checksum>
     </file>
     <file>
-      <filename>301.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>8431B9FD</checksum>
-    </file>
-    <file>
       <filename>301validator.xml</filename>
       <filetype>xml</filetype>
       <usage_type>resource</usage_type>
       <checksum>ADC760F6</checksum>
+    </file>
+    <file>
+      <filename>test_lighting.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>BE66B0E3</checksum>
+    </file>
+    <file>
+      <filename>301.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>5E28A77E</checksum>
     </file>
   </files>
 </measure>

--- a/rulesets/301EnergyRatingIndexRuleset/measure.xml
+++ b/rulesets/301EnergyRatingIndexRuleset/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>energy_rating_index_301_measure</name>
   <uid>02a31992-9a16-4945-bb51-e99209f7193b</uid>
-  <version_id>2bfd14d0-a532-4770-be74-6918e5b94e8f</version_id>
-  <version_modified>20201009T172822Z</version_modified>
+  <version_id>7366eaf9-a776-4d66-95d9-6fc65ba4861c</version_id>
+  <version_modified>20201009T192549Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>EnergyRatingIndex301Measure</class_name>
   <display_name>Apply Energy Rating Index Ruleset</display_name>
@@ -107,12 +107,6 @@
       <checksum>F8363BEC</checksum>
     </file>
     <file>
-      <filename>test_hvac.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>EA0EBD7A</checksum>
-    </file>
-    <file>
       <filename>test_enclosure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -154,16 +148,22 @@
       <checksum>ADC760F6</checksum>
     </file>
     <file>
+      <filename>test_hvac.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>4740FDF9</checksum>
+    </file>
+    <file>
       <filename>301.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>5E28A77E</checksum>
+      <checksum>CE78313F</checksum>
     </file>
     <file>
       <filename>test_lighting.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>27E4B3DE</checksum>
+      <checksum>69AB1734</checksum>
     </file>
   </files>
 </measure>

--- a/rulesets/301EnergyRatingIndexRuleset/resources/301.rb
+++ b/rulesets/301EnergyRatingIndexRuleset/resources/301.rb
@@ -2143,21 +2143,35 @@ class EnergyRatingIndex301Ruleset
   end
 
   def self.set_ceiling_fans_reference(orig_hpxml, new_hpxml)
-    return if orig_hpxml.ceiling_fans.size == 0
+    n_fans = orig_hpxml.ceiling_fans.map { |cf| cf.quantity }.sum(0)
+    if (Constants.ERIVersions.index(@eri_version) >= Constants.ERIVersions.index('2019')) && (n_fans < @nbeds + 1)
+      # In 301-2019, no ceiling fans in Reference Home if number of ceiling fans
+      # is less than Nbr + 1.
+      return
+    elsif n_fans < 1
+      # In 301-2014, no ceiling fans in Reference Home if no ceiling fans.
+      return
+    end
 
     medium_cfm = 3000.0
-
     new_hpxml.ceiling_fans.add(id: 'CeilingFans',
                                efficiency: medium_cfm / HVAC.get_default_ceiling_fan_power(),
                                quantity: HVAC.get_default_ceiling_fan_quantity(@nbeds))
   end
 
   def self.set_ceiling_fans_rated(orig_hpxml, new_hpxml)
-    return if orig_hpxml.ceiling_fans.size == 0
-
-    medium_cfm = 3000.0
+    n_fans = orig_hpxml.ceiling_fans.map { |cf| cf.quantity }.sum(0)
+    if (Constants.ERIVersions.index(@eri_version) >= Constants.ERIVersions.index('2019')) && (n_fans < @nbeds + 1)
+      # In 301-2019, no ceiling fans in Reference Home if number of ceiling fans
+      # is less than Nbr + 1.
+      return
+    elsif n_fans < 1
+      # In 301-2014, no ceiling fans in Reference Home if no ceiling fans.
+      return
+    end
 
     # Calculate average ceiling fan wattage
+    medium_cfm = 3000.0
     sum_w = 0.0
     num_cfs = 0
     orig_hpxml.ceiling_fans.each do |orig_ceiling_fan|

--- a/rulesets/301EnergyRatingIndexRuleset/resources/301.rb
+++ b/rulesets/301EnergyRatingIndexRuleset/resources/301.rb
@@ -1109,16 +1109,10 @@ class EnergyRatingIndex301Ruleset
 
     # Table 303.4.1(1) - Thermostat
     control_type = HPXML::HVACControlTypeManual
-    if orig_hpxml.ceiling_fans.size > 0
-      clg_ceiling_fan_offset = 0.5 # deg-F
-    else
-      clg_ceiling_fan_offset = nil
-    end
     new_hpxml.hvac_controls.add(id: 'HVACControl',
                                 control_type: control_type,
                                 heating_setpoint_temp: HVAC.get_default_heating_setpoint(control_type)[0],
-                                cooling_setpoint_temp: HVAC.get_default_cooling_setpoint(control_type)[0],
-                                ceiling_fan_cooling_setpoint_temp_offset: clg_ceiling_fan_offset)
+                                cooling_setpoint_temp: HVAC.get_default_cooling_setpoint(control_type)[0])
 
     # Distribution system
     add_reference_distribution_system(new_hpxml)
@@ -1218,11 +1212,6 @@ class EnergyRatingIndex301Ruleset
     end
 
     # Table 303.4.1(1) - Thermostat
-    if orig_hpxml.ceiling_fans.size > 0
-      clg_ceiling_fan_offset = 0.5 # deg-F
-    else
-      clg_ceiling_fan_offset = nil
-    end
     if orig_hpxml.hvac_controls.size > 0
       hvac_control = orig_hpxml.hvac_controls[0]
       control_type = hvac_control.control_type
@@ -1237,16 +1226,14 @@ class EnergyRatingIndex301Ruleset
                                   cooling_setpoint_temp: clg_sp,
                                   cooling_setup_temp: clg_setup_sp,
                                   cooling_setup_hours_per_week: clg_setup_hrs_per_week,
-                                  cooling_setup_start_hour: clg_setup_start_hr,
-                                  ceiling_fan_cooling_setpoint_temp_offset: clg_ceiling_fan_offset)
+                                  cooling_setup_start_hour: clg_setup_start_hr)
 
     else
       control_type = HPXML::HVACControlTypeManual
       new_hpxml.hvac_controls.add(id: 'HVACControl',
                                   control_type: control_type,
                                   heating_setpoint_temp: HVAC.get_default_heating_setpoint(control_type)[0],
-                                  cooling_setpoint_temp: HVAC.get_default_cooling_setpoint(control_type)[0],
-                                  ceiling_fan_cooling_setpoint_temp_offset: clg_ceiling_fan_offset)
+                                  cooling_setpoint_temp: HVAC.get_default_cooling_setpoint(control_type)[0])
     end
 
     # Table 4.2.2(1) - Thermal distribution systems
@@ -2157,6 +2144,7 @@ class EnergyRatingIndex301Ruleset
     new_hpxml.ceiling_fans.add(id: 'CeilingFans',
                                efficiency: medium_cfm / HVAC.get_default_ceiling_fan_power(),
                                quantity: HVAC.get_default_ceiling_fan_quantity(@nbeds))
+    new_hpxml.hvac_controls[0].ceiling_fan_cooling_setpoint_temp_offset = 0.5
   end
 
   def self.set_ceiling_fans_rated(orig_hpxml, new_hpxml)
@@ -2188,6 +2176,7 @@ class EnergyRatingIndex301Ruleset
     new_hpxml.ceiling_fans.add(id: 'CeilingFans',
                                efficiency: medium_cfm / avg_w,
                                quantity: HVAC.get_default_ceiling_fan_quantity(@nbeds))
+    new_hpxml.hvac_controls[0].ceiling_fan_cooling_setpoint_temp_offset = 0.5
   end
 
   def self.set_ceiling_fans_iad(orig_hpxml, new_hpxml)

--- a/rulesets/301EnergyRatingIndexRuleset/tests/test_hvac.rb
+++ b/rulesets/301EnergyRatingIndexRuleset/tests/test_hvac.rb
@@ -745,20 +745,6 @@ class ERIHVACtest < MiniTest::Test
     _check_thermostat(hpxml, HPXML::HVACControlTypeProgrammable, 68, 78, 66, 7 * 7, 23, 80, 6 * 7, 9)
   end
 
-  def test_ceiling_fan
-    hpxml_name = 'base-lighting-ceiling-fans.xml'
-
-    # Rated Home, Reference Home, IAD, IAD Reference
-    calc_types = [Constants.CalcTypeERIRatedHome,
-                  Constants.CalcTypeERIReferenceHome,
-                  Constants.CalcTypeERIIndexAdjustmentDesign,
-                  Constants.CalcTypeERIIndexAdjustmentReferenceHome]
-    calc_types.each do |calc_type|
-      hpxml = _test_measure(hpxml_name, calc_type)
-      _check_thermostat(hpxml, HPXML::HVACControlTypeManual, 68, 78, nil, nil, nil, nil, nil, nil, 0.5)
-    end
-  end
-
   def test_custom_setpoints
     hpxml_name = 'base-hvac-setpoints.xml'
 
@@ -1040,7 +1026,7 @@ class ERIHVACtest < MiniTest::Test
   end
 
   def _check_thermostat(hpxml, control_type, htg_sp, clg_sp, htg_setback = nil, htg_setback_hrs = nil, htg_setback_start_hr = nil,
-                        clg_setup = nil, clg_setup_hrs = nil, clg_setup_start_hr = nil, ceiling_fan_offset = nil)
+                        clg_setup = nil, clg_setup_hrs = nil, clg_setup_start_hr = nil)
     assert_equal(1, hpxml.hvac_controls.size)
     hvac_control = hpxml.hvac_controls[0]
     assert_equal(control_type, hvac_control.control_type)
@@ -1077,12 +1063,6 @@ class ERIHVACtest < MiniTest::Test
       assert_nil(hvac_control.cooling_setup_start_hour)
     else
       assert_equal(clg_setup_start_hr, hvac_control.cooling_setup_start_hour)
-    end
-
-    if ceiling_fan_offset.nil?
-      assert_nil(hvac_control.ceiling_fan_cooling_setpoint_temp_offset)
-    else
-      assert_equal(ceiling_fan_offset, hvac_control.ceiling_fan_cooling_setpoint_temp_offset)
     end
   end
 

--- a/rulesets/301EnergyRatingIndexRuleset/tests/test_lighting.rb
+++ b/rulesets/301EnergyRatingIndexRuleset/tests/test_lighting.rb
@@ -62,7 +62,6 @@ class ERILightingTest < MiniTest::Test
     # Test w/ 301-2019
     hpxml_name = 'base-lighting-ceiling-fans.xml'
     hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
-    hpxml.ceiling_fans[0].quantity = 4
     hpxml_name = File.basename(@tmp_hpxml_path)
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
 
@@ -129,11 +128,11 @@ class ERILightingTest < MiniTest::Test
     hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentReferenceHome)
     _check_ceiling_fans(hpxml, 3000.0 / 42.6, 4)
 
-    # Test w/ 5 bedrooms
+    # Test w/ different Nbr
     hpxml_name = 'base-lighting-ceiling-fans.xml'
     hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
-    hpxml.ceiling_fans[0].quantity = 6
     hpxml.building_construction.number_of_bedrooms = 5
+    hpxml.ceiling_fans[0].quantity = 6
     hpxml_name = File.basename(@tmp_hpxml_path)
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
 

--- a/rulesets/301EnergyRatingIndexRuleset/tests/test_lighting.rb
+++ b/rulesets/301EnergyRatingIndexRuleset/tests/test_lighting.rb
@@ -59,63 +59,99 @@ class ERILightingTest < MiniTest::Test
   end
 
   def test_ceiling_fans
+    # Test w/ 301-2019
     hpxml_name = 'base-lighting-ceiling-fans.xml'
-
-    medium_cfm = 3000.0
-
-    # Reference Home
-    hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIReferenceHome)
-    avg_fan_w = 42.6
-    _check_ceiling_fans(hpxml, medium_cfm / avg_fan_w, 4)
-
-    # Rated Home
-    hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIRatedHome)
-    avg_fan_w = 30.0
-    _check_ceiling_fans(hpxml, medium_cfm / avg_fan_w, 4)
-
-    # IAD
-    hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentDesign)
-    avg_fan_w = 42.6
-    _check_ceiling_fans(hpxml, medium_cfm / avg_fan_w, 4)
-
-    # IAD Reference
-    hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentReferenceHome)
-    avg_fan_w = 42.6
-    _check_ceiling_fans(hpxml, medium_cfm / avg_fan_w, 4)
-  end
-
-  def test_ceiling_fans_nbeds_5
-    hpxml_name = 'base-enclosure-beds-5.xml'
     hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
-    hpxml.ceiling_fans.add(id: 'CeilingFans',
-                           efficiency: 100,
-                           quantity: 2)
-
-    # Save new file
+    hpxml.ceiling_fans[0].quantity = 4
     hpxml_name = File.basename(@tmp_hpxml_path)
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
 
-    medium_cfm = 3000.0
+    # Reference Home
+    hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIReferenceHome)
+    _check_ceiling_fans(hpxml, 3000.0 / 42.6, 4)
+
+    # Rated Home
+    hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIRatedHome)
+    _check_ceiling_fans(hpxml, 3000.0 / 30.0, 4)
+
+    # IAD
+    hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentDesign)
+    _check_ceiling_fans(hpxml, 3000.0 / 42.6, 4)
+
+    # IAD Reference
+    hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentReferenceHome)
+    _check_ceiling_fans(hpxml, 3000.0 / 42.6, 4)
+
+    # Test w/ 301-2019 and Nfans < Nbr + 1
+    hpxml_name = 'base-lighting-ceiling-fans.xml'
+    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml.ceiling_fans[0].quantity = 3
+    hpxml_name = File.basename(@tmp_hpxml_path)
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+
+    # Reference Home
+    hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIReferenceHome)
+    _check_ceiling_fans(hpxml) # No ceiling fans
+
+    # Rated Home
+    hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIRatedHome)
+    _check_ceiling_fans(hpxml) # No ceiling fans
+
+    # IAD
+    hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentDesign)
+    _check_ceiling_fans(hpxml) # No ceiling fans
+
+    # IAD Reference
+    hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentReferenceHome)
+    _check_ceiling_fans(hpxml) # No ceiling fans
+
+    # Test w/ 301-2014 and Nfans < Nbr + 1
+    hpxml_name = 'base-lighting-ceiling-fans.xml'
+    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml.header.eri_calculation_version = '2014'
+    hpxml.ceiling_fans[0].quantity = 3
+    hpxml_name = File.basename(@tmp_hpxml_path)
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+
+    # Reference Home
+    hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIReferenceHome)
+    _check_ceiling_fans(hpxml, 3000.0 / 42.6, 4)
+
+    # Rated Home
+    hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIRatedHome)
+    _check_ceiling_fans(hpxml, 3000.0 / 30.0, 4)
+
+    # IAD
+    hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentDesign)
+    _check_ceiling_fans(hpxml, 3000.0 / 42.6, 4)
+
+    # IAD Reference
+    hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentReferenceHome)
+    _check_ceiling_fans(hpxml, 3000.0 / 42.6, 4)
+
+    # Test w/ 5 bedrooms
+    hpxml_name = 'base-lighting-ceiling-fans.xml'
+    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml.ceiling_fans[0].quantity = 6
+    hpxml.building_construction.number_of_bedrooms = 5
+    hpxml_name = File.basename(@tmp_hpxml_path)
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
 
     # Reference Home
     hpxml_doc = _test_measure(hpxml_name, Constants.CalcTypeERIReferenceHome)
-    avg_fan_w = 42.6
-    _check_ceiling_fans(hpxml_doc, medium_cfm / avg_fan_w, 6)
+    _check_ceiling_fans(hpxml_doc, 3000.0 / 42.6, 6)
 
     # Rated Home
     hpxml_doc = _test_measure(hpxml_name, Constants.CalcTypeERIRatedHome)
-    avg_fan_w = 30.0
-    _check_ceiling_fans(hpxml_doc, medium_cfm / avg_fan_w, 6)
+    _check_ceiling_fans(hpxml_doc, 3000.0 / 30.0, 6)
 
     # IAD
     hpxml_doc = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentDesign)
-    avg_fan_w = 42.6
-    _check_ceiling_fans(hpxml_doc, medium_cfm / avg_fan_w, 4)
+    _check_ceiling_fans(hpxml_doc, 3000.0 / 42.6, 4)
 
     # IAD Reference
     hpxml_doc = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentReferenceHome)
-    avg_fan_w = 42.6
-    _check_ceiling_fans(hpxml_doc, medium_cfm / avg_fan_w, 4)
+    _check_ceiling_fans(hpxml_doc, 3000.0 / 42.6, 4)
   end
 
   def _test_measure(hpxml_name, calc_type)
@@ -185,18 +221,22 @@ class ERILightingTest < MiniTest::Test
     end
   end
 
-  def _check_ceiling_fans(hpxml, cfm_per_w, quantity)
-    assert_equal(1, hpxml.ceiling_fans.size)
-    ceiling_fan = hpxml.ceiling_fans[0]
-    if cfm_per_w.nil?
-      assert_nil(ceiling_fan.efficiency)
+  def _check_ceiling_fans(hpxml, cfm_per_w = nil, quantity = nil)
+    if cfm_per_w.nil? && quantity.nil?
+      assert_equal(0, hpxml.ceiling_fans.size)
     else
-      assert_equal(cfm_per_w, ceiling_fan.efficiency)
-    end
-    if quantity.nil?
-      assert_nil(ceiling_fan.quantity)
-    else
-      assert_equal(quantity, ceiling_fan.quantity)
+      assert_equal(1, hpxml.ceiling_fans.size)
+      ceiling_fan = hpxml.ceiling_fans[0]
+      if cfm_per_w.nil?
+        assert_nil(ceiling_fan.efficiency)
+      else
+        assert_equal(cfm_per_w, ceiling_fan.efficiency)
+      end
+      if quantity.nil?
+        assert_nil(ceiling_fan.quantity)
+      else
+        assert_equal(quantity, ceiling_fan.quantity)
+      end
     end
   end
 end

--- a/rulesets/301EnergyRatingIndexRuleset/tests/test_lighting.rb
+++ b/rulesets/301EnergyRatingIndexRuleset/tests/test_lighting.rb
@@ -223,6 +223,7 @@ class ERILightingTest < MiniTest::Test
   def _check_ceiling_fans(hpxml, cfm_per_w = nil, quantity = nil)
     if cfm_per_w.nil? && quantity.nil?
       assert_equal(0, hpxml.ceiling_fans.size)
+      assert_nil(hpxml.hvac_controls[0].ceiling_fan_cooling_setpoint_temp_offset)
     else
       assert_equal(1, hpxml.ceiling_fans.size)
       ceiling_fan = hpxml.ceiling_fans[0]
@@ -236,6 +237,7 @@ class ERILightingTest < MiniTest::Test
       else
         assert_equal(quantity, ceiling_fan.quantity)
       end
+      assert_equal(0.5, hpxml.hvac_controls[0].ceiling_fan_cooling_setpoint_temp_offset)
     end
   end
 end

--- a/workflow/sample_files/base-lighting-ceiling-fans.xml
+++ b/workflow/sample_files/base-lighting-ceiling-fans.xml
@@ -551,7 +551,7 @@
             <FanSpeed>medium</FanSpeed>
             <Efficiency>100.0</Efficiency>
           </Airflow>
-          <Quantity>2</Quantity>
+          <Quantity>4</Quantity>
         </CeilingFan>
       </Lighting>
       <MiscLoads>


### PR DESCRIPTION
## Pull Request Description

Bugfix for how ceiling fans are configured for 301-2019. Unlike 301-2014, there should now be no ceiling fans in the Rated/Reference Homes when the number of ceiling fans < Nbr+1.

## Checklist

Not all may apply:

- [x] OS-HPXML git subtree has been pulled
- [x] 301 ruleset and unit tests have been updated
- [ ] 301validator.xml has been updated (reference EPvalidator.xml)
- [ ] Workflow tests have been updated
- [ ] Documentation has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
