### PR TITLE
Timeseries hot water loads

### DIFF
--- a/docs/source/outputs.rst
+++ b/docs/source/outputs.rst
@@ -227,7 +227,7 @@ Depending on the outputs requested, CSV files may include:
    Fuel Consumptions                   Energy use for each fuel type (in kBtu for fossil fuels and kWh for electricity).
    End Use Consumptions                Energy use for each end use type (in kBtu for fossil fuels and kWh for electricity).
    Hot Water Uses                      Water use for each end use type (in gallons).
-   Total Loads                         Heating and cooling loads (in kBtu) for the building.
+   Total Loads                         Heating, cooling, and hot water loads (in kBtu) for the building.
    Component Loads                     Heating and cooling loads (in kBtu) disaggregated by component (e.g., Walls, Windows, Infiltration, Ducts, etc.).
    Zone Temperatures                   Average temperatures (in deg-F) for each space modeled (e.g., living space, attic, garage, basement, crawlspace, etc.).
    Airflows                            Airflow rates (in cfm) for infiltration, mechanical ventilation, natural ventilation, and whole house fans.

--- a/hpxml-measures/HPXMLtoOpenStudio/measure.xml
+++ b/hpxml-measures/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>004404fb-8a4e-43fc-a7d0-253018d7bdb4</version_id>
-  <version_modified>20201030T004842Z</version_modified>
+  <version_id>4e2cf925-aac8-4417-b1c1-1701fdf4ea01</version_id>
+  <version_modified>20201114T000802Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -418,12 +418,6 @@
       <checksum>942C3E5E</checksum>
     </file>
     <file>
-      <filename>waterheater.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>85798EEC</checksum>
-    </file>
-    <file>
       <filename>test_water_heater.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -436,12 +430,6 @@
       <checksum>BF4566BB</checksum>
     </file>
     <file>
-      <filename>hvac.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B44BE66C</checksum>
-    </file>
-    <file>
       <filename>hpxml_defaults.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -452,12 +440,6 @@
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
       <checksum>466F5D83</checksum>
-    </file>
-    <file>
-      <filename>hpxml.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>4338890B</checksum>
     </file>
     <file>
       <filename>EPvalidator.xml</filename>
@@ -505,6 +487,24 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>E4CE9FD0</checksum>
+    </file>
+    <file>
+      <filename>hvac.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>BC17E0AD</checksum>
+    </file>
+    <file>
+      <filename>waterheater.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>8CC67A4B</checksum>
+    </file>
+    <file>
+      <filename>hpxml.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>489F268D</checksum>
     </file>
   </files>
 </measure>

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -1429,6 +1429,7 @@ class HPXML < Object
 
     def net_area
       return if nil?
+      return if @area.nil?
 
       val = @area
       skylights.each do |skylight|
@@ -1656,6 +1657,7 @@ class HPXML < Object
 
     def net_area
       return if nil?
+      return if @area.nil?
 
       val = @area
       (windows + doors).each do |subsurface|
@@ -1793,6 +1795,7 @@ class HPXML < Object
 
     def net_area
       return if nil?
+      return if @area.nil?
 
       val = @area
       (@hpxml_object.windows + @hpxml_object.doors).each do |subsurface|

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/hvac.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/hvac.rb
@@ -3987,7 +3987,7 @@ class HVAC
 
   def self.get_default_duct_surface_area(duct_type, ncfl_ag, cfa_served, n_returns)
     # Fraction of primary ducts (ducts outside conditioned space)
-    f_out = (ncfl_ag == 1) ? 1.0 : 0.75
+    f_out = (ncfl_ag <= 1) ? 1.0 : 0.75
 
     if duct_type == HPXML::DuctTypeSupply
       primary_duct_area = 0.27 * cfa_served * f_out

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/waterheater.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/waterheater.rb
@@ -145,6 +145,7 @@ class Waterheater
 
     # Fan:OnOff
     fan = setup_hpwh_fan(hpwh, obj_name_hpwh, airflow_rate)
+    dhw_map[water_heating_system.id] << fan
 
     # Amb temp & RH sensors, temp sensor shared across programs
     amb_temp_sensor, amb_rh_sensors = get_loc_temp_rh_sensors(model, obj_name_hpwh, loc_schedule, loc_space, living_zone)

--- a/hpxml-measures/SimulationOutputReport/measure.rb
+++ b/hpxml-measures/SimulationOutputReport/measure.rb
@@ -271,6 +271,8 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
         result << OpenStudio::IdfObject.load("EnergyManagementSystem:OutputVariable,#{load.ems_variable}_timeseries_outvar,#{load.ems_variable},Summed,ZoneTimestep,#{loads_program.name},J;").get
         result << OpenStudio::IdfObject.load("Output:Variable,*,#{load.ems_variable}_timeseries_outvar,#{timeseries_frequency};").get
       end
+      # And add HotWaterDelivered:
+      result << OpenStudio::IdfObject.load("Output:Variable,*,Water Use Connections Plant Hot Water Energy,#{timeseries_frequency};").get
     end
 
     if include_timeseries_component_loads
@@ -648,7 +650,12 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       end
 
       # Loads
-      @loads[LT::HotWaterDelivered].annual_output_by_system[sys_id] = get_report_variable_data_annual(keys, get_all_var_keys(@loads[LT::HotWaterDelivered].variable))
+      load = @loads[LT::HotWaterDelivered]
+      vars = get_all_var_keys(load.variable)
+      load.annual_output_by_system[sys_id] = get_report_variable_data_annual(keys, vars)
+      if include_timeseries_total_loads
+        load.timeseries_output_by_system[sys_id] = get_report_variable_data_timeseries(keys, vars, UnitConversions.convert(1.0, 'J', load.timeseries_units), 0, timeseries_frequency)
+      end
 
       # Combi boiler water system
       hvac_id = get_combi_hvac_id(sys_id)
@@ -2276,7 +2283,8 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     def self.WaterHeating(fuel)
       return { 'OpenStudio::Model::WaterHeaterMixed' => ["Water Heater #{fuel} Energy", "Water Heater Off Cycle Parasitic #{fuel} Energy", "Water Heater On Cycle Parasitic #{fuel} Energy"],
                'OpenStudio::Model::WaterHeaterStratified' => ["Water Heater #{fuel} Energy", "Water Heater Off Cycle Parasitic #{fuel} Energy", "Water Heater On Cycle Parasitic #{fuel} Energy"],
-               'OpenStudio::Model::CoilWaterHeatingAirToWaterHeatPumpWrapped' => ["Cooling Coil Water Heating #{fuel} Energy"] }
+               'OpenStudio::Model::CoilWaterHeatingAirToWaterHeatPumpWrapped' => ["Cooling Coil Water Heating #{fuel} Energy"],
+               'OpenStudio::Model::FanOnOff' => ["Fan #{fuel} Energy"] }
     end
 
     def self.WaterHeatingLoad

--- a/hpxml-measures/SimulationOutputReport/measure.xml
+++ b/hpxml-measures/SimulationOutputReport/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>3a615bce-d44b-4fb7-a4f5-327ad0877fd4</version_id>
-  <version_modified>20201020T182846Z</version_modified>
+  <version_id>c70ea03e-0cd2-4f41-b604-53a492503003</version_id>
+  <version_modified>20201118T161246Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -1048,7 +1048,7 @@
       <filename>output_report_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>6362EE9F</checksum>
+      <checksum>21271D95</checksum>
     </file>
     <file>
       <version>
@@ -1059,7 +1059,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>3216DA87</checksum>
+      <checksum>9BFBA824</checksum>
     </file>
   </files>
 </measure>

--- a/hpxml-measures/SimulationOutputReport/tests/output_report_test.rb
+++ b/hpxml-measures/SimulationOutputReport/tests/output_report_test.rb
@@ -247,6 +247,7 @@ class SimulationOutputReportTest < MiniTest::Test
   TimeseriesColsTotalLoads = [
     'Load: Heating',
     'Load: Cooling',
+    'Load: Hot Water: Delivered',
   ]
 
   TimeseriesColsComponentLoads = [
@@ -782,193 +783,157 @@ class SimulationOutputReportTest < MiniTest::Test
     _check_for_zero_baseload_timeseries_value(timeseries_csv, ['Electricity: Refrigerator'])
   end
 
-  def test_timeseries_timestep_ALL_60min
+  def test_timeseries_timestep_60min
     args_hash = { 'hpxml_path' => '../workflow/sample_files/base.xml',
                   'timeseries_frequency' => 'timestep',
                   'include_timeseries_fuel_consumptions' => true,
-                  'include_timeseries_end_use_consumptions' => true,
-                  'include_timeseries_hot_water_uses' => true,
-                  'include_timeseries_total_loads' => true,
-                  'include_timeseries_component_loads' => true,
-                  'include_timeseries_zone_temperatures' => true,
-                  'include_timeseries_airflows' => true,
-                  'include_timeseries_weather' => true }
+                  'include_timeseries_end_use_consumptions' => false,
+                  'include_timeseries_hot_water_uses' => false,
+                  'include_timeseries_total_loads' => false,
+                  'include_timeseries_component_loads' => false,
+                  'include_timeseries_zone_temperatures' => false,
+                  'include_timeseries_airflows' => false,
+                  'include_timeseries_weather' => false }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Time'] + all_timeseries_cols
-    actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
-    assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(8760, File.readlines(timeseries_csv).size - 2)
-    _check_for_zero_baseload_timeseries_value(timeseries_csv, ['Electricity: Refrigerator'])
   end
 
-  def test_timeseries_timestep_ALL_10min
+  def test_timeseries_timestep_10min
     args_hash = { 'hpxml_path' => '../workflow/sample_files/base-simcontrol-timestep-10-mins.xml',
                   'timeseries_frequency' => 'timestep',
                   'include_timeseries_fuel_consumptions' => true,
-                  'include_timeseries_end_use_consumptions' => true,
-                  'include_timeseries_hot_water_uses' => true,
-                  'include_timeseries_total_loads' => true,
-                  'include_timeseries_component_loads' => true,
-                  'include_timeseries_zone_temperatures' => true,
-                  'include_timeseries_airflows' => true,
-                  'include_timeseries_weather' => true }
+                  'include_timeseries_end_use_consumptions' => false,
+                  'include_timeseries_hot_water_uses' => false,
+                  'include_timeseries_total_loads' => false,
+                  'include_timeseries_component_loads' => false,
+                  'include_timeseries_zone_temperatures' => false,
+                  'include_timeseries_airflows' => false,
+                  'include_timeseries_weather' => false }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Time'] + all_timeseries_cols
-    actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
-    assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(52560, File.readlines(timeseries_csv).size - 2)
-    _check_for_zero_baseload_timeseries_value(timeseries_csv, ['Electricity: Refrigerator'])
   end
 
-  def test_timeseries_hourly_ALL_runperiod_Jan
+  def test_timeseries_hourly_runperiod_Jan
     args_hash = { 'hpxml_path' => '../workflow/sample_files/base-simcontrol-runperiod-1-month.xml',
                   'timeseries_frequency' => 'hourly',
                   'include_timeseries_fuel_consumptions' => true,
-                  'include_timeseries_end_use_consumptions' => true,
-                  'include_timeseries_hot_water_uses' => true,
-                  'include_timeseries_total_loads' => true,
-                  'include_timeseries_component_loads' => true,
-                  'include_timeseries_zone_temperatures' => true,
-                  'include_timeseries_airflows' => true,
-                  'include_timeseries_weather' => true }
+                  'include_timeseries_end_use_consumptions' => false,
+                  'include_timeseries_hot_water_uses' => false,
+                  'include_timeseries_total_loads' => false,
+                  'include_timeseries_component_loads' => false,
+                  'include_timeseries_zone_temperatures' => false,
+                  'include_timeseries_airflows' => false,
+                  'include_timeseries_weather' => false }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Time'] + all_timeseries_cols
-    actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
-    assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(31 * 24, File.readlines(timeseries_csv).size - 2)
-    _check_for_zero_baseload_timeseries_value(timeseries_csv, ['Electricity: Refrigerator'])
   end
 
-  def test_timeseries_daily_ALL_runperiod_Jan
+  def test_timeseries_daily_runperiod_Jan
     args_hash = { 'hpxml_path' => '../workflow/sample_files/base-simcontrol-runperiod-1-month.xml',
                   'timeseries_frequency' => 'daily',
                   'include_timeseries_fuel_consumptions' => true,
-                  'include_timeseries_end_use_consumptions' => true,
-                  'include_timeseries_hot_water_uses' => true,
-                  'include_timeseries_total_loads' => true,
-                  'include_timeseries_component_loads' => true,
-                  'include_timeseries_zone_temperatures' => true,
-                  'include_timeseries_airflows' => true,
-                  'include_timeseries_weather' => true }
+                  'include_timeseries_end_use_consumptions' => false,
+                  'include_timeseries_hot_water_uses' => false,
+                  'include_timeseries_total_loads' => false,
+                  'include_timeseries_component_loads' => false,
+                  'include_timeseries_zone_temperatures' => false,
+                  'include_timeseries_airflows' => false,
+                  'include_timeseries_weather' => false }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Time'] + all_timeseries_cols
-    actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
-    assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(31, File.readlines(timeseries_csv).size - 2)
-    _check_for_zero_baseload_timeseries_value(timeseries_csv, ['Electricity: Refrigerator'])
   end
 
-  def test_timeseries_monthly_ALL_runperiod_Jan
+  def test_timeseries_monthly_runperiod_Jan
     args_hash = { 'hpxml_path' => '../workflow/sample_files/base-simcontrol-runperiod-1-month.xml',
                   'timeseries_frequency' => 'monthly',
                   'include_timeseries_fuel_consumptions' => true,
-                  'include_timeseries_end_use_consumptions' => true,
-                  'include_timeseries_hot_water_uses' => true,
-                  'include_timeseries_total_loads' => true,
-                  'include_timeseries_component_loads' => true,
-                  'include_timeseries_zone_temperatures' => true,
-                  'include_timeseries_airflows' => true,
-                  'include_timeseries_weather' => true }
+                  'include_timeseries_end_use_consumptions' => false,
+                  'include_timeseries_hot_water_uses' => false,
+                  'include_timeseries_total_loads' => false,
+                  'include_timeseries_component_loads' => false,
+                  'include_timeseries_zone_temperatures' => false,
+                  'include_timeseries_airflows' => false,
+                  'include_timeseries_weather' => false }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Time'] + all_timeseries_cols
-    actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
-    assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(1, File.readlines(timeseries_csv).size - 2)
-    _check_for_zero_baseload_timeseries_value(timeseries_csv, ['Electricity: Refrigerator'])
   end
 
-  def test_timeseries_timestep_ALL_60min_runperiod_Jan
+  def test_timeseries_timestep_60min_runperiod_Jan
     args_hash = { 'hpxml_path' => '../workflow/sample_files/base-simcontrol-runperiod-1-month.xml',
                   'timeseries_frequency' => 'timestep',
                   'include_timeseries_fuel_consumptions' => true,
-                  'include_timeseries_end_use_consumptions' => true,
-                  'include_timeseries_hot_water_uses' => true,
-                  'include_timeseries_total_loads' => true,
-                  'include_timeseries_component_loads' => true,
-                  'include_timeseries_zone_temperatures' => true,
-                  'include_timeseries_airflows' => true,
-                  'include_timeseries_weather' => true }
+                  'include_timeseries_end_use_consumptions' => false,
+                  'include_timeseries_hot_water_uses' => false,
+                  'include_timeseries_total_loads' => false,
+                  'include_timeseries_component_loads' => false,
+                  'include_timeseries_zone_temperatures' => false,
+                  'include_timeseries_airflows' => false,
+                  'include_timeseries_weather' => false }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Time'] + all_timeseries_cols
-    actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
-    assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(31 * 24, File.readlines(timeseries_csv).size - 2)
-    _check_for_zero_baseload_timeseries_value(timeseries_csv, ['Electricity: Refrigerator'])
   end
 
-  def test_timeseries_hourly_ALL_AMY_2012
+  def test_timeseries_hourly_AMY_2012
     args_hash = { 'hpxml_path' => '../workflow/sample_files/base-location-AMY-2012.xml',
                   'timeseries_frequency' => 'hourly',
                   'include_timeseries_fuel_consumptions' => true,
-                  'include_timeseries_end_use_consumptions' => true,
-                  'include_timeseries_hot_water_uses' => true,
-                  'include_timeseries_total_loads' => true,
-                  'include_timeseries_component_loads' => true,
-                  'include_timeseries_zone_temperatures' => true,
-                  'include_timeseries_airflows' => true,
-                  'include_timeseries_weather' => true }
+                  'include_timeseries_end_use_consumptions' => false,
+                  'include_timeseries_hot_water_uses' => false,
+                  'include_timeseries_total_loads' => false,
+                  'include_timeseries_component_loads' => false,
+                  'include_timeseries_zone_temperatures' => false,
+                  'include_timeseries_airflows' => false,
+                  'include_timeseries_weather' => false }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Time'] + all_timeseries_cols
-    actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
-    assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(8784, File.readlines(timeseries_csv).size - 2)
-    _check_for_zero_baseload_timeseries_value(timeseries_csv, ['Electricity: Refrigerator'])
   end
 
-  def test_timeseries_daily_ALL_AMY_2012
+  def test_timeseries_daily_AMY_2012
     args_hash = { 'hpxml_path' => '../workflow/sample_files/base-location-AMY-2012.xml',
                   'timeseries_frequency' => 'daily',
                   'include_timeseries_fuel_consumptions' => true,
-                  'include_timeseries_end_use_consumptions' => true,
-                  'include_timeseries_hot_water_uses' => true,
-                  'include_timeseries_total_loads' => true,
-                  'include_timeseries_component_loads' => true,
-                  'include_timeseries_zone_temperatures' => true,
-                  'include_timeseries_airflows' => true,
-                  'include_timeseries_weather' => true }
+                  'include_timeseries_end_use_consumptions' => false,
+                  'include_timeseries_hot_water_uses' => false,
+                  'include_timeseries_total_loads' => false,
+                  'include_timeseries_component_loads' => false,
+                  'include_timeseries_zone_temperatures' => false,
+                  'include_timeseries_airflows' => false,
+                  'include_timeseries_weather' => false }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Time'] + all_timeseries_cols
-    actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
-    assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(366, File.readlines(timeseries_csv).size - 2)
-    _check_for_zero_baseload_timeseries_value(timeseries_csv, ['Electricity: Refrigerator'])
   end
 
-  def test_timeseries_timestep_ALL_60min_AMY_2012
+  def test_timeseries_timestep_60min_AMY_2012
     args_hash = { 'hpxml_path' => '../workflow/sample_files/base-location-AMY-2012.xml',
                   'timeseries_frequency' => 'timestep',
                   'include_timeseries_fuel_consumptions' => true,
-                  'include_timeseries_end_use_consumptions' => true,
-                  'include_timeseries_hot_water_uses' => true,
-                  'include_timeseries_total_loads' => true,
-                  'include_timeseries_component_loads' => true,
-                  'include_timeseries_zone_temperatures' => true,
-                  'include_timeseries_airflows' => true,
-                  'include_timeseries_weather' => true }
+                  'include_timeseries_end_use_consumptions' => false,
+                  'include_timeseries_hot_water_uses' => false,
+                  'include_timeseries_total_loads' => false,
+                  'include_timeseries_component_loads' => false,
+                  'include_timeseries_zone_temperatures' => false,
+                  'include_timeseries_airflows' => false,
+                  'include_timeseries_weather' => false }
     annual_csv, timeseries_csv, eri_csv = _test_measure(args_hash)
     assert(File.exist?(annual_csv))
     assert(File.exist?(timeseries_csv))
-    expected_timeseries_cols = ['Time'] + all_timeseries_cols
-    actual_timeseries_cols = File.readlines(timeseries_csv)[0].strip.split(',')
-    assert_equal(expected_timeseries_cols.sort, actual_timeseries_cols.sort)
     assert_equal(8784, File.readlines(timeseries_csv).size - 2)
-    _check_for_zero_baseload_timeseries_value(timeseries_csv, ['Electricity: Refrigerator'])
   end
 
   def test_eri_designs

--- a/hpxml-measures/docs/source/hpxml_to_openstudio.rst
+++ b/hpxml-measures/docs/source/hpxml_to_openstudio.rst
@@ -665,8 +665,22 @@ Air Distribution
 - Optional return ducts (``Ducts[DuctType='return']``)
 
 For each duct, ``DuctInsulationRValue`` must be provided.
-``DuctLocation`` and ``DuctSurfaceArea`` can be optionally provided.
-The provided ``DuctLocation`` can be one of the following:
+``DuctSurfaceArea`` and ``DuctLocation`` must both be provided or both not be provided.
+
+If ``DuctSurfaceArea`` is not provided, duct areas will be calculated based on ANSI/ASHRAE Standard 152-2004:
+
+======================  ====================================================================
+Duct Type               Default Value
+======================  ====================================================================
+Primary supply ducts    :math:`0.27 \cdot F_{out} \cdot CFA_{ServedByAirDistribution}`
+Secondary supply ducts  :math:`0.27 \cdot (1 - F_{out}) \cdot CFA_{ServedByAirDistribution}`
+Primary return ducts    :math:`b_r \cdot F_{out} \cdot CFA_{ServedByAirDistribution}`
+Secondary return ducts  :math:`b_r \cdot (1 - F_{out}) \cdot CFA_{ServedByAirDistribution}`
+======================  ====================================================================
+
+where F\ :sub:`out` is 1.0 when ``NumberofConditionedFloorsAboveGrade`` <= 1 and 0.75 when ``NumberofConditionedFloorsAboveGrade`` > 1, and b\ :sub:`r` is 0.05 * ``NumberofReturnRegisters`` with a maximum value of 0.25.
+
+If ``DuctLocation`` is provided, it can be one of the following:
 
 ==============================  ================================================  =========================================================  =========================  ================
 Location                        Description                                       Temperature                                                Building Type              Default Priority
@@ -689,21 +703,8 @@ other multifamily buffer space  E.g., enclosed unconditioned stairwell          
 other non-freezing space        E.g., shared parking garage ceiling               Floats with outside; minimum of 40F                        Attached/Multifamily only
 ==============================  ================================================  =========================================================  =========================  ================
 
-If ``DuctLocation`` is not provided, the primary duct location will be chosen based on the presence of spaces and the "Default Priority" indicated above.
-For a 2+ story home, secondary ducts will also be located in the living space.
-
-If ``DuctSurfaceArea`` is not provided, the total duct area will be calculated based on ANSI/ASHRAE Standard 152-2004:
-
-========================================  ====================================================================
-Element Name                              Default Value
-========================================  ====================================================================
-DuctSurfaceArea (primary supply ducts)    :math:`0.27 \cdot F_{out} \cdot CFA_{ServedByAirDistribution}`
-DuctSurfaceArea (secondary supply ducts)  :math:`0.27 \cdot (1 - F_{out}) \cdot CFA_{ServedByAirDistribution}`
-DuctSurfaceArea (primary return ducts)    :math:`b_r \cdot F_{out} \cdot CFA_{ServedByAirDistribution}`
-DuctSurfaceArea (secondary return ducts)  :math:`b_r \cdot (1 - F_{out}) \cdot CFA_{ServedByAirDistribution}`
-========================================  ====================================================================
-
-where F\ :sub:`out` is 1.0 for 1-story homes and 0.75 for 2+ story homes and b\ :sub:`r` is 0.05 * ``NumberofReturnRegisters`` with a maximum value of 0.25.
+If ``DuctLocation`` is not provided, the location for primary ducts will be chosen based on the presence of spaces and the "Default Priority" indicated above.
+Any secondary ducts (when ``NumberofConditionedFloorsAboveGrade`` > 1) will always be located in the living space.
 
 Hydronic Distribution
 ~~~~~~~~~~~~~~~~~~~~~

--- a/hpxml-measures/docs/source/simulation_output_report.rst
+++ b/hpxml-measures/docs/source/simulation_output_report.rst
@@ -243,7 +243,7 @@ Depending on the outputs requested, CSV files may include:
    Fuel Consumptions                   Energy use for each fuel type (in kBtu for fossil fuels and kWh for electricity).
    End Use Consumptions                Energy use for each end use type (in kBtu for fossil fuels and kWh for electricity).
    Hot Water Uses                      Water use for each end use type (in gallons).
-   Total Loads                         Heating and cooling loads (in kBtu) for the building.
+   Total Loads                         Heating, cooling, and hot water loads (in kBtu) for the building.
    Component Loads                     Heating and cooling loads (in kBtu) disaggregated by component (e.g., Walls, Windows, Infiltration, Ducts, etc.).
    Zone Temperatures                   Average temperatures (in deg-F) for each space modeled (e.g., living space, attic, garage, basement, crawlspace, etc.).
    Airflows                            Airflow rates (in cfm) for infiltration, mechanical ventilation (including clothes dryer exhaust), natural ventilation, whole house fans.

--- a/hpxml-measures/workflow/run_simulation.rb
+++ b/hpxml-measures/workflow/run_simulation.rb
@@ -156,6 +156,8 @@ rundir = File.join(options[:output_dir], 'run')
 puts "HPXML: #{options[:hpxml]}"
 success = run_workflow(basedir, rundir, options[:hpxml], options[:debug], timeseries_output_freq, timeseries_outputs)
 
-if success
-  puts "Completed in #{(Time.now - start_time).round(1)} seconds."
+if not success
+  exit! 1
 end
+
+puts "Completed in #{(Time.now - start_time).round(1)} seconds."


### PR DESCRIPTION
## Pull Request Description

Includes hot water loads (in addition to heating/cooling loads) when timeseries total loads are requested.

Also fixes possible "Error: Electricity category end uses (X) do not sum to total (X)." when the building has a heat pump water heater.

## Checklist

Not all may apply:

- [x] OS-HPXML git subtree has been pulled
- [ ] 301 ruleset and unit tests have been updated
- [ ] 301validator.xml has been updated (reference EPvalidator.xml)
- [ ] Workflow tests have been updated
- [x] Documentation has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
