### PR TITLE
ASHRAE 140 wrt Ideal Air Systems

### DIFF
--- a/hpxml-measures/HPXMLtoOpenStudio/measure.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/measure.rb
@@ -2248,7 +2248,7 @@ class OSModel
     living_zone = spaces[HPXML::LocationLivingSpace].thermalZone.get
     obj_name = Constants.ObjectNameIdealAirSystem
 
-    if @hpxml.building_construction.use_only_ideal_air_system
+    if @hpxml.building_construction.use_only_ideal_air_system || @apply_ashrae140_assumptions
       cooling_load_frac = 1.0
       heating_load_frac = 1.0
       if @apply_ashrae140_assumptions

--- a/hpxml-measures/HPXMLtoOpenStudio/measure.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/measure.rb
@@ -2248,7 +2248,7 @@ class OSModel
     living_zone = spaces[HPXML::LocationLivingSpace].thermalZone.get
     obj_name = Constants.ObjectNameIdealAirSystem
 
-    if @hpxml.building_construction.use_only_ideal_air_system || @apply_ashrae140_assumptions
+    if @hpxml.building_construction.use_only_ideal_air_system || (@apply_ashrae140_assumptions && (@hpxml.total_fraction_heat_load_served + @hpxml.total_fraction_heat_load_served == 0.0))
       cooling_load_frac = 1.0
       heating_load_frac = 1.0
       if @apply_ashrae140_assumptions

--- a/hpxml-measures/HPXMLtoOpenStudio/measure.xml
+++ b/hpxml-measures/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>f6115c95-7f5a-4d83-bbc2-66e8cf7ee91d</version_id>
-  <version_modified>20210113T205345Z</version_modified>
+  <version_id>05c4ebe7-19cf-45e0-9d8e-df137dbe55f8</version_id>
+  <version_modified>20210114T171413Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -467,17 +467,6 @@
       <checksum>727CC3F3</checksum>
     </file>
     <file>
-      <version>
-        <software_program>OpenStudio</software_program>
-        <identifier>2.1.1</identifier>
-        <min_compatible>2.1.1</min_compatible>
-      </version>
-      <filename>measure.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>script</usage_type>
-      <checksum>D1A6959F</checksum>
-    </file>
-    <file>
       <filename>unit_conversions.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -530,6 +519,17 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>7CED8CC9</checksum>
+    </file>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>2.1.1</identifier>
+        <min_compatible>2.1.1</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>1B43A974</checksum>
     </file>
   </files>
 </measure>

--- a/hpxml-measures/HPXMLtoOpenStudio/measure.xml
+++ b/hpxml-measures/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>05c4ebe7-19cf-45e0-9d8e-df137dbe55f8</version_id>
-  <version_modified>20210114T171413Z</version_modified>
+  <version_id>0018a71c-0aed-4c42-800d-e7cbcc2ce22b</version_id>
+  <version_modified>20210114T214816Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -529,7 +529,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>1B43A974</checksum>
+      <checksum>25F12FC4</checksum>
     </file>
   </files>
 </measure>

--- a/hpxml-measures/tasks.rb
+++ b/hpxml-measures/tasks.rb
@@ -632,7 +632,6 @@ def set_hpxml_building_construction(hpxml_file, hpxml)
     hpxml.building_construction.conditioned_floor_area = 1539
     hpxml.building_construction.conditioned_building_volume = 12312
     hpxml.building_construction.residential_facility_type = HPXML::ResidentialTypeSFD
-    hpxml.building_construction.use_only_ideal_air_system = true
   elsif ['ASHRAE_Standard_140/L322XC.xml'].include? hpxml_file
     hpxml.building_construction.number_of_conditioned_floors = 2
     hpxml.building_construction.conditioned_floor_area = 3078

--- a/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L100AC.xml
+++ b/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L100AC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L100AL.xml
+++ b/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L100AL.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L110AC.xml
+++ b/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L110AC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L110AL.xml
+++ b/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L110AL.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L120AC.xml
+++ b/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L120AC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L120AL.xml
+++ b/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L120AL.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L130AC.xml
+++ b/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L130AC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L130AL.xml
+++ b/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L130AL.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L140AC.xml
+++ b/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L140AC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L140AL.xml
+++ b/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L140AL.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L150AC.xml
+++ b/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L150AC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L150AL.xml
+++ b/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L150AL.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L155AC.xml
+++ b/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L155AC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L155AL.xml
+++ b/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L155AL.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L160AC.xml
+++ b/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L160AC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L160AL.xml
+++ b/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L160AL.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L170AC.xml
+++ b/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L170AC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L170AL.xml
+++ b/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L170AL.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L200AC.xml
+++ b/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L200AC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L200AL.xml
+++ b/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L200AL.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L202AC.xml
+++ b/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L202AC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L202AL.xml
+++ b/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L202AL.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L302XC.xml
+++ b/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L302XC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L304XC.xml
+++ b/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L304XC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L322XC.xml
+++ b/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L322XC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>3078.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>24624.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L324XC.xml
+++ b/hpxml-measures/workflow/tests/ASHRAE_Standard_140/L324XC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>3078.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>24624.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/tasks.rb
+++ b/tasks.rb
@@ -259,7 +259,6 @@ def set_hpxml_site(hpxml_file, hpxml)
 end
 
 def set_hpxml_building_construction(hpxml_file, hpxml)
-  hpxml.building_construction.use_only_ideal_air_system = nil
   if ['RESNET_Tests/Other_HERS_AutoGen_Reference_Home_301_2014/03-L304.xml',
       'RESNET_Tests/4.3_HERS_Method/L100A-03.xml',
       'RESNET_Tests/Other_Hot_Water_301_2019_PreAddendumA/L100AD-HW-01.xml',

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L100AC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L100AC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L100AL.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L100AL.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L110AC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L110AC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L110AL.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L110AL.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L120AC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L120AC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L120AL.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L120AL.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L130AC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L130AC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L130AL.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L130AL.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L140AC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L140AC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L140AL.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L140AL.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L150AC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L150AC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L150AL.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L150AL.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L155AC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L155AC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L155AL.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L155AL.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L160AC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L160AC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L160AL.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L160AL.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L170AC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L170AC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L170AL.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L170AL.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L200AC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L200AC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L200AL.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L200AL.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L202AC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L202AC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L202AL.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L202AL.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L302XC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L302XC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L304XC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L304XC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>1539.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>12312.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L322XC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L322XC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>3078.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>24624.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>

--- a/workflow/tests/RESNET_Tests/4.1_Standard_140/L324XC.xml
+++ b/workflow/tests/RESNET_Tests/4.1_Standard_140/L324XC.xml
@@ -28,9 +28,6 @@
           <NumberofBedrooms>3</NumberofBedrooms>
           <ConditionedFloorArea>3078.0</ConditionedFloorArea>
           <ConditionedBuildingVolume>24624.0</ConditionedBuildingVolume>
-          <extension>
-            <UseOnlyIdealAirSystem>true</UseOnlyIdealAirSystem>
-          </extension>
         </BuildingConstruction>
       </BuildingSummary>
       <ClimateandRiskZones>


### PR DESCRIPTION
## Pull Request Description

Removes the need to set `UseOnlyIdealAirSystem=true` in the ASHRAE 140 HPXML files now that we have the more general `ApplyASHRAE140Assumptions=true` flag.

## Checklist

Not all may apply:

- [ ] OS-HPXML git subtree has been pulled
- [ ] 301 ruleset and unit tests have been updated
- [ ] 301validator.xml has been updated (reference EPvalidator.xml)
- [ ] Workflow tests have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
