### PR TITLE
Changes for RESNET 55i

### DIFF
--- a/docs/source/workflow_outputs.rst
+++ b/docs/source/workflow_outputs.rst
@@ -25,7 +25,7 @@ ERI_Worksheet.csv
 ~~~~~~~~~~~~~~~~~
 
 The ``ERI_Worksheet.csv`` file includes more detailed components that feed into the ERI_Results.csv values.
-The file reflects the formate of the Worksheet tab of the HERS Method Test spreadsheet.
+The file reflects the format of the Worksheet tab of the HERS Method Test spreadsheet.
 
 Note that multiple comma-separated values will be reported for many of these outputs if there are multiple heating, cooling, or hot water systems.
 

--- a/rulesets/301EnergyRatingIndexRuleset/measure.xml
+++ b/rulesets/301EnergyRatingIndexRuleset/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>energy_rating_index_301_measure</name>
   <uid>02a31992-9a16-4945-bb51-e99209f7193b</uid>
-  <version_id>d7863fba-8b1b-4770-b59f-9838465fdec7</version_id>
-  <version_modified>20210116T132236Z</version_modified>
+  <version_id>4e7faf5e-4ee6-4de4-ac7e-55f9212a9afe</version_id>
+  <version_modified>20210121T214009Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>EnergyRatingIndex301Measure</class_name>
   <display_name>Apply Energy Rating Index Ruleset</display_name>
@@ -142,12 +142,6 @@
       <checksum>D9D31592</checksum>
     </file>
     <file>
-      <filename>301.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>275FFC4E</checksum>
-    </file>
-    <file>
       <filename>test_hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -170,6 +164,12 @@
       <filetype>xml</filetype>
       <usage_type>resource</usage_type>
       <checksum>9CC389CC</checksum>
+    </file>
+    <file>
+      <filename>301.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>D6FA2DDC</checksum>
     </file>
   </files>
 </measure>

--- a/rulesets/301EnergyRatingIndexRuleset/resources/301.rb
+++ b/rulesets/301EnergyRatingIndexRuleset/resources/301.rb
@@ -1399,8 +1399,8 @@ class EnergyRatingIndex301Ruleset
     # Table 4.3.1(1) Configuration of Index Adjustment Design - Cooling systems
     # Table 4.3.1(1) Configuration of Index Adjustment Design - Thermostat
 
-    # Note: 301-2019 Addendum B says Grade I, but is being changed to grade III
-    # so that IAD and IAD Reference are the same.
+    # Note: 301-2019 Addendum B says Grade I, but it was changed to Grade III in
+    # RESNET 55i.
     set_systems_hvac_reference(orig_hpxml, new_hpxml)
 
     # Change DSE to 1.0
@@ -1424,7 +1424,7 @@ class EnergyRatingIndex301Ruleset
     if mech_vent_fans.empty?
       # Airflow only
       new_hpxml.ventilation_fans.add(id: 'MechanicalVentilation',
-                                     fan_type: HPXML::MechVentTypeBalanced,
+                                     fan_type: HPXML::MechVentTypeBalanced, # Per RESNET 55i
                                      tested_flow_rate: q_fan_airflow,
                                      hours_in_operation: 24,
                                      fan_power: 0.0,
@@ -1458,7 +1458,7 @@ class EnergyRatingIndex301Ruleset
 
       # Airflow and fan power
       new_hpxml.ventilation_fans.add(id: 'MechanicalVentilation',
-                                     fan_type: HPXML::MechVentTypeBalanced,
+                                     fan_type: HPXML::MechVentTypeBalanced, # Per RESNET 55i
                                      tested_flow_rate: q_fan_airflow,
                                      hours_in_operation: 24,
                                      fan_power: fan_power_w,
@@ -1481,7 +1481,7 @@ class EnergyRatingIndex301Ruleset
         # Airflow measured; set to max of provided value and min Qfan requirement
         average_oa_unit_flow_rate = [orig_vent_fan.average_oa_unit_flow_rate, q_fans[orig_vent_fan.id]].max
         if average_oa_unit_flow_rate > orig_vent_fan.average_oa_unit_flow_rate
-          # Increase hours in operation to try to meet requirement
+          # Increase hours in operation to try to meet requirement, per RESNET 55i
           hours_in_operation = [average_oa_unit_flow_rate / orig_vent_fan.average_oa_unit_flow_rate * hours_in_operation, 24.0].min
         end
       else
@@ -1508,7 +1508,7 @@ class EnergyRatingIndex301Ruleset
         # Fan power provided
         fan_power = orig_vent_fan.fan_power
         if not orig_vent_fan.flow_rate_not_tested
-          # Increase proportionally with airflow
+          # Increase proportionally with airflow, per RESNET 55i
           fan_power = orig_vent_fan.fan_power * total_unit_flow_rate / orig_vent_fan.total_unit_flow_rate
         end
         if not orig_vent_fan.is_shared_system
@@ -2076,7 +2076,7 @@ class EnergyRatingIndex301Ruleset
       ief = 1.82
     end
     new_hpxml.dehumidifiers.add(id: 'Dehumidifier',
-                                type: dehumidifier.type,
+                                type: dehumidifier.type, # Per RESNET 55i
                                 capacity: dehumidifier.capacity,
                                 integrated_energy_factor: ief,
                                 rh_setpoint: 0.60,
@@ -2335,7 +2335,7 @@ class EnergyRatingIndex301Ruleset
     end
     cfm_oa_addtl_exhaust -= unmeasured_exhaust_fans.map { |f| q_fans[f.id] }.sum(0.0)
 
-    # 2. Ensure each unmeasured system is at least 15 cfm per P. Fairey and ASHRAE 62.2
+    # 2. Ensure each unmeasured system is at least 15 cfm per RESNET 55i
     q_fans.each do |id, val|
       q_fans[id] = [q_fans[id], 15.0].max
     end
@@ -2759,7 +2759,7 @@ class EnergyRatingIndex301Ruleset
 
   def self.get_reference_basement_wall_rvalue()
     # Table 4.2.2(2) - Component Heat Transfer Characteristics for Reference Home
-    # Basement Wall Exterior R-Value
+    # Basement Wall Exterior R-Value per RESNET 55i
     if ['1A', '1B', '1C', '2A', '2B', '2C', '3A', '3B', '3C'].include? @iecc_zone
       return 0.0
     elsif ['4A', '4B', '4C', '5A', '5B', '5C', '6A', '6B', '6C', '7', '8'].include? @iecc_zone

--- a/workflow/energy_rating_index.rb
+++ b/workflow/energy_rating_index.rb
@@ -330,7 +330,8 @@ def _calculate_eri(rated_output, ref_output, results_iad = nil)
   if results[:teu] > 0
     results[:pefrac] = (results[:teu] - results[:opp]) / results[:teu]
   end
-
+  
+  results[:eul_dh] = rated_output[:elecDehumidifier]
   results[:eul_la] = (rated_output[:elecLightingInterior] + rated_output[:elecLightingExterior] +
                       rated_output[:elecLightingGarage] + rated_output[:elecRefrigerator] +
                       rated_output[:elecDishwasher] + rated_output[:elecClothesWasher] +
@@ -341,9 +342,9 @@ def _calculate_eri(rated_output, ref_output, results_iad = nil)
                       rated_output[:oilClothesDryer] + rated_output[:oilRangeOven] +
                       rated_output[:propaneClothesDryer] + rated_output[:propaneRangeOven] +
                       rated_output[:woodcordClothesDryer] + rated_output[:woodcordRangeOven] +
-                      rated_output[:woodpelletsClothesDryer] + rated_output[:woodpelletsRangeOven] +
-                      rated_output[:elecDehumidifier])
+                      rated_output[:woodpelletsClothesDryer] + rated_output[:woodpelletsRangeOven])
 
+  results[:reul_dh] = ref_output[:elecDehumidifier]
   results[:reul_la] = (ref_output[:elecLightingInterior] + ref_output[:elecLightingExterior] +
                        ref_output[:elecLightingGarage] + ref_output[:elecRefrigerator] +
                        ref_output[:elecDishwasher] + ref_output[:elecClothesWasher] +
@@ -354,8 +355,7 @@ def _calculate_eri(rated_output, ref_output, results_iad = nil)
                        ref_output[:oilClothesDryer] + ref_output[:oilRangeOven] +
                        ref_output[:propaneClothesDryer] + ref_output[:propaneRangeOven] +
                        ref_output[:woodcordClothesDryer] + ref_output[:woodcordRangeOven] +
-                       ref_output[:woodpelletsClothesDryer] + ref_output[:woodpelletsRangeOven] +
-                       ref_output[:elecDehumidifier])
+                       ref_output[:woodpelletsClothesDryer] + ref_output[:woodpelletsRangeOven])
 
   # === #
   # ERI #
@@ -364,13 +364,13 @@ def _calculate_eri(rated_output, ref_output, results_iad = nil)
   results[:trl] = results[:reul_heat].sum(0.0) +
                   results[:reul_cool].sum(0.0) +
                   results[:reul_dhw].sum(0.0) +
-                  results[:reul_la]
+                  results[:reul_la] + results[:reul_dh]
   results[:tnml] = results[:nmeul_heat].sum(0.0) +
                    results[:nmeul_cool].sum(0.0) +
                    results[:nmeul_dhw].sum(0.0) +
                    results[:nmeul_vent_preheat].sum(0.0) +
                    results[:nmeul_vent_precool].sum(0.0) +
-                   results[:eul_la]
+                   results[:eul_la] + results[:eul_dh]
 
   if not results_iad.nil?
 
@@ -410,6 +410,7 @@ def write_results(results, resultsdir, design_outputs, results_iad)
   results_out << ['EC_x Heating (MBtu)', results[:ec_x_heat].map { |x| x.round(2) }.join(',')]
   results_out << ['EC_x Cooling (MBtu)', results[:ec_x_cool].map { |x| x.round(2) }.join(',')]
   results_out << ['EC_x Hot Water (MBtu)', results[:ec_x_dhw].map { |x| x.round(2) }.join(',')]
+  results_out << ['EC_x Dehumid (MBtu)', results[:eul_dh].round(2)]
   results_out << ['EC_x L&A (MBtu)', results[:eul_la].round(2)]
   if not results_iad.nil?
     results_out << ['IAD_Save (%)', results[:iad_save].round(5)]
@@ -469,6 +470,7 @@ def write_results(results, resultsdir, design_outputs, results_iad)
   if not results_iad.nil?
     worksheet_out << ['Ref Home NS', ref_output[:hpxml_nst]]
   end
+  worksheet_out << ['Ref dehumid', results[:reul_dh].round(2)]
   worksheet_out << ['Ref L&A resMELs', ref_output[:elecPlugLoads].round(2)]
   worksheet_out << ['Ref L&A intLgt', (ref_output[:elecLightingInterior] + ref_output[:elecLightingGarage]).round(2)]
   worksheet_out << ['Ref L&A extLgt', ref_output[:elecLightingExterior].round(2)]
@@ -480,7 +482,6 @@ def write_results(results, resultsdir, design_outputs, results_iad)
   worksheet_out << ['Ref L&A cWash', ref_output[:elecClothesWasher].round(2)]
   worksheet_out << ['Ref L&A mechV', ref_output[:elecMechVent].round(2)]
   worksheet_out << ['Ref L&A ceilFan', ref_output[:elecCeilingFan].round(2)]
-  worksheet_out << ['Ref L&A dehumid', ref_output[:elecDehumidifier].round(2)]
   worksheet_out << ['Ref L&A total', results[:reul_la].round(2)]
   CSV.open(worksheet_csv, 'wb') { |csv| worksheet_out.to_a.each { |elem| csv << elem } }
 end

--- a/workflow/energy_rating_index.rb
+++ b/workflow/energy_rating_index.rb
@@ -330,7 +330,7 @@ def _calculate_eri(rated_output, ref_output, results_iad = nil)
   if results[:teu] > 0
     results[:pefrac] = (results[:teu] - results[:opp]) / results[:teu]
   end
-  
+
   results[:eul_dh] = rated_output[:elecDehumidifier]
   results[:eul_la] = (rated_output[:elecLightingInterior] + rated_output[:elecLightingExterior] +
                       rated_output[:elecLightingGarage] + rated_output[:elecRefrigerator] +


### PR DESCRIPTION
## Pull Request Description

Breaks out EUL_DH/REUL_DH from EUL_LA/REUL_LA in output files. All other changes were already incorporated.

## Checklist

Not all may apply:

- [ ] OS-HPXML git subtree has been pulled
- [ ] 301 ruleset and unit tests have been updated
- [ ] 301validator.xml has been updated (reference EPvalidator.xml)
- [ ] Workflow tests have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
