### PR TITLE
Small fix to chiller documentation

### DIFF
--- a/docs/source/workflow_inputs.rst
+++ b/docs/source/workflow_inputs.rst
@@ -746,7 +746,7 @@ If a chiller is specified, additional information is entered in ``CoolingSystem`
   ``extension/FanCoilWatts``                                                  double    W       >= 0         See [#]_             Fan coil power
   ==========================================================================  ========  ======  ===========  ========  =========  =========================================
 
-  .. [#] HVACDistribution type must be HydronicDistribution (type: "radiator", "baseboard", "radiant floor", or "radiant ceiling") or HydronicAndAirDistribution (type: "fan coil" or "water loop heat pump").
+  .. [#] HVACDistribution type must be HydronicDistribution (type: "radiator", "baseboard", "radiant floor", "radiant ceiling", or "water loop") or AirDistribution (type: "fan coil").
   .. [#] FanCoilWatts only required if chiller connected to a fan coil.
 
 Cooling Tower


### PR DESCRIPTION
## Pull Request Description

Fixes chiller documentation to remove reference to deprecated `HydronicAndAirDistribution`.

## Checklist

Not all may apply:

- [ ] OS-HPXML git subtree has been pulled
- [ ] 301 ruleset and unit tests have been updated
- [ ] 301validator.xml has been updated (reference EPvalidator.xml)
- [ ] Workflow tests have been updated
- [x] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
