### PR TITLE
Error Reporting Fix: Allow error reporting to complete without crashing if the system identifier is completely undefined

### DIFF
--- a/hpxml-measures/HPXMLtoOpenStudio/resources/hpxml.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/hpxml.rb
@@ -5434,7 +5434,7 @@ class HPXML < Object
         sys_ids[obj.id] = 0 if sys_ids[obj.id].nil?
         sys_ids[obj.id] += 1
 
-        errors << "Empty SystemIdentifier ID ('#{obj.id}') detected for #{attribute}." if obj.id.size == 0
+        errors << "Empty SystemIdentifier ID ('#{obj.id}') detected for #{attribute}." if !obj.id || obj.id.size == 0
       end
     end
     sys_ids.each do |sys_id, cnt|


### PR DESCRIPTION
## Pull Request Description

- If SystemIdentifier isn't included on an object at all, the check_errors function would crash with a runtime error about reading size of undefined
- This fix makes the useful error print out if the id isn't defined at all, or if the string that is there is empty

This is my first PR into this repo, so please let me know which if any of the steps below I need to do to make this a more complete PR. 
 
## Checklist

Not all may apply:

- [ ] OS-HPXML git subtree has been pulled
- [ ] 301 ruleset and unit tests have been updated
- [ ] 301validator.xml has been updated (reference EPvalidator.xml)
- [ ] Workflow tests have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
