### PR TITLE
Consider Empty Strings nil for floats, integers, and booleans

### DIFF
--- a/hpxml-measures/HPXMLtoOpenStudio/resources/xmlhelper.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/xmlhelper.rb
@@ -251,19 +251,16 @@ def to_boolean(value)
 end
 
 def to_float_or_nil(value)
-  return if value.nil?
-
+  return if value.nil? || (value.instance_of?(String) && value.empty?)
   return to_float(value)
 end
 
 def to_integer_or_nil(value)
-  return if value.nil?
-
+  return if value.nil? || (value.instance_of?(String) && value.empty?)
   return to_integer(value)
 end
 
 def to_boolean_or_nil(value)
-  return if value.nil?
-
+  return if value.nil? || (value.instance_of?(String) && value.empty?)
   return to_boolean(value)
 end


### PR DESCRIPTION
## Pull Request Description

- This fixes an error that occurs in some of th xmls we generate. For some reason empty tags (<Emmitance></Emittance> as an example) sometimes get interpreted as empty strings. When that happens these to_x_or_nil functions fail to convert to x.
- Allowing the empty strings to be considered nil allows us to get to the better validation issues.

As with my last PR, let me know which of the below items I need to do to make this a complete PR :)

## Checklist

Not all may apply:

- [ ] OS-HPXML git subtree has been pulled
- [ ] 301 ruleset and unit tests have been updated
- [ ] 301validator.xml has been updated (reference EPvalidator.xml)
- [ ] Workflow tests have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
