### PR TITLE
Allow skipping component loads (for faster performance)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+## OpenStudio-ERI v1.2.0 (pending)
+
+__New Features__
+- Adds a `--skip-component-loads` argument for faster performance.
+
+__Bugfixes__
+
 ## OpenStudio-ERI v1.1.1
 
 __New Features__

--- a/docs/source/capabilities.rst
+++ b/docs/source/capabilities.rst
@@ -29,3 +29,4 @@ There are additional ways that software developers using this workflow can reduc
 - Run on Linux/Mac platform, which is significantly faster by taking advantage of the POSIX fork call.
 - Do not use the ``--hourly`` flag unless hourly output is required. If required, limit requests to hourly variables of interest.
 - Run on computing environments with 1) fast CPUs, 2) sufficient memory, and 3) enough processors to allow all simulations to run in parallel.
+- Use the ``--skip-component-loads`` argument if heating/cooling component loads are not of interest.

--- a/docs/source/workflow_outputs.rst
+++ b/docs/source/workflow_outputs.rst
@@ -181,6 +181,9 @@ Annual Component Building Loads
 
 Component loads represent the estimated contribution of different building components to the annual heating/cooling building loads.
 The sum of component loads for heating (or cooling) will roughly equal the annual heating (or cooling) building load reported above.
+
+**Note**: These values will be zero if the ``--skip-component-loads`` argument is used.
+
 Current component loads disaggregated by Heating/Cooling are listed below.
    
    ================================================= =========================================================================================================

--- a/hpxml-measures/Changelog.md
+++ b/hpxml-measures/Changelog.md
@@ -1,6 +1,7 @@
 ## OpenStudio-HPXML v1.2.0 (Pending)
 
 __New Features__
+- Adds a `--skip-component-loads` argument for faster performance.
 - Allow `Slab/ExposedPerimeter` to be zero.
 - **Breaking change**: Replaces `Site/extension/ShelterCoefficient` with `Site/ShieldingofHome`.
 - Removes `ClothesDryer/ControlType` from being a required input, it is not used.

--- a/hpxml-measures/HPXMLtoOpenStudio/measure.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/measure.rb
@@ -70,6 +70,12 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
     arg.setDefaultValue(false)
     args << arg
 
+    arg = OpenStudio::Measure::OSArgument.makeBoolArgument('skip_component_loads', false)
+    arg.setDisplayName('Skip component loads?')
+    arg.setDescription('If true, skips the calculation of heating/cooling component loads for faster performance.')
+    arg.setDefaultValue(false)
+    args << arg
+
     arg = OpenStudio::Measure::OSArgument.makeBoolArgument('skip_validation', false)
     arg.setDisplayName('Skip Validation?')
     arg.setDescription('If true, bypasses HPXML input validation for faster performance. WARNING: This should only be used if the supplied HPXML file has already been validated against the Schema & Schematron documents.')
@@ -100,6 +106,7 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
     # assign the user inputs to variables
     hpxml_path = runner.getStringArgumentValue('hpxml_path', user_arguments)
     output_dir = runner.getStringArgumentValue('output_dir', user_arguments)
+    skip_component_loads = runner.getBoolArgumentValue('skip_component_loads', user_arguments)
     debug = runner.getBoolArgumentValue('debug', user_arguments)
     skip_validation = runner.getBoolArgumentValue('skip_validation', user_arguments)
     building_id = runner.getOptionalStringArgumentValue('building_id', user_arguments)
@@ -144,7 +151,8 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
         FileUtils.cp(epw_path, epw_output_path)
       end
 
-      OSModel.create(hpxml, runner, model, hpxml_path, epw_path, cache_path, output_dir, building_id, debug)
+      OSModel.create(hpxml, runner, model, hpxml_path, epw_path, cache_path, output_dir,
+                     skip_component_loads, building_id, debug)
     rescue Exception => e
       runner.registerError("#{e.message}\n#{e.backtrace.join("\n")}")
       return false
@@ -189,7 +197,8 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
 end
 
 class OSModel
-  def self.create(hpxml, runner, model, hpxml_path, epw_path, cache_path, output_dir, building_id, debug)
+  def self.create(hpxml, runner, model, hpxml_path, epw_path, cache_path, output_dir,
+                  skip_component_loads, building_id, debug)
     @hpxml = hpxml
     @debug = debug
 
@@ -263,7 +272,7 @@ class OSModel
 
     # Output
 
-    add_component_loads_output(runner, model, spaces)
+    add_loads_output(runner, model, spaces, skip_component_loads)
     add_output_control_files(runner, model)
     # Uncomment to debug EMS
     # add_ems_debug_output(runner, model)
@@ -2442,31 +2451,72 @@ class OSModel
     return map_str.to_s
   end
 
-  def self.add_component_loads_output(runner, model, spaces)
+  def self.add_loads_output(runner, model, spaces, skip_component_loads)
     living_zone = spaces[HPXML::LocationLivingSpace].thermalZone.get
 
-    # Prevent certain objects (e.g., OtherEquipment) from being counted towards both, e.g., ducts and internal gains
-    objects_already_processed = []
+    liv_load_sensors, intgain_dehumidifier = add_total_loads_output(runner, model, living_zone)
+    return if skip_component_loads
 
-    # EMS Sensors: Global
+    add_component_loads_output(runner, model, living_zone, liv_load_sensors, intgain_dehumidifier)
+  end
 
+  def self.add_total_loads_output(runner, model, living_zone)
     liv_load_sensors = {}
-
     liv_load_sensors[:htg] = OpenStudio::Model::EnergyManagementSystemSensor.new(model, "Heating:EnergyTransfer:Zone:#{living_zone.name.to_s.upcase}")
     liv_load_sensors[:htg].setName('htg_load_liv')
-
     liv_load_sensors[:clg] = OpenStudio::Model::EnergyManagementSystemSensor.new(model, "Cooling:EnergyTransfer:Zone:#{living_zone.name.to_s.upcase}")
     liv_load_sensors[:clg].setName('clg_load_liv')
 
     tot_load_sensors = {}
-
     tot_load_sensors[:htg] = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Heating:EnergyTransfer')
     tot_load_sensors[:htg].setName('htg_load_tot')
-
     tot_load_sensors[:clg] = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Cooling:EnergyTransfer')
     tot_load_sensors[:clg].setName('clg_load_tot')
 
-    load_adj_sensors = {} # Sensors used to adjust E+ EnergyTransfer meter, eg. dehumidifier as load in our program, but included in Heating:EnergyTransfer as HVAC equipment
+    # Need to adjusted E+ EnergyTransfer meters for dehumidifiers
+    intgain_dehumidifier = nil
+    model.getZoneHVACDehumidifierDXs.each do |e|
+      next unless e.thermalZone.get.name.to_s == living_zone.name.to_s
+
+      intgains_sensors << []
+      { 'Zone Dehumidifier Sensible Heating Energy' => 'ig_dehumidifier' }.each do |var, name|
+        intgain_dehumidifier = OpenStudio::Model::EnergyManagementSystemSensor.new(model, var)
+        intgain_dehumidifier.setName(name)
+        intgain_dehumidifier.setKeyName(e.name.to_s)
+      end
+    end
+
+    # EMS program
+    program = OpenStudio::Model::EnergyManagementSystemProgram.new(model)
+    program.setName(Constants.ObjectNameTotalLoadsProgram)
+    program.addLine('Set loads_htg_tot = 0')
+    program.addLine('Set loads_clg_tot = 0')
+    program.addLine("If #{liv_load_sensors[:htg].name} > 0")
+    s = "  Set loads_htg_tot = #{tot_load_sensors[:htg].name} - #{tot_load_sensors[:clg].name}"
+    if not intgain_dehumidifier.nil?
+      s += " - #{intgain_dehumidifier.name}"
+    end
+    program.addLine(s)
+    program.addLine("ElseIf #{liv_load_sensors[:clg].name} > 0")
+    s = "  Set loads_clg_tot = #{tot_load_sensors[:clg].name} - #{tot_load_sensors[:htg].name}"
+    if not intgain_dehumidifier.nil?
+      s += " + #{intgain_dehumidifier.name}"
+    end
+    program.addLine(s)
+    program.addLine('EndIf')
+
+    # EMS calling manager
+    program_calling_manager = OpenStudio::Model::EnergyManagementSystemProgramCallingManager.new(model)
+    program_calling_manager.setName("#{program.name} calling manager")
+    program_calling_manager.setCallingPoint('EndOfZoneTimestepAfterZoneReporting')
+    program_calling_manager.addProgram(program)
+
+    return liv_load_sensors, intgain_dehumidifier
+  end
+
+  def self.add_component_loads_output(runner, model, living_zone, liv_load_sensors, intgain_dehumidifier)
+    # Prevent certain objects (e.g., OtherEquipment) from being counted towards both, e.g., ducts and internal gains
+    objects_already_processed = []
 
     # EMS Sensors: Surfaces, SubSurfaces, InternalMass
 
@@ -2656,27 +2706,7 @@ class OSModel
       ducts_mix_loss_sensor.setKeyName(living_zone.name.to_s)
     end
 
-    # Return duct losses
-    model.getOtherEquipments.sort.each do |o|
-      next if objects_already_processed.include? o
-
-      is_duct_load = o.additionalProperties.getFeatureAsBoolean(Constants.IsDuctLoadForReport)
-      next unless is_duct_load.is_initialized
-
-      objects_already_processed << o
-      next unless is_duct_load.get
-
-      ducts_sensors << []
-      { 'Other Equipment Convective Heating Energy' => 'ducts_conv',
-        'Other Equipment Radiant Heating Energy' => 'ducts_rad' }.each do |var, name|
-        ducts_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, var)
-        ducts_sensor.setName(name)
-        ducts_sensor.setKeyName(o.name.to_s)
-        ducts_sensors[-1] << ducts_sensor
-      end
-    end
-
-    # Supply duct losses
+    # Duct losses
     model.getOtherEquipments.sort.each do |o|
       next if objects_already_processed.include? o
 
@@ -2711,20 +2741,6 @@ class OSModel
         intgains_elec_equip_sensor.setName(name)
         intgains_elec_equip_sensor.setKeyName(o.name.to_s)
         intgains_sensors[-1] << intgains_elec_equip_sensor
-      end
-    end
-
-    model.getGasEquipments.sort.each do |o|
-      next unless o.space.get.thermalZone.get.name.to_s == living_zone.name.to_s
-      next if objects_already_processed.include? o
-
-      intgains_sensors << []
-      { 'Gas Equipment Convective Heating Energy' => 'ig_ge_conv',
-        'Gas Equipment Radiant Heating Energy' => 'ig_ge_rad' }.each do |var, name|
-        intgains_gas_equip_sensor = OpenStudio::Model::EnergyManagementSystemSensor.new(model, var)
-        intgains_gas_equip_sensor.setName(name)
-        intgains_gas_equip_sensor.setKeyName(o.name.to_s)
-        intgains_sensors[-1] << intgains_gas_equip_sensor
       end
     end
 
@@ -2769,17 +2785,8 @@ class OSModel
       end
     end
 
-    model.getZoneHVACDehumidifierDXs.each do |e|
-      next unless e.thermalZone.get.name.to_s == living_zone.name.to_s
-
-      intgains_sensors << []
-      { 'Zone Dehumidifier Sensible Heating Energy' => 'ig_dehumidifier' }.each do |var, name|
-        intgain_dehumidifier = OpenStudio::Model::EnergyManagementSystemSensor.new(model, var)
-        intgain_dehumidifier.setName(name)
-        intgain_dehumidifier.setKeyName(e.name.to_s)
-        load_adj_sensors[:dehumidifier] = intgain_dehumidifier
-        intgains_sensors[-1] << intgain_dehumidifier
-      end
+    if not intgain_dehumidifier.nil?
+      intgains_sensors[-1] << intgain_dehumidifier
     end
 
     intgains_dhw_sensors = {}
@@ -2900,27 +2907,6 @@ class OSModel
         program.addLine("Set loads_#{mode}_#{nonsurf_name} = #{sign}hr_#{nonsurf_name} * #{mode}_mode")
       end
     end
-
-    # EMS program: Total loads
-    program.addLine('Set loads_htg_tot = 0')
-    program.addLine('Set loads_clg_tot = 0')
-    program.addLine("If #{liv_load_sensors[:htg].name} > 0")
-    s = "  Set loads_htg_tot = #{tot_load_sensors[:htg].name} - #{tot_load_sensors[:clg].name}"
-    load_adj_sensors.each do |key, adj_sensor|
-      if ['dehumidifier'].include? key.to_s
-        s += " - #{adj_sensor.name}"
-      end
-    end
-    program.addLine(s)
-    program.addLine("ElseIf #{liv_load_sensors[:clg].name} > 0")
-    s = "  Set loads_clg_tot = #{tot_load_sensors[:clg].name} - #{tot_load_sensors[:htg].name}"
-    load_adj_sensors.each do |key, adj_sensor|
-      if ['dehumidifier'].include? key.to_s
-        s += " + #{adj_sensor.name}"
-      end
-    end
-    program.addLine(s)
-    program.addLine('EndIf')
 
     # EMS calling manager
     program_calling_manager = OpenStudio::Model::EnergyManagementSystemProgramCallingManager.new(model)

--- a/hpxml-measures/HPXMLtoOpenStudio/measure.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/measure.rb
@@ -2478,7 +2478,6 @@ class OSModel
     model.getZoneHVACDehumidifierDXs.each do |e|
       next unless e.thermalZone.get.name.to_s == living_zone.name.to_s
 
-      intgains_sensors << []
       { 'Zone Dehumidifier Sensible Heating Energy' => 'ig_dehumidifier' }.each do |var, name|
         intgain_dehumidifier = OpenStudio::Model::EnergyManagementSystemSensor.new(model, var)
         intgain_dehumidifier.setName(name)

--- a/hpxml-measures/HPXMLtoOpenStudio/measure.xml
+++ b/hpxml-measures/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>91af11ac-83ce-4fad-b71d-f485917632a9</version_id>
-  <version_modified>20210326T162712Z</version_modified>
+  <version_id>5b62efa4-2cdf-4611-9983-52c6ba88cfba</version_id>
+  <version_modified>20210330T065245Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -31,6 +31,25 @@
       <name>debug</name>
       <display_name>Debug Mode?</display_name>
       <description>If true: 1) Writes in.osm file, 2) Generates additional log output, and 3) Creates all EnergyPlus output files.</description>
+      <type>Boolean</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <default_value>false</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>skip_component_loads</name>
+      <display_name>Skip component loads?</display_name>
+      <description>If true, skips the calculation of heating/cooling component loads for faster performance.</description>
       <type>Boolean</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -373,12 +392,6 @@
       <checksum>E6A57DCD</checksum>
     </file>
     <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>5C04ADBE</checksum>
-    </file>
-    <file>
       <filename>test_hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -419,12 +432,6 @@
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
       <checksum>9911B5A5</checksum>
-    </file>
-    <file>
-      <filename>misc_loads.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>F8DA5682</checksum>
     </file>
     <file>
       <filename>meta_measure.rb</filename>
@@ -499,17 +506,6 @@
       <checksum>BC9FF6C3</checksum>
     </file>
     <file>
-      <version>
-        <software_program>OpenStudio</software_program>
-        <identifier>2.1.1</identifier>
-        <min_compatible>2.1.1</min_compatible>
-      </version>
-      <filename>measure.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>script</usage_type>
-      <checksum>166BD10B</checksum>
-    </file>
-    <file>
       <filename>HPXMLDataTypes.xsd</filename>
       <filetype>xsd</filetype>
       <usage_type>resource</usage_type>
@@ -538,6 +534,29 @@
       <filetype>xml</filetype>
       <usage_type>resource</usage_type>
       <checksum>7C3B4225</checksum>
+    </file>
+    <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>F76E3AB7</checksum>
+    </file>
+    <file>
+      <filename>misc_loads.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>3A60F8A9</checksum>
+    </file>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>2.1.1</identifier>
+        <min_compatible>2.1.1</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>CBF390E0</checksum>
     </file>
   </files>
 </measure>

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/constants.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/constants.rb
@@ -357,6 +357,10 @@ class Constants
     return 'dhw source hx'
   end
 
+  def self.ObjectNameTotalLoadsProgram
+    return 'total loads program'
+  end
+
   def self.ObjectNameUnitHeater
     return 'unit heater'
   end

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/misc_loads.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/misc_loads.rb
@@ -99,17 +99,18 @@ class MiscLoads
     if heater_therm > 0
       space_design_level = heater_sch.calcDesignLevelFromDailyTherm(heater_therm / 365.0)
 
-      mel_def = OpenStudio::Model::GasEquipmentDefinition.new(model)
-      mel = OpenStudio::Model::GasEquipment.new(mel_def)
-      mel.setName(obj_name)
-      mel.setEndUseSubcategory(obj_name)
-      mel.setSpace(living_space)
-      mel_def.setName(obj_name)
-      mel_def.setDesignLevel(space_design_level)
-      mel_def.setFractionRadiant(0)
-      mel_def.setFractionLatent(0)
-      mel_def.setFractionLost(1)
-      mel.setSchedule(heater_sch.schedule)
+      mfl_def = OpenStudio::Model::OtherEquipmentDefinition.new(model)
+      mfl = OpenStudio::Model::OtherEquipment.new(mfl_def)
+      mfl.setName(obj_name)
+      mfl.setEndUseSubcategory(obj_name)
+      mfl.setFuelType(EPlus.fuel_type(HPXML::FuelTypeNaturalGas))
+      mfl.setSpace(living_space)
+      mfl_def.setName(obj_name)
+      mfl_def.setDesignLevel(space_design_level)
+      mfl_def.setFractionRadiant(0)
+      mfl_def.setFractionLatent(0)
+      mfl_def.setFractionLost(1)
+      mfl.setSchedule(heater_sch.schedule)
     end
   end
 

--- a/hpxml-measures/SimulationOutputReport/measure.rb
+++ b/hpxml-measures/SimulationOutputReport/measure.rb
@@ -154,7 +154,13 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     # Get a few things from the model
     get_object_maps()
 
-    loads_program = @model.getModelObjectByName(Constants.ObjectNameComponentLoadsProgram.gsub(' ', '_')).get.to_EnergyManagementSystemProgram.get
+    total_loads_program = @model.getModelObjectByName(Constants.ObjectNameTotalLoadsProgram.gsub(' ', '_')).get.to_EnergyManagementSystemProgram.get
+    comp_loads_program = @model.getModelObjectByName(Constants.ObjectNameComponentLoadsProgram.gsub(' ', '_'))
+    if comp_loads_program.is_initialized
+      comp_loads_program = comp_loads_program.get.to_EnergyManagementSystemProgram.get
+    else
+      comp_loads_program = nil
+    end
 
     # Annual outputs
 
@@ -202,13 +208,16 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
 
     # Add component load outputs
     @component_loads.each do |key, comp_load|
-      result << OpenStudio::IdfObject.load("EnergyManagementSystem:OutputVariable,#{comp_load.ems_variable}_annual_outvar,#{comp_load.ems_variable},Summed,ZoneTimestep,#{loads_program.name},J;").get
+      next if comp_loads_program.nil?
+      result << OpenStudio::IdfObject.load("EnergyManagementSystem:OutputVariable,#{comp_load.ems_variable}_annual_outvar,#{comp_load.ems_variable},Summed,ZoneTimestep,#{comp_loads_program.name},J;").get
       result << OpenStudio::IdfObject.load("Output:Variable,*,#{comp_load.ems_variable}_annual_outvar,runperiod;").get
     end
+
+    # Add total load outputs
     @loads.each do |load_type, load|
       next if load.ems_variable.nil?
 
-      result << OpenStudio::IdfObject.load("EnergyManagementSystem:OutputVariable,#{load.ems_variable}_annual_outvar,#{load.ems_variable},Summed,ZoneTimestep,#{loads_program.name},J;").get
+      result << OpenStudio::IdfObject.load("EnergyManagementSystem:OutputVariable,#{load.ems_variable}_annual_outvar,#{load.ems_variable},Summed,ZoneTimestep,#{total_loads_program.name},J;").get
       result << OpenStudio::IdfObject.load("Output:Variable,*,#{load.ems_variable}_annual_outvar,runperiod;").get
     end
 
@@ -295,7 +304,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       @loads.each do |load_type, load|
         next if load.ems_variable.nil?
 
-        result << OpenStudio::IdfObject.load("EnergyManagementSystem:OutputVariable,#{load.ems_variable}_timeseries_outvar,#{load.ems_variable},Summed,ZoneTimestep,#{loads_program.name},J;").get
+        result << OpenStudio::IdfObject.load("EnergyManagementSystem:OutputVariable,#{load.ems_variable}_timeseries_outvar,#{load.ems_variable},Summed,ZoneTimestep,#{total_loads_program.name},J;").get
         result << OpenStudio::IdfObject.load("Output:Variable,*,#{load.ems_variable}_timeseries_outvar,#{timeseries_frequency};").get
       end
       # And add HotWaterDelivered:
@@ -304,7 +313,9 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
 
     if include_timeseries_component_loads
       @component_loads.each do |key, comp_load|
-        result << OpenStudio::IdfObject.load("EnergyManagementSystem:OutputVariable,#{comp_load.ems_variable}_timeseries_outvar,#{comp_load.ems_variable},Summed,ZoneTimestep,#{loads_program.name},J;").get
+        next if comp_loads_program.nil?
+
+        result << OpenStudio::IdfObject.load("EnergyManagementSystem:OutputVariable,#{comp_load.ems_variable}_timeseries_outvar,#{comp_load.ems_variable},Summed,ZoneTimestep,#{comp_loads_program.name},J;").get
         result << OpenStudio::IdfObject.load("Output:Variable,*,#{comp_load.ems_variable}_timeseries_outvar,#{timeseries_frequency};").get
       end
     end
@@ -412,18 +423,20 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     write_annual_output_results(runner, outputs, output_format, annual_output_path)
     report_sim_outputs(outputs, runner)
     write_eri_output_results(outputs, eri_output_path)
-    write_timeseries_output_results(runner, output_format,
-                                    timeseries_output_path,
-                                    timeseries_frequency,
-                                    include_timeseries_fuel_consumptions,
-                                    include_timeseries_end_use_consumptions,
-                                    include_timeseries_hot_water_uses,
-                                    include_timeseries_total_loads,
-                                    include_timeseries_component_loads,
-                                    include_timeseries_unmet_loads,
-                                    include_timeseries_zone_temperatures,
-                                    include_timeseries_airflows,
-                                    include_timeseries_weather)
+    if not @timestamps.nil?
+      write_timeseries_output_results(runner, output_format,
+                                      timeseries_output_path,
+                                      timeseries_frequency,
+                                      include_timeseries_fuel_consumptions,
+                                      include_timeseries_end_use_consumptions,
+                                      include_timeseries_hot_water_uses,
+                                      include_timeseries_total_loads,
+                                      include_timeseries_component_loads,
+                                      include_timeseries_unmet_loads,
+                                      include_timeseries_zone_temperatures,
+                                      include_timeseries_airflows,
+                                      include_timeseries_weather)
+    end
 
     return true
   end
@@ -1597,7 +1610,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
 
     return values if disable_ems_shift
 
-    if (key_values.size == 1) && (key_values[0] == 'EMS')
+    if (key_values.size == 1) && (key_values[0] == 'EMS') && (@timestamps.size > 0)
       if (timeseries_frequency.downcase == 'timestep' || (timeseries_frequency.downcase == 'hourly' && @model.getTimestep.numberOfTimestepsPerHour == 1))
         # Shift all values by 1 timestep due to EMS reporting lag
         return values[1..-1] + [values[-1]]

--- a/hpxml-measures/SimulationOutputReport/measure.xml
+++ b/hpxml-measures/SimulationOutputReport/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>3b09cd0b-92a2-41c6-b70e-c41c938ff1d2</version_id>
-  <version_modified>20210309T001238Z</version_modified>
+  <version_id>49605fe2-bd20-4058-9b2c-2abcc5806928</version_id>
+  <version_modified>20210330T064129Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -915,7 +915,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>F29271E9</checksum>
+      <checksum>00C7AE82</checksum>
     </file>
   </files>
 </measure>

--- a/hpxml-measures/docs/source/intro.rst
+++ b/hpxml-measures/docs/source/intro.rst
@@ -46,6 +46,7 @@ There are additional ways that software developers using this workflow can reduc
 - Run on Linux/Mac platform, which is significantly faster than Windows.
 - Run on computing environments with 1) fast CPUs, 2) sufficient memory, and 3) enough processors to allow all simulations to run in parallel.
 - Limit requests for timeseries output (e.g., ``--hourly``, ``--daily``, ``--timestep`` arguments) and limit the number of output variables requested.
+- Use the ``--skip-component-loads`` argument if heating/cooling component loads are not of interest.
 - Use the ``--skip-validation`` argument if the HPXML input file has already been validated against the Schema & Schematron documents.
 
 License

--- a/hpxml-measures/docs/source/workflow_outputs.rst
+++ b/hpxml-measures/docs/source/workflow_outputs.rst
@@ -210,6 +210,9 @@ Annual Component Building Loads
 
 Component loads represent the estimated contribution of different building components to the annual heating/cooling building loads.
 The sum of component loads for heating (or cooling) will roughly equal the annual heating (or cooling) building load reported above.
+
+**Note**: These values will be zero if the ``--skip-component-loads`` argument is used.
+
 Current component loads disaggregated by Heating/Cooling are listed below.
    
    ================================================= =========================================================================================================

--- a/hpxml-measures/workflow/run_simulation.rb
+++ b/hpxml-measures/workflow/run_simulation.rb
@@ -10,7 +10,8 @@ require_relative '../HPXMLtoOpenStudio/resources/version'
 
 basedir = File.expand_path(File.dirname(__FILE__))
 
-def run_workflow(basedir, rundir, hpxml, debug, timeseries_output_freq, timeseries_outputs, skip_validation, output_format, building_id)
+def run_workflow(basedir, rundir, hpxml, debug, timeseries_output_freq, timeseries_outputs, skip_validation, skip_comp_loads,
+                 output_format, building_id)
   measures_dir = File.join(basedir, '..')
 
   measures = {}
@@ -20,6 +21,7 @@ def run_workflow(basedir, rundir, hpxml, debug, timeseries_output_freq, timeseri
   args = {}
   args['hpxml_path'] = hpxml
   args['output_dir'] = rundir
+  args['skip_component_loads'] = skip_comp_loads
   args['debug'] = debug
   args['skip_validation'] = skip_validation
   args['building_id'] = building_id
@@ -85,8 +87,13 @@ OptionParser.new do |opts|
   end
 
   options[:skip_validation] = false
-  opts.on('-s', '--skip-validation', 'Skip Schema/Schematron validation') do |t|
+  opts.on('-s', '--skip-validation', 'Skip Schema/Schematron validation for faster performance') do |t|
     options[:skip_validation] = true
+  end
+
+  options[:skip_comp_loads] = false
+  opts.on('--skip-component-loads', 'Skip heating/cooling component loads calculation for faster performance') do |t|
+    options[:skip_comp_loads] = true
   end
 
   opts.on('-b', '--building-id <ID>', 'ID of Building to simulate (required when multiple HPXML Building elements)') do |t|
@@ -172,7 +179,7 @@ rundir = File.join(options[:output_dir], 'run')
 # Run design
 puts "HPXML: #{options[:hpxml]}"
 success = run_workflow(basedir, rundir, options[:hpxml], options[:debug], timeseries_output_freq, timeseries_outputs,
-                       options[:skip_validation], options[:output_format], options[:building_id])
+                       options[:skip_validation], options[:skip_comp_loads], options[:output_format], options[:building_id])
 
 if not success
   exit! 1

--- a/hpxml-measures/workflow/template.osw
+++ b/hpxml-measures/workflow/template.osw
@@ -9,6 +9,7 @@
         "hpxml_path": "../workflow/sample_files/base.xml",
         "output_dir": "../workflow/run",
         "debug": false,
+        "skip_component_loads": false,
         "skip_validation": false
       },
       "measure_dir_name": "HPXMLtoOpenStudio"

--- a/workflow/design.rb
+++ b/workflow/design.rb
@@ -20,7 +20,7 @@ def get_output_hpxml(resultsdir, designdir)
   return File.join(resultsdir, File.basename(designdir) + '.xml')
 end
 
-def run_design(basedir, output_dir, run, resultsdir, hpxml, debug, hourly_outputs)
+def run_design(basedir, output_dir, run, resultsdir, hpxml, debug, hourly_outputs, skip_comp_loads)
   measures_dir = File.join(File.dirname(__FILE__), '..')
   design_name, designdir = get_design_name_and_dir(output_dir, run)
   output_hpxml = get_output_hpxml(resultsdir, designdir)
@@ -44,6 +44,7 @@ def run_design(basedir, output_dir, run, resultsdir, hpxml, debug, hourly_output
   args['hpxml_path'] = output_hpxml
   args['output_dir'] = output_dir
   args['debug'] = debug
+  args['skip_component_loads'] = skip_comp_loads
   args['skip_validation'] = !debug
   update_args_hash(measures, measure_subdir, args)
 
@@ -67,7 +68,7 @@ def run_design(basedir, output_dir, run, resultsdir, hpxml, debug, hourly_output
   return output_hpxml
 end
 
-if ARGV.size == 7
+if ARGV.size == 8
   basedir = ARGV[0]
   output_dir = ARGV[1]
   run = ARGV[2].split('|').map { |x| (x.length == 0 ? nil : x) }
@@ -75,5 +76,6 @@ if ARGV.size == 7
   hpxml = ARGV[4]
   debug = (ARGV[5].downcase.to_s == 'true')
   hourly_outputs = ARGV[6].split('|')
-  run_design(basedir, output_dir, run, resultsdir, hpxml, debug, hourly_outputs)
+  skip_comp_loads = (ARGV[7].downcase.to_s == 'true')
+  run_design(basedir, output_dir, run, resultsdir, hpxml, debug, hourly_outputs, skip_comp_loads)
 end


### PR DESCRIPTION
## Pull Request Description

Adds a `--skip-component-loads` argument to allow skipping the heating/cooling component loads calculation if not of interest. When used, reduces runtime of each simulation by 1-1.5 seconds.

## Checklist

Not all may apply:

- [x] OS-HPXML git subtree has been pulled
- [ ] 301 ruleset and unit tests have been updated
- [ ] 301validator.xml has been updated (reference EPvalidator.xml)
- [ ] Workflow tests have been updated
- [x] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
