### PR TITLE
Enable --skip-component-loads on CI runs.

### DIFF
--- a/workflow/tests/energy_rating_index_test.rb
+++ b/workflow/tests/energy_rating_index_test.rb
@@ -37,7 +37,6 @@ class EnergyRatingIndexTest < Minitest::Test
       hpxmls, csvs, runtime = _run_workflow(xml, test_name)
       all_results[File.basename(xml)] = _get_csv_results(csvs[:eri_results])
       all_results[File.basename(xml)]['Workflow Runtime (s)'] = runtime
-      break
     end
     assert(all_results.size > 0)
 

--- a/workflow/tests/energy_rating_index_test.rb
+++ b/workflow/tests/energy_rating_index_test.rb
@@ -37,6 +37,7 @@ class EnergyRatingIndexTest < Minitest::Test
       hpxmls, csvs, runtime = _run_workflow(xml, test_name)
       all_results[File.basename(xml)] = _get_csv_results(csvs[:eri_results])
       all_results[File.basename(xml)]['Workflow Runtime (s)'] = runtime
+      break
     end
     assert(all_results.size > 0)
 
@@ -570,7 +571,7 @@ class EnergyRatingIndexTest < Minitest::Test
     end
 
     # Run energy_rating_index workflow
-    command = "\"#{OpenStudio.getOpenStudioCLI}\" \"#{File.join(File.dirname(__FILE__), '../energy_rating_index.rb')}\" -x #{xml}#{hourly} -o #{rundir} --debug"
+    command = "\"#{OpenStudio.getOpenStudioCLI}\" \"#{File.join(File.dirname(__FILE__), '../energy_rating_index.rb')}\" --skip-component-loads -x #{xml}#{hourly} -o #{rundir} --debug"
     start_time = Time.now
     system(command)
     runtime = (Time.now - start_time).round(2)


### PR DESCRIPTION
## Pull Request Description

[description here]

## Checklist

Not all may apply:

- [ ] OS-HPXML git subtree has been pulled
- [ ] 301 ruleset and unit tests have been updated
- [ ] 301validator.xml has been updated (reference EPvalidator.xml)
- [ ] Workflow tests have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
