### PR TITLE
Opt-in component loads calc

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 ## OpenStudio-ERI v1.2.0 (pending)
 
 __New Features__
-- Adds a `--skip-component-loads` argument for faster performance.
+- **Breaking change**: Heating/cooling component loads no longer calculated by default for faster performance; use `--add-component-loads` argument if desired.
 
 __Bugfixes__
 

--- a/docs/source/capabilities.rst
+++ b/docs/source/capabilities.rst
@@ -5,14 +5,15 @@ ERI Capabilities
 ----------------
 The following ERI Standards and Addenda are currently available:
 
-- ANSI/RESNET/ICC 301-2014© "Standard for the Calculation and Labeling of the Energy Performance of Low-Rise Residential Buildings using an Energy Rating Index".
-- ANSI/RESNET/ICC 301-2014 Addendum A-2015, Domestic Hot Water Systems, January 15, 2016
-- ANSI/RESNET/ICC 301-2014 Addendum D-2017, Duct Leakage to Outside Test Exception, January 1, 2018
-- ANSI/RESNET/ICC 301-2014 Addendum E-2018, House Size Index Adjustment Factors, February 1, 2018
-- ANSI/RESNET/ICC 301-2014 Addendum G-2018, Solid State Lighting, February 2, 2018
-- ANSI/RESNET/ICC 301-2014 Addendum L-2018, Duct Leakage to Outside Test Exception, July 1, 2019
-- ANSI/RESNET/ICC 301-2019 "Standard for the Calculation and Labeling of the Energy Performance of Dwelling and Sleeping Units using an Energy Rating Index".
-- ANSI/RESNET/ICC 301-2019 Addendum A-2019, Clothes Washers and Dryers and Dishwashers, July 1, 2020
+- ANSI/RESNET/ICC 301-2014© "Standard for the Calculation and Labeling of the Energy Performance of Low-Rise Residential Buildings using an Energy Rating Index"
+- ANSI/RESNET/ICC 301-2014 Addendum A-2015, Domestic Hot Water Systems
+- ANSI/RESNET/ICC 301-2014 Addendum D-2017, Duct Leakage to Outside Test Exception
+- ANSI/RESNET/ICC 301-2014 Addendum E-2018, House Size Index Adjustment Factors
+- ANSI/RESNET/ICC 301-2014 Addendum G-2018, Solid State Lighting
+- ANSI/RESNET/ICC 301-2014 Addendum L-2018, Duct Leakage to Outside Test Exception
+- ANSI/RESNET/ICC 301-2019 "Standard for the Calculation and Labeling of the Energy Performance of Dwelling and Sleeping Units using an Energy Rating Index"
+- ANSI/RESNET/ICC 301-2019 Addendum A-2019, Clothes Washers and Dryers and Dishwashers
+- ANSI/RESNET/ICC 301-2019 Addendum B-2020, Clarifications, HVAC Quality Installation Grading, and Dehumidification
 
 Accuracy vs Speed
 -----------------
@@ -29,4 +30,4 @@ There are additional ways that software developers using this workflow can reduc
 - Run on Linux/Mac platform, which is significantly faster by taking advantage of the POSIX fork call.
 - Do not use the ``--hourly`` flag unless hourly output is required. If required, limit requests to hourly variables of interest.
 - Run on computing environments with 1) fast CPUs, 2) sufficient memory, and 3) enough processors to allow all simulations to run in parallel.
-- Use the ``--skip-component-loads`` argument if heating/cooling component loads are not of interest.
+- Avoid using the ``--add-component-loads`` argument if heating/cooling component loads are not of interest.

--- a/docs/source/workflow_outputs.rst
+++ b/docs/source/workflow_outputs.rst
@@ -179,10 +179,11 @@ Current peak building loads are listed below.
 Annual Component Building Loads
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+**Note**: This section is only available if the ``--add-component-loads`` argument is used.
+The argument is not used by default for faster performance.
+
 Component loads represent the estimated contribution of different building components to the annual heating/cooling building loads.
 The sum of component loads for heating (or cooling) will roughly equal the annual heating (or cooling) building load reported above.
-
-**Note**: These values will be zero if the ``--skip-component-loads`` argument is used.
 
 Current component loads disaggregated by Heating/Cooling are listed below.
    

--- a/hpxml-measures/Changelog.md
+++ b/hpxml-measures/Changelog.md
@@ -1,9 +1,9 @@
 ## OpenStudio-HPXML v1.2.0 (Pending)
 
 __New Features__
-- Adds a `--skip-component-loads` argument for faster performance.
-- Allow `Slab/ExposedPerimeter` to be zero.
+- **Breaking change**: Heating/cooling component loads no longer calculated by default for faster performance; use `--add-component-loads` argument if desired.
 - **Breaking change**: Replaces `Site/extension/ShelterCoefficient` with `Site/ShieldingofHome`.
+- Allows `Slab/ExposedPerimeter` to be zero.
 - Removes `ClothesDryer/ControlType` from being a required input, it is not used.
 - Moves additional error-checking from the ruby measure to the schematron validator.
 - Adds more detail to error messages regarding the wrong data type in the HPXML file.

--- a/hpxml-measures/HPXMLtoOpenStudio/measure.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/measure.rb
@@ -70,9 +70,9 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
     arg.setDefaultValue(false)
     args << arg
 
-    arg = OpenStudio::Measure::OSArgument.makeBoolArgument('skip_component_loads', false)
-    arg.setDisplayName('Skip component loads?')
-    arg.setDescription('If true, skips the calculation of heating/cooling component loads for faster performance.')
+    arg = OpenStudio::Measure::OSArgument.makeBoolArgument('add_component_loads', false)
+    arg.setDisplayName('Add component loads?')
+    arg.setDescription('If true, adds the calculation of heating/cooling component loads (not enabled by default for faster performance).')
     arg.setDefaultValue(false)
     args << arg
 
@@ -106,7 +106,7 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
     # assign the user inputs to variables
     hpxml_path = runner.getStringArgumentValue('hpxml_path', user_arguments)
     output_dir = runner.getStringArgumentValue('output_dir', user_arguments)
-    skip_component_loads = runner.getBoolArgumentValue('skip_component_loads', user_arguments)
+    add_component_loads = runner.getBoolArgumentValue('add_component_loads', user_arguments)
     debug = runner.getBoolArgumentValue('debug', user_arguments)
     skip_validation = runner.getBoolArgumentValue('skip_validation', user_arguments)
     building_id = runner.getOptionalStringArgumentValue('building_id', user_arguments)
@@ -152,7 +152,7 @@ class HPXMLtoOpenStudio < OpenStudio::Measure::ModelMeasure
       end
 
       OSModel.create(hpxml, runner, model, hpxml_path, epw_path, cache_path, output_dir,
-                     skip_component_loads, building_id, debug)
+                     add_component_loads, building_id, debug)
     rescue Exception => e
       runner.registerError("#{e.message}\n#{e.backtrace.join("\n")}")
       return false
@@ -198,7 +198,7 @@ end
 
 class OSModel
   def self.create(hpxml, runner, model, hpxml_path, epw_path, cache_path, output_dir,
-                  skip_component_loads, building_id, debug)
+                  add_component_loads, building_id, debug)
     @hpxml = hpxml
     @debug = debug
 
@@ -272,7 +272,7 @@ class OSModel
 
     # Output
 
-    add_loads_output(runner, model, spaces, skip_component_loads)
+    add_loads_output(runner, model, spaces, add_component_loads)
     add_output_control_files(runner, model)
     # Uncomment to debug EMS
     # add_ems_debug_output(runner, model)
@@ -2451,11 +2451,11 @@ class OSModel
     return map_str.to_s
   end
 
-  def self.add_loads_output(runner, model, spaces, skip_component_loads)
+  def self.add_loads_output(runner, model, spaces, add_component_loads)
     living_zone = spaces[HPXML::LocationLivingSpace].thermalZone.get
 
     liv_load_sensors, intgain_dehumidifier = add_total_loads_output(runner, model, living_zone)
-    return if skip_component_loads
+    return unless add_component_loads
 
     add_component_loads_output(runner, model, living_zone, liv_load_sensors, intgain_dehumidifier)
   end

--- a/hpxml-measures/HPXMLtoOpenStudio/measure.xml
+++ b/hpxml-measures/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>5b62efa4-2cdf-4611-9983-52c6ba88cfba</version_id>
-  <version_modified>20210330T065245Z</version_modified>
+  <version_id>59939bcd-5de3-4091-9b7f-80b12ffda704</version_id>
+  <version_modified>20210331T140029Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -47,9 +47,9 @@
       </choices>
     </argument>
     <argument>
-      <name>skip_component_loads</name>
-      <display_name>Skip component loads?</display_name>
-      <description>If true, skips the calculation of heating/cooling component loads for faster performance.</description>
+      <name>add_component_loads</name>
+      <display_name>Add component loads?</display_name>
+      <description>If true, adds the calculation of heating/cooling component loads (not enabled by default for faster performance).</description>
       <type>Boolean</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -556,7 +556,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>CBF390E0</checksum>
+      <checksum>A0728E31</checksum>
     </file>
   </files>
 </measure>

--- a/hpxml-measures/SimulationOutputReport/measure.rb
+++ b/hpxml-measures/SimulationOutputReport/measure.rb
@@ -423,20 +423,18 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     write_annual_output_results(runner, outputs, output_format, annual_output_path)
     report_sim_outputs(outputs, runner)
     write_eri_output_results(outputs, eri_output_path)
-    if not @timestamps.nil?
-      write_timeseries_output_results(runner, output_format,
-                                      timeseries_output_path,
-                                      timeseries_frequency,
-                                      include_timeseries_fuel_consumptions,
-                                      include_timeseries_end_use_consumptions,
-                                      include_timeseries_hot_water_uses,
-                                      include_timeseries_total_loads,
-                                      include_timeseries_component_loads,
-                                      include_timeseries_unmet_loads,
-                                      include_timeseries_zone_temperatures,
-                                      include_timeseries_airflows,
-                                      include_timeseries_weather)
-    end
+    write_timeseries_output_results(runner, output_format,
+                                    timeseries_output_path,
+                                    timeseries_frequency,
+                                    include_timeseries_fuel_consumptions,
+                                    include_timeseries_end_use_consumptions,
+                                    include_timeseries_hot_water_uses,
+                                    include_timeseries_total_loads,
+                                    include_timeseries_component_loads,
+                                    include_timeseries_unmet_loads,
+                                    include_timeseries_zone_temperatures,
+                                    include_timeseries_airflows,
+                                    include_timeseries_weather)
 
     return true
   end
@@ -960,9 +958,11 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     @peak_loads.each do |load_type, peak_load|
       results_out << ["#{peak_load.name} (#{peak_load.annual_units})", peak_load.annual_output.round(2)]
     end
-    results_out << [line_break]
-    @component_loads.each do |load_type, load|
-      results_out << ["#{load.name} (#{load.annual_units})", load.annual_output.round(2)]
+    if @component_loads.values.map { |load| load.annual_output }.sum > 0 # Skip if component loads not calculated
+      results_out << [line_break]
+      @component_loads.each do |load_type, load|
+        results_out << ["#{load.name} (#{load.annual_units})", load.annual_output.round(2)]
+      end
     end
     results_out << [line_break]
     @hot_water_uses.each do |hot_water_type, hot_water|

--- a/hpxml-measures/SimulationOutputReport/measure.xml
+++ b/hpxml-measures/SimulationOutputReport/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>df9d170c-c21a-4130-866d-0d46b06073fd</uid>
-  <version_id>49605fe2-bd20-4058-9b2c-2abcc5806928</version_id>
-  <version_modified>20210330T064129Z</version_modified>
+  <version_id>96e26b91-6565-43ff-aaec-c785557d4f85</version_id>
+  <version_modified>20210331T140029Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>HPXML Simulation Output Report</display_name>
@@ -915,7 +915,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>00C7AE82</checksum>
+      <checksum>A8CD702E</checksum>
     </file>
   </files>
 </measure>

--- a/hpxml-measures/docs/source/intro.rst
+++ b/hpxml-measures/docs/source/intro.rst
@@ -46,7 +46,7 @@ There are additional ways that software developers using this workflow can reduc
 - Run on Linux/Mac platform, which is significantly faster than Windows.
 - Run on computing environments with 1) fast CPUs, 2) sufficient memory, and 3) enough processors to allow all simulations to run in parallel.
 - Limit requests for timeseries output (e.g., ``--hourly``, ``--daily``, ``--timestep`` arguments) and limit the number of output variables requested.
-- Use the ``--skip-component-loads`` argument if heating/cooling component loads are not of interest.
+- Avoid using the ``--add-component-loads`` argument if heating/cooling component loads are not of interest.
 - Use the ``--skip-validation`` argument if the HPXML input file has already been validated against the Schema & Schematron documents.
 
 License

--- a/hpxml-measures/docs/source/workflow_outputs.rst
+++ b/hpxml-measures/docs/source/workflow_outputs.rst
@@ -208,10 +208,11 @@ Current peak building loads are listed below.
 Annual Component Building Loads
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+**Note**: This section is only available if the ``--add-component-loads`` argument is used.
+The argument is not used by default for faster performance.
+
 Component loads represent the estimated contribution of different building components to the annual heating/cooling building loads.
 The sum of component loads for heating (or cooling) will roughly equal the annual heating (or cooling) building load reported above.
-
-**Note**: These values will be zero if the ``--skip-component-loads`` argument is used.
 
 Current component loads disaggregated by Heating/Cooling are listed below.
    

--- a/hpxml-measures/workflow/run_simulation.rb
+++ b/hpxml-measures/workflow/run_simulation.rb
@@ -10,7 +10,7 @@ require_relative '../HPXMLtoOpenStudio/resources/version'
 
 basedir = File.expand_path(File.dirname(__FILE__))
 
-def run_workflow(basedir, rundir, hpxml, debug, timeseries_output_freq, timeseries_outputs, skip_validation, skip_comp_loads,
+def run_workflow(basedir, rundir, hpxml, debug, timeseries_output_freq, timeseries_outputs, skip_validation, add_comp_loads,
                  output_format, building_id)
   measures_dir = File.join(basedir, '..')
 
@@ -21,8 +21,8 @@ def run_workflow(basedir, rundir, hpxml, debug, timeseries_output_freq, timeseri
   args = {}
   args['hpxml_path'] = hpxml
   args['output_dir'] = rundir
-  args['skip_component_loads'] = skip_comp_loads
   args['debug'] = debug
+  args['add_component_loads'] = (add_comp_loads || timeseries_outputs.include?('componentloads'))
   args['skip_validation'] = skip_validation
   args['building_id'] = building_id
   update_args_hash(measures, measure_subdir, args)
@@ -91,9 +91,9 @@ OptionParser.new do |opts|
     options[:skip_validation] = true
   end
 
-  options[:skip_comp_loads] = false
-  opts.on('--skip-component-loads', 'Skip heating/cooling component loads calculation for faster performance') do |t|
-    options[:skip_comp_loads] = true
+  options[:add_comp_loads] = false
+  opts.on('--add-component-loads', 'Add heating/cooling component loads calculation') do |t|
+    options[:add_comp_loads] = true
   end
 
   opts.on('-b', '--building-id <ID>', 'ID of Building to simulate (required when multiple HPXML Building elements)') do |t|
@@ -179,7 +179,7 @@ rundir = File.join(options[:output_dir], 'run')
 # Run design
 puts "HPXML: #{options[:hpxml]}"
 success = run_workflow(basedir, rundir, options[:hpxml], options[:debug], timeseries_output_freq, timeseries_outputs,
-                       options[:skip_validation], options[:skip_comp_loads], options[:output_format], options[:building_id])
+                       options[:skip_validation], options[:add_comp_loads], options[:output_format], options[:building_id])
 
 if not success
   exit! 1

--- a/hpxml-measures/workflow/template.osw
+++ b/hpxml-measures/workflow/template.osw
@@ -9,7 +9,7 @@
         "hpxml_path": "../workflow/sample_files/base.xml",
         "output_dir": "../workflow/run",
         "debug": false,
-        "skip_component_loads": false,
+        "add_component_loads": false,
         "skip_validation": false
       },
       "measure_dir_name": "HPXMLtoOpenStudio"

--- a/workflow/design.rb
+++ b/workflow/design.rb
@@ -76,6 +76,6 @@ if ARGV.size == 8
   hpxml = ARGV[4]
   debug = (ARGV[5].downcase.to_s == 'true')
   hourly_outputs = ARGV[6].split('|')
-  skip_comp_loads = (ARGV[7].downcase.to_s == 'true')
-  run_design(basedir, output_dir, run, resultsdir, hpxml, debug, hourly_outputs, skip_comp_loads)
+  add_comp_loads = (ARGV[7].downcase.to_s == 'true')
+  run_design(basedir, output_dir, run, resultsdir, hpxml, debug, hourly_outputs, add_comp_loads)
 end

--- a/workflow/design.rb
+++ b/workflow/design.rb
@@ -20,7 +20,7 @@ def get_output_hpxml(resultsdir, designdir)
   return File.join(resultsdir, File.basename(designdir) + '.xml')
 end
 
-def run_design(basedir, output_dir, run, resultsdir, hpxml, debug, hourly_outputs, skip_comp_loads)
+def run_design(basedir, output_dir, run, resultsdir, hpxml, debug, hourly_outputs, add_comp_loads)
   measures_dir = File.join(File.dirname(__FILE__), '..')
   design_name, designdir = get_design_name_and_dir(output_dir, run)
   output_hpxml = get_output_hpxml(resultsdir, designdir)
@@ -44,7 +44,7 @@ def run_design(basedir, output_dir, run, resultsdir, hpxml, debug, hourly_output
   args['hpxml_path'] = output_hpxml
   args['output_dir'] = output_dir
   args['debug'] = debug
-  args['skip_component_loads'] = skip_comp_loads
+  args['add_component_loads'] = (add_comp_loads || hourly_outputs.include?('componentloads'))
   args['skip_validation'] = !debug
   update_args_hash(measures, measure_subdir, args)
 


### PR DESCRIPTION
## Pull Request Description

Follow-up to #514.

**Breaking change**: Changes component load calculation to opt-in w/ `--add-component-loads` arguments. (Previously opt-out w/ `--skip-component-loads` argument.)

## Checklist

Not all may apply:

- [x] OS-HPXML git subtree has been pulled
- [ ] 301 ruleset and unit tests have been updated
- [ ] 301validator.xml has been updated (reference EPvalidator.xml)
- [x] Workflow tests have been updated
- [x] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
