### PR TITLE
Removes shared laundry limitation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ __New Features__
 - Switches room air conditioner model to use Cutler performance curves.
 - Shared systems now preserved in the Rated Home (as opposed to configuring, e.g., the equivalent central AC w/ SEEReq for a chiller).
 - Removes limitation that a shared water heater serving a shared laundry room can't also serve dwelling unit fixtures (i.e., FractionDHWLoadServed is no longer required to be zero).
+- When Reference/Rated water heater fuels are determined by predominant water/space heating fuels, fossil fuel is now selected in the case of a tie.
 
 __Bugfixes__
 - Prevents a solar hot water system w/ SolarFraction=1.

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ __New Features__
 - Allows `DuctLeakageMeasurement` & `ConditionedFloorAreaServed` to not be specified for ductless fan coil systems; **Breaking change**: `AirDistributionType` is now required for all air distribution systems.
 - Switches room air conditioner model to use Cutler performance curves.
 - Shared systems now preserved in the Rated Home (as opposed to configuring, e.g., the equivalent central AC w/ SEEReq for a chiller).
+- Removes limitation that a shared water heater serving a shared laundry room can't also serve dwelling unit fixtures (i.e., FractionDHWLoadServed is no longer required to be zero).
 
 __Bugfixes__
 - Prevents a solar hot water system w/ SolarFraction=1.

--- a/hpxml-measures/Changelog.md
+++ b/hpxml-measures/Changelog.md
@@ -3,12 +3,12 @@
 __New Features__
 - **Breaking change**: Heating/cooling component loads no longer calculated by default for faster performance; use `--add-component-loads` argument if desired.
 - **Breaking change**: Replaces `Site/extension/ShelterCoefficient` with `Site/ShieldingofHome`.
-- **Breaking change**: `AirDistributionType` is now required for all air distribution systems.
-- Allows `DuctLeakageMeasurement` & `ConditionedFloorAreaServed` to not be specified for ductless fan coil systems.
+- Allows `DuctLeakageMeasurement` & `ConditionedFloorAreaServed` to not be specified for ductless fan coil systems; **Breaking change**: `AirDistributionType` is now required for all air distribution systems.
 - Allows `Slab/ExposedPerimeter` to be zero.
 - Removes `ClothesDryer/ControlType` from being a required input, it is not used.
 - Switches room air conditioner model to use Cutler performance curves.
 - Relaxes tolerance for duct leakage to outside warning when ducts solely in conditioned space.
+- Removes limitation that a shared water heater serving a shared laundry room can't also serve dwelling unit fixtures (i.e., FractionDHWLoadServed is no longer required to be zero).
 - Moves additional error-checking from the ruby measure to the schematron validator. 
 
 __Bugfixes__

--- a/hpxml-measures/HPXMLtoOpenStudio/measure.xml
+++ b/hpxml-measures/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>5b89dc21-f8d6-40a4-b553-44fee9db5bdb</version_id>
-  <version_modified>20210428T034944Z</version_modified>
+  <version_id>bae0e084-f9cd-453a-9be8-9a4bc8623cdd</version_id>
+  <version_modified>20210428T175957Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -440,12 +440,6 @@
       <checksum>2BD03B80</checksum>
     </file>
     <file>
-      <filename>test_water_heater.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>E507D3D1</checksum>
-    </file>
-    <file>
       <filename>test_generator.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -462,12 +456,6 @@
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
       <checksum>E962DB16</checksum>
-    </file>
-    <file>
-      <filename>EPvalidator.xml</filename>
-      <filetype>xml</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>E88FE4FD</checksum>
     </file>
     <file>
       <filename>test_airflow.rb</filename>
@@ -557,6 +545,18 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>2AD627A4</checksum>
+    </file>
+    <file>
+      <filename>EPvalidator.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>95FBB68A</checksum>
+    </file>
+    <file>
+      <filename>test_water_heater.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>C8BB1267</checksum>
     </file>
   </files>
 </measure>

--- a/hpxml-measures/HPXMLtoOpenStudio/resources/EPvalidator.xml
+++ b/hpxml-measures/HPXMLtoOpenStudio/resources/EPvalidator.xml
@@ -1333,7 +1333,6 @@
     <sch:title>[ClothesWasherType=Shared]</sch:title>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Appliances/h:ClothesWasher[h:IsSharedAppliance="true"]'>
       <sch:assert role='ERROR' test='count(../../h:BuildingSummary/h:BuildingConstruction[h:ResidentialFacilityType[text()="single-family attached" or text()="apartment unit"]]) = 1'>Expected 1 element(s) for xpath: ../../BuildingSummary/BuildingConstruction[ResidentialFacilityType[text()="single-family attached" or text()="apartment unit"]]</sch:assert>
-      <sch:assert role='ERROR' test='count(../../h:Systems/h:WaterHeating/h:WaterHeatingSystem[h:IsSharedSystem="true" and number(h:FractionDHWLoadServed)=0]) &gt;= 1'>Expected 1 or more element(s) for xpath: ../../Systems/WaterHeating/WaterHeatingSystem[IsSharedSystem="true" and number(FractionDHWLoadServed)=0]</sch:assert>
       <sch:assert role='ERROR' test='count(h:AttachedToWaterHeatingSystem) = 1'>Expected 1 element(s) for xpath: AttachedToWaterHeatingSystem</sch:assert>
     </sch:rule>
   </sch:pattern>
@@ -1395,7 +1394,6 @@
     <sch:title>[DishwasherType=Shared]</sch:title>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Appliances/h:Dishwasher[h:IsSharedAppliance="true"]'>
       <sch:assert role='ERROR' test='count(../../h:BuildingSummary/h:BuildingConstruction[h:ResidentialFacilityType[text()="single-family attached" or text()="apartment unit"]]) = 1'>Expected 1 element(s) for xpath: ../../BuildingSummary/BuildingConstruction[ResidentialFacilityType[text()="single-family attached" or text()="apartment unit"]]</sch:assert>
-      <sch:assert role='ERROR' test='count(../../h:Systems/h:WaterHeating/h:WaterHeatingSystem[h:IsSharedSystem="true" and number(h:FractionDHWLoadServed)=0]) &gt;= 1'>Expected 1 or more element(s) for xpath: ../../Systems/WaterHeating/WaterHeatingSystem[IsSharedSystem="true" and number(FractionDHWLoadServed)=0]</sch:assert>
       <sch:assert role='ERROR' test='count(h:AttachedToWaterHeatingSystem) = 1'>Expected 1 element(s) for xpath: AttachedToWaterHeatingSystem</sch:assert>
     </sch:rule>
   </sch:pattern>

--- a/hpxml-measures/HPXMLtoOpenStudio/tests/test_water_heater.rb
+++ b/hpxml-measures/HPXMLtoOpenStudio/tests/test_water_heater.rb
@@ -1094,43 +1094,27 @@ class HPXMLtoOpenStudioWaterHeaterTest < MiniTest::Test
 
     # Get HPXML values
     water_heating_system = hpxml.water_heating_systems[0]
-    shared_water_heating_system = hpxml.water_heating_systems[1]
 
     # Expected value
-    tank_volumes = [UnitConversions.convert(water_heating_system.tank_volume * 0.9, 'gal', 'm^3'),
-                    UnitConversions.convert(shared_water_heating_system.tank_volume * 0.9, 'gal', 'm^3')] # convert to actual volume
-    caps = [UnitConversions.convert(water_heating_system.heating_capacity / 1000.0, 'kBtu/hr', 'W'),
-            UnitConversions.convert(shared_water_heating_system.heating_capacity / 1000.0, 'kBtu/hr', 'W')]
-    fuels = [EPlus.fuel_type(water_heating_system.fuel_type),
-             EPlus.fuel_type(shared_water_heating_system.fuel_type)]
-    uas = [UnitConversions.convert(1.335, 'Btu/(hr*F)', 'W/K'),
-           UnitConversions.convert(1.335 / shared_water_heating_system.number_of_units_served, 'Btu/(hr*F)', 'W/K')]
-    t_sets = [UnitConversions.convert(water_heating_system.temperature, 'F', 'C') + 1,
-              UnitConversions.convert(shared_water_heating_system.temperature, 'F', 'C') + 1] # setpoint + 1/2 deadband
-    ther_effs = [1.0, 1.0]
-    locs = [water_heating_system.location,
-            shared_water_heating_system.location]
+    tank_volume = UnitConversions.convert(water_heating_system.tank_volume * 0.95, 'gal', 'm^3') # convert to actual volume
+    cap = UnitConversions.convert(water_heating_system.heating_capacity / 1000.0, 'kBtu/hr', 'W')
+    fuel = EPlus.fuel_type(water_heating_system.fuel_type)
+    ua = UnitConversions.convert(7.88, 'Btu/(hr*F)', 'W/K') / water_heating_system.number_of_units_served
+    t_set = UnitConversions.convert(water_heating_system.temperature, 'F', 'C') + 1 # setpoint + 1/2 deadband
+    ther_eff = 0.773
+    loc = water_heating_system.location
 
     # Check water heater
-    assert_equal(2, model.getWaterHeaterMixeds.size)
-    wh = model.getWaterHeaterMixeds.sort[0]
-    assert_equal(fuels[0], wh.heaterFuelType)
-    assert_equal(locs[0], wh.ambientTemperatureThermalZone.get.name.get)
-    assert_in_epsilon(tank_volumes[0], wh.tankVolume.get, 0.001)
-    assert_in_epsilon(caps[0], wh.heaterMaximumCapacity.get, 0.001)
-    assert_in_epsilon(uas[0], wh.onCycleLossCoefficienttoAmbientTemperature.get, 0.001)
-    assert_in_epsilon(uas[0], wh.offCycleLossCoefficienttoAmbientTemperature.get, 0.001)
-    assert_in_epsilon(t_sets[0], wh.setpointTemperatureSchedule.get.to_ScheduleConstant.get.value, 0.001)
-    assert_in_epsilon(ther_effs[0], wh.heaterThermalEfficiency.get, 0.001)
-    wh = model.getWaterHeaterMixeds.sort[1]
-    assert_equal(fuels[1], wh.heaterFuelType)
-    assert_equal('Schedule', wh.ambientTemperatureIndicator)
-    assert_in_epsilon(tank_volumes[1], wh.tankVolume.get, 0.001)
-    assert_in_epsilon(caps[1], wh.heaterMaximumCapacity.get, 0.001)
-    assert_in_epsilon(uas[1], wh.onCycleLossCoefficienttoAmbientTemperature.get, 0.001)
-    assert_in_epsilon(uas[1], wh.offCycleLossCoefficienttoAmbientTemperature.get, 0.001)
-    assert_in_epsilon(t_sets[1], wh.setpointTemperatureSchedule.get.to_ScheduleConstant.get.value, 0.001)
-    assert_in_epsilon(ther_effs[1], wh.heaterThermalEfficiency.get, 0.001)
+    assert_equal(1, model.getWaterHeaterMixeds.size)
+    wh = model.getWaterHeaterMixeds[0]
+    assert_equal(fuel, wh.heaterFuelType)
+    assert_equal(loc, wh.ambientTemperatureThermalZone.get.name.get)
+    assert_in_epsilon(tank_volume, wh.tankVolume.get, 0.001)
+    assert_in_epsilon(cap, wh.heaterMaximumCapacity.get, 0.001)
+    assert_in_epsilon(ua, wh.onCycleLossCoefficienttoAmbientTemperature.get, 0.001)
+    assert_in_epsilon(ua, wh.offCycleLossCoefficienttoAmbientTemperature.get, 0.001)
+    assert_in_epsilon(t_set, wh.setpointTemperatureSchedule.get.to_ScheduleConstant.get.value, 0.001)
+    assert_in_epsilon(ther_eff, wh.heaterThermalEfficiency.get, 0.001)
   end
 
   def _test_measure(args_hash)

--- a/hpxml-measures/tasks.rb
+++ b/hpxml-measures/tasks.rb
@@ -4395,7 +4395,8 @@ def set_hpxml_water_heating_systems(hpxml_file, hpxml)
     hpxml.water_heating_systems[0].heating_capacity = nil
     hpxml.water_heating_systems[0].tank_volume = nil
     hpxml.water_heating_systems[0].recovery_efficiency = nil
-  elsif ['base-bldgtype-multifamily-shared-water-heater.xml'].include? hpxml_file
+  elsif ['base-bldgtype-multifamily-shared-water-heater.xml',
+         'base-bldgtype-multifamily-shared-laundry-room.xml'].include? hpxml_file
     hpxml.water_heating_systems.clear
     hpxml.water_heating_systems.add(id: 'SharedWaterHeater',
                                     is_shared_system: true,
@@ -4409,14 +4410,6 @@ def set_hpxml_water_heating_systems(hpxml_file, hpxml)
                                     energy_factor: 0.59,
                                     recovery_efficiency: 0.76,
                                     temperature: Waterheater.get_default_hot_water_temperature(Constants.ERIVersions[-1]))
-  elsif ['base-bldgtype-multifamily-shared-laundry-room.xml'].include? hpxml_file
-    hpxml.water_heating_systems[0].location = HPXML::LocationLivingSpace
-    hpxml.water_heating_systems << hpxml.water_heating_systems[0].dup
-    hpxml.water_heating_systems[1].id = 'SharedWaterHeater'
-    hpxml.water_heating_systems[1].is_shared_system = true
-    hpxml.water_heating_systems[1].number_of_units_served = 6
-    hpxml.water_heating_systems[1].fraction_dhw_load_served = 0
-    hpxml.water_heating_systems[1].location = HPXML::LocationOtherHeatedSpace
   elsif ['invalid_files/multifamily-reference-water-heater.xml'].include? hpxml_file
     hpxml.water_heating_systems[0].location = HPXML::LocationOtherNonFreezingSpace
   elsif ['invalid_files/dhw-invalid-ef-tank.xml'].include? hpxml_file

--- a/hpxml-measures/workflow/sample_files/base-bldgtype-multifamily-shared-laundry-room.xml
+++ b/hpxml-measures/workflow/sample_files/base-bldgtype-multifamily-shared-laundry-room.xml
@@ -265,27 +265,17 @@
         </HVAC>
         <WaterHeating>
           <WaterHeatingSystem>
-            <SystemIdentifier id='WaterHeater'/>
-            <FuelType>electricity</FuelType>
+            <SystemIdentifier id='SharedWaterHeater'/>
+            <FuelType>natural gas</FuelType>
             <WaterHeaterType>storage water heater</WaterHeaterType>
             <Location>living space</Location>
-            <TankVolume>40.0</TankVolume>
-            <FractionDHWLoadServed>1.0</FractionDHWLoadServed>
-            <HeatingCapacity>18767.0</HeatingCapacity>
-            <EnergyFactor>0.95</EnergyFactor>
-            <HotWaterTemperature>125.0</HotWaterTemperature>
-          </WaterHeatingSystem>
-          <WaterHeatingSystem>
-            <SystemIdentifier id='SharedWaterHeater'/>
-            <FuelType>electricity</FuelType>
-            <WaterHeaterType>storage water heater</WaterHeaterType>
-            <Location>other heated space</Location>
             <IsSharedSystem>true</IsSharedSystem>
             <NumberofUnitsServed>6</NumberofUnitsServed>
-            <TankVolume>40.0</TankVolume>
-            <FractionDHWLoadServed>0.0</FractionDHWLoadServed>
-            <HeatingCapacity>18767.0</HeatingCapacity>
-            <EnergyFactor>0.95</EnergyFactor>
+            <TankVolume>120.0</TankVolume>
+            <FractionDHWLoadServed>1.0</FractionDHWLoadServed>
+            <HeatingCapacity>40000.0</HeatingCapacity>
+            <EnergyFactor>0.59</EnergyFactor>
+            <RecoveryEfficiency>0.76</RecoveryEfficiency>
             <HotWaterTemperature>125.0</HotWaterTemperature>
           </WaterHeatingSystem>
           <HotWaterDistribution>

--- a/hpxml-measures/workflow/sample_files/invalid_files/invalid-facility-type-equipment.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/invalid-facility-type-equipment.xml
@@ -265,27 +265,17 @@
         </HVAC>
         <WaterHeating>
           <WaterHeatingSystem>
-            <SystemIdentifier id='WaterHeater'/>
-            <FuelType>electricity</FuelType>
+            <SystemIdentifier id='SharedWaterHeater'/>
+            <FuelType>natural gas</FuelType>
             <WaterHeaterType>storage water heater</WaterHeaterType>
             <Location>living space</Location>
-            <TankVolume>40.0</TankVolume>
-            <FractionDHWLoadServed>1.0</FractionDHWLoadServed>
-            <HeatingCapacity>18767.0</HeatingCapacity>
-            <EnergyFactor>0.95</EnergyFactor>
-            <HotWaterTemperature>125.0</HotWaterTemperature>
-          </WaterHeatingSystem>
-          <WaterHeatingSystem>
-            <SystemIdentifier id='SharedWaterHeater'/>
-            <FuelType>electricity</FuelType>
-            <WaterHeaterType>storage water heater</WaterHeaterType>
-            <Location>other heated space</Location>
             <IsSharedSystem>true</IsSharedSystem>
             <NumberofUnitsServed>6</NumberofUnitsServed>
-            <TankVolume>40.0</TankVolume>
-            <FractionDHWLoadServed>0.0</FractionDHWLoadServed>
-            <HeatingCapacity>18767.0</HeatingCapacity>
-            <EnergyFactor>0.95</EnergyFactor>
+            <TankVolume>120.0</TankVolume>
+            <FractionDHWLoadServed>1.0</FractionDHWLoadServed>
+            <HeatingCapacity>40000.0</HeatingCapacity>
+            <EnergyFactor>0.59</EnergyFactor>
+            <RecoveryEfficiency>0.76</RecoveryEfficiency>
             <HotWaterTemperature>125.0</HotWaterTemperature>
           </WaterHeatingSystem>
           <HotWaterDistribution>

--- a/hpxml-measures/workflow/sample_files/invalid_files/unattached-shared-clothes-washer-water-heater.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/unattached-shared-clothes-washer-water-heater.xml
@@ -265,27 +265,17 @@
         </HVAC>
         <WaterHeating>
           <WaterHeatingSystem>
-            <SystemIdentifier id='WaterHeater'/>
-            <FuelType>electricity</FuelType>
+            <SystemIdentifier id='SharedWaterHeater'/>
+            <FuelType>natural gas</FuelType>
             <WaterHeaterType>storage water heater</WaterHeaterType>
             <Location>living space</Location>
-            <TankVolume>40.0</TankVolume>
-            <FractionDHWLoadServed>1.0</FractionDHWLoadServed>
-            <HeatingCapacity>18767.0</HeatingCapacity>
-            <EnergyFactor>0.95</EnergyFactor>
-            <HotWaterTemperature>125.0</HotWaterTemperature>
-          </WaterHeatingSystem>
-          <WaterHeatingSystem>
-            <SystemIdentifier id='SharedWaterHeater'/>
-            <FuelType>electricity</FuelType>
-            <WaterHeaterType>storage water heater</WaterHeaterType>
-            <Location>other heated space</Location>
             <IsSharedSystem>true</IsSharedSystem>
             <NumberofUnitsServed>6</NumberofUnitsServed>
-            <TankVolume>40.0</TankVolume>
-            <FractionDHWLoadServed>0.0</FractionDHWLoadServed>
-            <HeatingCapacity>18767.0</HeatingCapacity>
-            <EnergyFactor>0.95</EnergyFactor>
+            <TankVolume>120.0</TankVolume>
+            <FractionDHWLoadServed>1.0</FractionDHWLoadServed>
+            <HeatingCapacity>40000.0</HeatingCapacity>
+            <EnergyFactor>0.59</EnergyFactor>
+            <RecoveryEfficiency>0.76</RecoveryEfficiency>
             <HotWaterTemperature>125.0</HotWaterTemperature>
           </WaterHeatingSystem>
           <HotWaterDistribution>

--- a/hpxml-measures/workflow/sample_files/invalid_files/unattached-shared-dishwasher-water-heater.xml
+++ b/hpxml-measures/workflow/sample_files/invalid_files/unattached-shared-dishwasher-water-heater.xml
@@ -265,27 +265,17 @@
         </HVAC>
         <WaterHeating>
           <WaterHeatingSystem>
-            <SystemIdentifier id='WaterHeater'/>
-            <FuelType>electricity</FuelType>
+            <SystemIdentifier id='SharedWaterHeater'/>
+            <FuelType>natural gas</FuelType>
             <WaterHeaterType>storage water heater</WaterHeaterType>
             <Location>living space</Location>
-            <TankVolume>40.0</TankVolume>
-            <FractionDHWLoadServed>1.0</FractionDHWLoadServed>
-            <HeatingCapacity>18767.0</HeatingCapacity>
-            <EnergyFactor>0.95</EnergyFactor>
-            <HotWaterTemperature>125.0</HotWaterTemperature>
-          </WaterHeatingSystem>
-          <WaterHeatingSystem>
-            <SystemIdentifier id='SharedWaterHeater'/>
-            <FuelType>electricity</FuelType>
-            <WaterHeaterType>storage water heater</WaterHeaterType>
-            <Location>other heated space</Location>
             <IsSharedSystem>true</IsSharedSystem>
             <NumberofUnitsServed>6</NumberofUnitsServed>
-            <TankVolume>40.0</TankVolume>
-            <FractionDHWLoadServed>0.0</FractionDHWLoadServed>
-            <HeatingCapacity>18767.0</HeatingCapacity>
-            <EnergyFactor>0.95</EnergyFactor>
+            <TankVolume>120.0</TankVolume>
+            <FractionDHWLoadServed>1.0</FractionDHWLoadServed>
+            <HeatingCapacity>40000.0</HeatingCapacity>
+            <EnergyFactor>0.59</EnergyFactor>
+            <RecoveryEfficiency>0.76</RecoveryEfficiency>
             <HotWaterTemperature>125.0</HotWaterTemperature>
           </WaterHeatingSystem>
           <HotWaterDistribution>

--- a/rulesets/301EnergyRatingIndexRuleset/resources/301validator.xml
+++ b/rulesets/301EnergyRatingIndexRuleset/resources/301validator.xml
@@ -1232,7 +1232,6 @@
     <sch:title>[ClothesWasherType=Shared]</sch:title>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Appliances/h:ClothesWasher[h:IsSharedAppliance="true"]'>
       <sch:assert role='ERROR' test='count(../../h:BuildingSummary/h:BuildingConstruction[h:ResidentialFacilityType[text()="single-family attached" or text()="apartment unit"]]) = 1'>Expected 1 element(s) for xpath: ../../BuildingSummary/BuildingConstruction[ResidentialFacilityType[text()="single-family attached" or text()="apartment unit"]]</sch:assert>
-      <sch:assert role='ERROR' test='count(../../h:Systems/h:WaterHeating/h:WaterHeatingSystem[h:IsSharedSystem="true" and number(h:FractionDHWLoadServed)=0]) &gt;= 1'>Expected 1 or more element(s) for xpath: ../../Systems/WaterHeating/WaterHeatingSystem[IsSharedSystem="true" and number(FractionDHWLoadServed)=0]</sch:assert>
       <sch:assert role='ERROR' test='count(h:AttachedToWaterHeatingSystem) = 1'>Expected 1 element(s) for xpath: AttachedToWaterHeatingSystem</sch:assert>
       <sch:assert role='ERROR' test='count(h:NumberofUnits) = 1'>Expected 1 element(s) for xpath: NumberofUnits</sch:assert>
       <sch:assert role='ERROR' test='count(h:NumberofUnitsServed) = 1'>Expected 1 element(s) for xpath: NumberofUnitsServed</sch:assert>
@@ -1279,7 +1278,6 @@
     <sch:title>[DishwasherType=Shared]</sch:title>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Appliances/h:Dishwasher[h:IsSharedAppliance="true"]'>
       <sch:assert role='ERROR' test='count(../../h:BuildingSummary/h:BuildingConstruction[h:ResidentialFacilityType[text()="single-family attached" or text()="apartment unit"]]) = 1'>Expected 1 element(s) for xpath: ../../BuildingSummary/BuildingConstruction[ResidentialFacilityType[text()="single-family attached" or text()="apartment unit"]]</sch:assert>
-      <sch:assert role='ERROR' test='count(../../h:Systems/h:WaterHeating/h:WaterHeatingSystem[h:IsSharedSystem="true" and number(h:FractionDHWLoadServed)=0]) &gt;= 1'>Expected 1 or more element(s) for xpath: ../../Systems/WaterHeating/WaterHeatingSystem[IsSharedSystem="true" and number(FractionDHWLoadServed)=0]</sch:assert>
       <sch:assert role='ERROR' test='count(h:AttachedToWaterHeatingSystem) = 1'>Expected 1 element(s) for xpath: AttachedToWaterHeatingSystem</sch:assert>
     </sch:rule>
   </sch:pattern>

--- a/rulesets/301EnergyRatingIndexRuleset/tests/test_water_heating.rb
+++ b/rulesets/301EnergyRatingIndexRuleset/tests/test_water_heating.rb
@@ -424,17 +424,16 @@ class ERIWaterHeatingTest < MiniTest::Test
     hpxml_name = 'base-bldgtype-multifamily-shared-laundry-room.xml'
 
     hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIReferenceHome)
-    _check_water_heater(hpxml, [{ whtype: HPXML::WaterHeaterTypeStorage, fuel: HPXML::FuelTypeElectricity, setpoint: 125.0, location: HPXML::LocationLivingSpace, tank_vol: 40, ef: 0.9172, n_units_served: 1 }])
+    _check_water_heater(hpxml, [{ whtype: HPXML::WaterHeaterTypeStorage, fuel: HPXML::FuelTypeNaturalGas, setpoint: 125.0, location: HPXML::LocationLivingSpace, tank_vol: 40, ef: 0.59, n_units_served: 1 }])
     _check_hot_water_distribution(hpxml, disttype: HPXML::DHWDistTypeStandard, pipe_r: 0.0, pipe_l: 70.0)
     hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIRatedHome)
-    _check_water_heater(hpxml, [{ whtype: HPXML::WaterHeaterTypeStorage, fuel: HPXML::FuelTypeElectricity, setpoint: 125.0, location: HPXML::LocationLivingSpace, tank_vol: 40, ef: 0.95, n_units_served: 1 },
-                                { whtype: HPXML::WaterHeaterTypeStorage, fuel: HPXML::FuelTypeElectricity, setpoint: 125.0, location: HPXML::LocationOtherHeatedSpace, tank_vol: 40, ef: 0.95, n_units_served: 6, frac_load: 0 }])
+    _check_water_heater(hpxml, [{ whtype: HPXML::WaterHeaterTypeStorage, fuel: HPXML::FuelTypeNaturalGas, setpoint: 125.0, location: HPXML::LocationLivingSpace, tank_vol: 120, ef: 0.59, n_units_served: 6 }])
     _check_hot_water_distribution(hpxml, disttype: HPXML::DHWDistTypeStandard, pipe_r: 0.0, pipe_l: 50)
     calc_types = [Constants.CalcTypeERIIndexAdjustmentDesign,
                   Constants.CalcTypeERIIndexAdjustmentReferenceHome]
     calc_types.each do |calc_type|
       hpxml = _test_measure(hpxml_name, calc_type)
-      _check_water_heater(hpxml, [{ whtype: HPXML::WaterHeaterTypeStorage, fuel: HPXML::FuelTypeElectricity, setpoint: 125.0, location: HPXML::LocationLivingSpace, tank_vol: 40, ef: 0.9172, n_units_served: 1 }])
+      _check_water_heater(hpxml, [{ whtype: HPXML::WaterHeaterTypeStorage, fuel: HPXML::FuelTypeNaturalGas, setpoint: 125.0, location: HPXML::LocationLivingSpace, tank_vol: 40, ef: 0.59, n_units_served: 1 }])
       _check_hot_water_distribution(hpxml, disttype: HPXML::DHWDistTypeStandard, pipe_r: 0.0, pipe_l: 89.28)
     end
   end

--- a/workflow/sample_files/base-bldgtype-multifamily-shared-laundry-room.xml
+++ b/workflow/sample_files/base-bldgtype-multifamily-shared-laundry-room.xml
@@ -282,28 +282,17 @@
         </HVAC>
         <WaterHeating>
           <WaterHeatingSystem>
-            <SystemIdentifier id='WaterHeater'/>
-            <FuelType>electricity</FuelType>
+            <SystemIdentifier id='SharedWaterHeater'/>
+            <FuelType>natural gas</FuelType>
             <WaterHeaterType>storage water heater</WaterHeaterType>
             <Location>living space</Location>
-            <IsSharedSystem>false</IsSharedSystem>
-            <TankVolume>40.0</TankVolume>
-            <FractionDHWLoadServed>1.0</FractionDHWLoadServed>
-            <HeatingCapacity>18767.0</HeatingCapacity>
-            <EnergyFactor>0.95</EnergyFactor>
-            <HotWaterTemperature>125.0</HotWaterTemperature>
-          </WaterHeatingSystem>
-          <WaterHeatingSystem>
-            <SystemIdentifier id='SharedWaterHeater'/>
-            <FuelType>electricity</FuelType>
-            <WaterHeaterType>storage water heater</WaterHeaterType>
-            <Location>other heated space</Location>
             <IsSharedSystem>true</IsSharedSystem>
             <NumberofUnitsServed>6</NumberofUnitsServed>
-            <TankVolume>40.0</TankVolume>
-            <FractionDHWLoadServed>0.0</FractionDHWLoadServed>
-            <HeatingCapacity>18767.0</HeatingCapacity>
-            <EnergyFactor>0.95</EnergyFactor>
+            <TankVolume>120.0</TankVolume>
+            <FractionDHWLoadServed>1.0</FractionDHWLoadServed>
+            <HeatingCapacity>40000.0</HeatingCapacity>
+            <EnergyFactor>0.59</EnergyFactor>
+            <RecoveryEfficiency>0.76</RecoveryEfficiency>
             <HotWaterTemperature>125.0</HotWaterTemperature>
           </WaterHeatingSystem>
           <HotWaterDistribution>

--- a/workflow/tests/base_results/sample_files.csv
+++ b/workflow/tests/base_results/sample_files.csv
@@ -27,7 +27,7 @@ base-bldgtype-multifamily-shared-chiller-only-water-loop-heat-pump.xml,78.18,7.8
 base-bldgtype-multifamily-shared-cooling-tower-only-water-loop-heat-pump.xml,66.51,7.88,5.57,10.46,12.54,3.52,11.47,4.5,2.96,9.68,0.0,13.08,0.23107
 base-bldgtype-multifamily-shared-generator.xml,69.22,7.88,5.57,10.46,12.54,3.52,11.47,3.06,2.83,9.68,0.0,13.08,0.23107
 base-bldgtype-multifamily-shared-ground-loop-ground-to-air-heat-pump.xml,66.04,7.88,5.57,10.46,6.03,3.52,11.47,3.1,2.04,9.68,0.0,13.08,0.23023
-base-bldgtype-multifamily-shared-laundry-room.xml,63.87,8.11,5.39,10.42,12.91,3.44,11.43,3.18,2.77,9.86,0.0,13.08,0.23155
+base-bldgtype-multifamily-shared-laundry-room.xml,60.47,7.34,5.86,10.49,11.69,3.63,18.26,3.26,2.74,12.53,0.0,13.08,0.23077
 base-bldgtype-multifamily-shared-mechvent-preconditioning.xml,73.94,7.75,5.66,10.46,12.34,3.55,11.47,0.61,3.51,9.67,0.0,14.58,0.23107
 base-bldgtype-multifamily-shared-mechvent.xml,66.03,7.75,5.66,10.46,12.34,3.55,11.47,2.88,2.84,9.69,0.0,14.58,0.23107
 base-bldgtype-multifamily-shared-pv.xml,5.75,7.88,5.57,10.46,12.54,3.52,11.47,3.06,2.83,9.68,0.0,13.08,0.23107

--- a/workflow/tests/base_results/sample_files_energystar.csv
+++ b/workflow/tests/base_results/sample_files_energystar.csv
@@ -28,7 +28,7 @@
 [SF_National_3.1] base-bldgtype-multifamily-shared-cooling-tower-only-water-loop-heat-pump.xml,72.0,1.0,72.0,65.0,65.0,PASS
 [SF_National_3.1] base-bldgtype-multifamily-shared-generator.xml,67.0,1.0,67.0,68.0,68.0,FAIL
 [SF_National_3.1] base-bldgtype-multifamily-shared-ground-loop-ground-to-air-heat-pump.xml,66.0,1.0,66.0,65.0,65.0,PASS
-[SF_National_3.1] base-bldgtype-multifamily-shared-laundry-room.xml,69.0,1.0,69.0,63.0,63.0,PASS
+[SF_National_3.1] base-bldgtype-multifamily-shared-laundry-room.xml,85.0,1.0,85.0,59.0,59.0,PASS
 [SF_National_3.1] base-bldgtype-multifamily-shared-mechvent-preconditioning.xml,67.0,1.0,67.0,73.0,73.0,FAIL
 [SF_National_3.1] base-bldgtype-multifamily-shared-mechvent.xml,67.0,1.0,67.0,65.0,65.0,PASS
 [SF_National_3.1] base-bldgtype-multifamily-shared-pv.xml,67.0,1.0,67.0,63.0,63.0,PASS
@@ -163,7 +163,7 @@
 [MF_National_1.1] base-bldgtype-multifamily-shared-cooling-tower-only-water-loop-heat-pump.xml,74.0,1.0,74.0,67.0,67.0,PASS
 [MF_National_1.1] base-bldgtype-multifamily-shared-generator.xml,69.0,1.0,69.0,69.0,69.0,PASS
 [MF_National_1.1] base-bldgtype-multifamily-shared-ground-loop-ground-to-air-heat-pump.xml,68.0,1.0,68.0,66.0,66.0,PASS
-[MF_National_1.1] base-bldgtype-multifamily-shared-laundry-room.xml,70.0,1.0,70.0,64.0,64.0,PASS
+[MF_National_1.1] base-bldgtype-multifamily-shared-laundry-room.xml,63.0,1.0,63.0,60.0,60.0,PASS
 [MF_National_1.1] base-bldgtype-multifamily-shared-mechvent-preconditioning.xml,69.0,1.0,69.0,74.0,74.0,FAIL
 [MF_National_1.1] base-bldgtype-multifamily-shared-mechvent.xml,69.0,1.0,69.0,66.0,66.0,PASS
 [MF_National_1.1] base-bldgtype-multifamily-shared-pv.xml,69.0,1.0,69.0,64.0,64.0,PASS


### PR DESCRIPTION
## Pull Request Description

Removes limitation that a shared water heater serving a shared laundry room can't also serve dwelling unit fixtures (i.e., `FractionDHWLoadServed` is no longer required to be zero).

## Checklist

Not all may apply:

- [x] OS-HPXML git subtree has been pulled
- [x] 301/ES rulesets and unit tests have been updated
- [x] 301validator.xml has been updated (reference EPvalidator.xml)
- [ ] Workflow tests have been updated
- [ ] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
