### PR TITLE
Allow more timeseries outputs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 __New Features__
 - Updates to OpenStudio 3.2.0/EnergyPlus 9.5.0.
+- Allows monthly or daily timeseries outputs instead of hourly.
 - Allows additional fuel types for generators.
 - Removes error-check for number of bedrooms based on conditioned floor area, per RESNET guidance.
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -30,13 +30,13 @@ This will generate output as shown below:
 
 .. image:: https://user-images.githubusercontent.com/5861765/82058115-8be1cc80-9681-11ea-9288-8b1eca5ec422.png
 
-You can also request generation of hourly output CSV files as part of the calculation by providing one or more ``--hourly`` flags.
+You can also request generation of timeseries output CSV files as part of the calculation by providing one or more timeseries flags (``--hourly``, ``--daily``, or ``--monthly``).
 
-To request all possible hourly outputs:
+For example, to request all possible hourly outputs:
 ``openstudio workflow/energy_rating_index.rb -x workflow/sample_files/base.xml --hourly ALL``
 
-Or one or more specific hourly output types can be requested, e.g.:
-``openstudio workflow/energy_rating_index.rb -x workflow/sample_files/base.xml --hourly fuels --hourly temperatures``
+Or for example, one or more specific monthly output types can be requested, e.g.:
+``openstudio workflow/energy_rating_index.rb -x workflow/sample_files/base.xml --monthly fuels --monthly temperatures``
 
 Run ``openstudio workflow/energy_rating_index.rb -h`` to see all available commands/arguments.
 

--- a/docs/source/workflow_outputs.rst
+++ b/docs/source/workflow_outputs.rst
@@ -225,11 +225,11 @@ Current annual hot water uses are listed below.
    Hot Water: Distribution Waste (gal) 
    =================================== =====
 
-ERI______Home_Hourly.csv
-~~~~~~~~~~~~~~~~~~~~~~~~
+Timeseries Outputs
+~~~~~~~~~~~~~~~~~~
 
-See the :ref:`running` section for requesting hourly outputs.
-When requested, a CSV file of hourly outputs is written for the Reference/Rated Homes (e.g., ``ERIReferenceHome_Hourly.csv`` for the Reference home).
+See the :ref:`running` section for requesting timeseries outputs.
+When requested, a CSV file of timeseries outputs is written for the Reference/Rated Homes (e.g., ``ERIReferenceHome_Hourly.csv``, ``ERIReferenceHome_Daily.csv``, or ``ERIReferenceHome_Monthly.csv`` for the Reference home).
 
 Depending on the outputs requested, CSV files may include:
 
@@ -247,7 +247,9 @@ Depending on the outputs requested, CSV files may include:
    Weather                             Weather file data including outdoor temperatures, relative humidity, wind speed, and solar.
    =================================== =====
 
-Timestamps in the output use the end-of-hour convention.
+Timeseries outputs can be one of the following frequencies: hourly, daily, or monthly.
+
+Timestamps in the output use the end-of-hour (or end-of-day for daily frequency, etc.) convention.
 Most outputs will be summed over the hour (e.g., energy) but some will be averaged over the hour (e.g., temperatures, airflows).
 
 See the `example ERIRatedHome_Hourly.csv <https://github.com/NREL/OpenStudio-ERI/tree/master/workflow/sample_results_eri/results/ERIRatedHome_Hourly.csv>`_.

--- a/rulesets/301EnergyRatingIndexRuleset/measure.rb
+++ b/rulesets/301EnergyRatingIndexRuleset/measure.rb
@@ -117,6 +117,7 @@ class EnergyRatingIndex301Measure < OpenStudio::Measure::ModelMeasure
     if not File.exist?(epw_path)
       fail "'#{epw_path}' could not be found."
     end
+
     cache_path = epw_path.gsub('.epw', '-cache.csv')
     if not File.exist?(cache_path)
       runner.registerError("'#{cache_path}' could not be found. Perhaps you need to run: openstudio energy_rating_index.rb --cache-weather")

--- a/rulesets/EnergyStarRuleset/measure.xml
+++ b/rulesets/EnergyStarRuleset/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>energy_star_measure</name>
   <uid>cd245684-9633-49dd-9eae-d5ccfa972bab</uid>
-  <version_id>66626e58-c56f-47d2-897f-f4c9bd8dc4dd</version_id>
-  <version_modified>20210519T143051Z</version_modified>
+  <version_id>0c9514d8-9bed-4634-add7-1789f5d98f11</version_id>
+  <version_modified>20210716T155139Z</version_modified>
   <xml_checksum>48718AE9</xml_checksum>
   <class_name>EnergyStarMeasure</class_name>
   <display_name>Apply ENERGY STAR Ruleset</display_name>
@@ -143,12 +143,6 @@
       <checksum>BBC0B2C6</checksum>
     </file>
     <file>
-      <filename>test_es_ventilation.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>26342B84</checksum>
-    </file>
-    <file>
       <filename>util.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -161,18 +155,6 @@
       <checksum>55764DAE</checksum>
     </file>
     <file>
-      <filename>test_es_enclosure.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>E5E0CF7A</checksum>
-    </file>
-    <file>
-      <filename>EnergyStarRuleset.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>E7B293C7</checksum>
-    </file>
-    <file>
       <filename>util.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -183,6 +165,24 @@
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
       <checksum>5F3803B5</checksum>
+    </file>
+    <file>
+      <filename>test_es_ventilation.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>95EC34B2</checksum>
+    </file>
+    <file>
+      <filename>test_es_enclosure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>F9F2179E</checksum>
+    </file>
+    <file>
+      <filename>EnergyStarRuleset.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>E1EABF62</checksum>
     </file>
   </files>
 </measure>

--- a/rulesets/EnergyStarRuleset/resources/EnergyStarRuleset.rb
+++ b/rulesets/EnergyStarRuleset/resources/EnergyStarRuleset.rb
@@ -684,6 +684,7 @@ class EnergyStarRuleset
     remaining_fracload_served_cooling = 1.0 # init
     orig_hpxml.hvac_systems.each do |h|
       next if h.distribution_system_idref.nil?
+
       if h.respond_to?(:fraction_heat_load_served) && h.fraction_heat_load_served.to_f > 0
         remaining_cfa_served_heating -= h.distribution_system.conditioned_floor_area_served.to_f
         remaining_fracload_served_heating -= h.fraction_heat_load_served
@@ -1300,6 +1301,7 @@ class EnergyStarRuleset
       elsif ['GU', 'MP'].include? @state_code
         return 0.401
       end
+
       fail "Unexpected state code: #{@state_code}."
     elsif [ESConstants.SFFloridaVer3_1].include? @program_version
       return 0.082
@@ -1775,11 +1777,13 @@ class EnergyStarRuleset
     # calculate total ceiling area and adiabatic ceiling area
     orig_hpxml.frame_floors.each do |orig_frame_floor|
       next unless orig_frame_floor.is_ceiling
+
       total_ceiling_area += orig_frame_floor.area
 
       ceiling_exterior_boundary << orig_frame_floor.exterior_adjacent_to unless ceiling_exterior_boundary.include?(orig_frame_floor.exterior_adjacent_to)
 
       next unless [HPXML::LocationLivingSpace, HPXML::LocationOtherHousingUnit].include? orig_frame_floor.exterior_adjacent_to
+
       adiabatic_ceiling_area += orig_frame_floor.area
     end
 

--- a/rulesets/EnergyStarRuleset/tests/test_es_enclosure.rb
+++ b/rulesets/EnergyStarRuleset/tests/test_es_enclosure.rb
@@ -506,6 +506,7 @@ class EnergyStarEnclosureTest < MiniTest::Test
       hpxml = HPXML.new(hpxml_path: @tmp_hpxml_path)
       hpxml.windows.each do |window|
         next unless window.azimuth == 0
+
         window.performance_class = HPXML::WindowClassArchitectural
         window.fraction_operable = 0.0
       end
@@ -527,6 +528,7 @@ class EnergyStarEnclosureTest < MiniTest::Test
       hpxml = HPXML.new(hpxml_path: @tmp_hpxml_path)
       hpxml.windows.each do |window|
         next unless window.azimuth == 180
+
         window.performance_class = HPXML::WindowClassArchitectural
         window.fraction_operable = 1.0
       end
@@ -561,7 +563,7 @@ class EnergyStarEnclosureTest < MiniTest::Test
       hpxml.climate_and_risk_zones.weather_station_wmo = 722020
       XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
       hpxml = _test_measure()
-      _check_windows(hpxml, frac_operable:  0.67,
+      _check_windows(hpxml, frac_operable: 0.67,
                             values_by_azimuth: { 0 => { area: areas[0], ufactor: ufactor, shgc: shgc },
                                                  180 => { area: areas[1], ufactor: ufactor, shgc: shgc },
                                                  90 => { area: areas[2], ufactor: ufactor, shgc: shgc },

--- a/rulesets/EnergyStarRuleset/tests/test_es_ventilation.rb
+++ b/rulesets/EnergyStarRuleset/tests/test_es_ventilation.rb
@@ -91,6 +91,7 @@ class EnergyStarVentTest < MiniTest::Test
   def test_mech_vent_attached_or_multifamily_location_miami_fl
     ESConstants.AllVersions.each do |es_version|
       next unless ESConstants.NationalVersions.include?(es_version)
+
       _convert_to_es('base-bldgtype-multifamily.xml', es_version)
       hpxml = HPXML.new(hpxml_path: @tmp_hpxml_path)
       hpxml.climate_and_risk_zones.iecc_zone = '1A'

--- a/tasks.rb
+++ b/tasks.rb
@@ -1143,6 +1143,7 @@ def set_hpxml_heating_systems(hpxml_file, hpxml)
     elsif hpxml_file.include?('CZ6')
       afue = 0.95
     end
+
     hpxml.heating_systems.clear
     hpxml.heating_systems.add(id: 'HeatingSystem',
                               distribution_system_idref: 'HVACDistribution',
@@ -1257,6 +1258,7 @@ def set_hpxml_cooling_systems(hpxml_file, hpxml)
     elsif hpxml_file.include?('CZ2')
       seer = 14.5
     end
+
     hpxml.cooling_systems.clear
     hpxml.cooling_systems.add(id: 'CoolingSystem',
                               distribution_system_idref: 'HVACDistribution',
@@ -1364,6 +1366,7 @@ def set_hpxml_heat_pumps(hpxml_file, hpxml)
       hspf = 9.5
       seer = 14.5
     end
+
     hpxml.heat_pumps.clear
     hpxml.heat_pumps.add(id: 'HeatPump',
                          distribution_system_idref: 'HVACDistribution',

--- a/workflow/design.rb
+++ b/workflow/design.rb
@@ -12,7 +12,7 @@ def get_output_filename(run, file_suffix = '.xml')
   return File.join(run[3], run[0].gsub(' ', '') + file_suffix)
 end
 
-def run_design(basedir, run, hpxml, debug, hourly_outputs, add_comp_loads)
+def run_design(basedir, run, hpxml, debug, timeseries_output_freq, timeseries_outputs, add_comp_loads)
   measures_dir = File.join(File.dirname(__FILE__), '..')
   designdir = get_design_dir(run)
   output_hpxml = get_output_filename(run)
@@ -33,23 +33,23 @@ def run_design(basedir, run, hpxml, debug, hourly_outputs, add_comp_loads)
   args['hpxml_path'] = output_hpxml
   args['output_dir'] = File.absolute_path(designdir)
   args['debug'] = debug
-  args['add_component_loads'] = (add_comp_loads || hourly_outputs.include?('componentloads'))
+  args['add_component_loads'] = (add_comp_loads || timeseries_outputs.include?('componentloads'))
   args['skip_validation'] = !debug
   update_args_hash(measures, measure_subdir, args)
 
   # Add reporting measure to workflow
   measure_subdir = 'hpxml-measures/SimulationOutputReport'
   args = {}
-  args['timeseries_frequency'] = 'hourly'
-  args['include_timeseries_fuel_consumptions'] = hourly_outputs.include? 'fuels'
-  args['include_timeseries_end_use_consumptions'] = hourly_outputs.include? 'enduses'
-  args['include_timeseries_hot_water_uses'] = hourly_outputs.include? 'hotwater'
-  args['include_timeseries_total_loads'] = hourly_outputs.include? 'loads'
-  args['include_timeseries_component_loads'] = hourly_outputs.include? 'componentloads'
-  args['include_timeseries_unmet_loads'] = hourly_outputs.include? 'unmetloads'
-  args['include_timeseries_zone_temperatures'] = hourly_outputs.include? 'temperatures'
-  args['include_timeseries_airflows'] = hourly_outputs.include? 'airflows'
-  args['include_timeseries_weather'] = hourly_outputs.include? 'weather'
+  args['timeseries_frequency'] = timeseries_output_freq
+  args['include_timeseries_fuel_consumptions'] = timeseries_outputs.include? 'fuels'
+  args['include_timeseries_end_use_consumptions'] = timeseries_outputs.include? 'enduses'
+  args['include_timeseries_hot_water_uses'] = timeseries_outputs.include? 'hotwater'
+  args['include_timeseries_total_loads'] = timeseries_outputs.include? 'loads'
+  args['include_timeseries_component_loads'] = timeseries_outputs.include? 'componentloads'
+  args['include_timeseries_unmet_loads'] = timeseries_outputs.include? 'unmetloads'
+  args['include_timeseries_zone_temperatures'] = timeseries_outputs.include? 'temperatures'
+  args['include_timeseries_airflows'] = timeseries_outputs.include? 'airflows'
+  args['include_timeseries_weather'] = timeseries_outputs.include? 'weather'
   update_args_hash(measures, measure_subdir, args)
 
   print_prefix = "[#{run[0]}] "
@@ -59,12 +59,13 @@ def run_design(basedir, run, hpxml, debug, hourly_outputs, add_comp_loads)
   return output_hpxml
 end
 
-if ARGV.size == 6
+if ARGV.size == 7
   basedir = ARGV[0]
   run = ARGV[1].split('|').map { |x| (x.length == 0 ? nil : x) }
   hpxml = ARGV[2]
   debug = (ARGV[3].downcase.to_s == 'true')
-  hourly_outputs = ARGV[4].split('|')
-  add_comp_loads = (ARGV[5].downcase.to_s == 'true')
-  run_design(basedir, run, hpxml, debug, hourly_outputs, add_comp_loads)
+  timeseries_output_freq = ARGV[4]
+  timeseries_outputs = ARGV[5].split('|')
+  add_comp_loads = (ARGV[6].downcase.to_s == 'true')
+  run_design(basedir, run, hpxml, debug, timeseries_output_freq, timeseries_outputs, add_comp_loads)
 end

--- a/workflow/energy_rating_index.rb
+++ b/workflow/energy_rating_index.rb
@@ -31,6 +31,7 @@ def get_eri_version(hpxml_path)
   if (eri_version != 'latest') && (not Constants.ERIVersions.include?(eri_version))
     fail "Unexpected ERICalculation/Version: '#{eri_version}'."
   end
+
   return eri_version
 end
 

--- a/workflow/energy_star.rb
+++ b/workflow/energy_star.rb
@@ -33,6 +33,7 @@ def get_es_version(hpxml_path)
   if not ESConstants.AllVersions.include?(es_version)
     fail "Unexpected EnergyStarCalculation/Version: '#{es_version}'."
   end
+
   return es_version
 end
 

--- a/workflow/util.rb
+++ b/workflow/util.rb
@@ -14,7 +14,7 @@ def setup_resultsdir(options)
 end
 
 def process_arguments(calling_rb, args, basedir)
-  hourly_types = ['ALL', 'fuels', 'enduses', 'hotwater', 'loads', 'componentloads', 'unmetloads', 'temperatures', 'airflows', 'weather']
+  timeseries_types = ['ALL', 'fuels', 'enduses', 'hotwater', 'loads', 'componentloads', 'unmetloads', 'temperatures', 'airflows', 'weather']
 
   options = {}
   OptionParser.new do |opts|
@@ -29,8 +29,18 @@ def process_arguments(calling_rb, args, basedir)
     end
 
     options[:hourly_outputs] = []
-    opts.on('--hourly TYPE', hourly_types, "Request hourly output type (#{hourly_types[0..4].join(', ')},", "#{hourly_types[5..-1].join(', ')}); can be called multiple times") do |t|
+    opts.on('--hourly TYPE', timeseries_types, "Request hourly output type (#{timeseries_types[0..4].join(', ')},", "#{timeseries_types[5..-1].join(', ')}); can be called multiple times") do |t|
       options[:hourly_outputs] << t
+    end
+
+    options[:daily_outputs] = []
+    opts.on('--daily TYPE', timeseries_types, "Request daily output type (#{timeseries_types[0..4].join(', ')},", "#{timeseries_types[5..-1].join(', ')}); can be called multiple times") do |t|
+      options[:daily_outputs] << t
+    end
+
+    options[:monthly_outputs] = []
+    opts.on('--monthly TYPE', timeseries_types, "Request monthly output type (#{timeseries_types[0..4].join(', ')},", "#{timeseries_types[5..-1].join(', ')}); can be called multiple times") do |t|
+      options[:monthly_outputs] << t
     end
 
     opts.on('-w', '--download-weather', 'Downloads all US TMY3 weather files') do |t|
@@ -62,10 +72,32 @@ def process_arguments(calling_rb, args, basedir)
     end
   end.parse!(args)
 
-  if options[:hourly_outputs].include? 'ALL'
-    options[:hourly_outputs] = hourly_types[1..-1]
+  options[:timeseries_output_freq] = 'none'
+  options[:timeseries_outputs] = []
+  n_freq = 0
+  if not options[:hourly_outputs].empty?
+    n_freq += 1
+    options[:timeseries_output_freq] = 'hourly'
+    options[:timeseries_outputs] = options[:hourly_outputs]
+  end
+  if not options[:daily_outputs].empty?
+    n_freq += 1
+    options[:timeseries_output_freq] = 'daily'
+    options[:timeseries_outputs] = options[:daily_outputs]
+  end
+  if not options[:monthly_outputs].empty?
+    n_freq += 1
+    options[:timeseries_output_freq] = 'monthly'
+    options[:timeseries_outputs] = options[:monthly_outputs]
   end
 
+  if n_freq > 1
+    fail 'Multiple timeseries frequencies (hourly, daily, monthly) are not supported.'
+  end
+
+  if options[:timeseries_outputs].include? 'ALL'
+    options[:timeseries_outputs] = timeseries_types[1..-1]
+  end
   if options[:version]
     workflow_version = '1.2.0'
     puts "OpenStudio-ERI v#{workflow_version}"
@@ -114,7 +146,9 @@ def run_simulations(runs, options, basedir)
     end
 
     Parallel.map(runs, in_processes: runs.size) do |run|
-      output_hpxml_path, designdir = run_design_direct(basedir, run, options[:hpxml], options[:debug], options[:hourly_outputs], options[:add_comp_loads])
+      output_hpxml_path, designdir = run_design_direct(basedir, run, options[:hpxml], options[:debug],
+                                                       options[:timeseries_output_freq], options[:timeseries_outputs],
+                                                       options[:add_comp_loads])
       kill unless File.exist? File.join(designdir, 'eplusout.end')
     end
 
@@ -134,7 +168,9 @@ def run_simulations(runs, options, basedir)
 
     pids = {}
     Parallel.map(runs, in_threads: runs.size) do |run|
-      output_hpxml_path, designdir, pids[run] = run_design_spawn(basedir, run, options[:hpxml], options[:debug], options[:hourly_outputs], options[:add_comp_loads])
+      output_hpxml_path, designdir, pids[run] = run_design_spawn(basedir, run, options[:hpxml], options[:debug],
+                                                                 options[:timeseries_output_freq], options[:timeseries_outputs],
+                                                                 options[:add_comp_loads])
       Process.wait pids[run]
       if not File.exist? File.join(designdir, 'eplusout.end')
         kill(pids)
@@ -145,18 +181,18 @@ def run_simulations(runs, options, basedir)
   end
 end
 
-def run_design_direct(basedir, run, hpxml, debug, hourly_outputs, add_comp_loads)
+def run_design_direct(basedir, run, hpxml, debug, timeseries_output_freq, timeseries_outputs, add_comp_loads)
   # Calls design.rb methods directly. Should only be called from a forked
   # process. This is the fastest approach.
   designdir = get_design_dir(run)
-  hourly_outputs = hourly_outputs_for_run(run, hourly_outputs)
+  timeseries_output_freq, timeseries_outputs = timeseries_output_for_run(run, timeseries_output_freq, timeseries_outputs)
 
-  output_hpxml_path = run_design(basedir, run, hpxml, debug, hourly_outputs, add_comp_loads)
+  output_hpxml_path = run_design(basedir, run, hpxml, debug, timeseries_output_freq, timeseries_outputs, add_comp_loads)
 
   return output_hpxml_path, designdir
 end
 
-def run_design_spawn(basedir, run, hpxml, debug, hourly_outputs, add_comp_loads)
+def run_design_spawn(basedir, run, hpxml, debug, timeseries_output_freq, timeseries_outputs, add_comp_loads)
   # Calls design.rb in a new spawned process in order to utilize multiple
   # processes. Not as efficient as calling design.rb methods directly in
   # forked processes for a couple reasons:
@@ -164,20 +200,20 @@ def run_design_spawn(basedir, run, hpxml, debug, hourly_outputs, add_comp_loads)
   # 2. There is overhead to spawning processes vs using forked processes
   designdir = get_design_dir(run)
   output_hpxml_path = get_output_filename(run)
-  hourly_outputs = hourly_outputs_for_run(run, hourly_outputs)
+  timeseries_output_freq, timeseries_outputs = timeseries_output_for_run(run, timeseries_output_freq, timeseries_outputs)
 
   cli_path = OpenStudio.getOpenStudioCLI
-  pid = Process.spawn("\"#{cli_path}\" \"#{File.join(File.dirname(__FILE__), 'design.rb')}\" \"#{basedir}\" \"#{run.join('|')}\" \"#{hpxml}\" #{debug} \"#{hourly_outputs.join('|')}\" \"#{add_comp_loads}\"")
+  pid = Process.spawn("\"#{cli_path}\" \"#{File.join(File.dirname(__FILE__), 'design.rb')}\" \"#{basedir}\" \"#{run.join('|')}\" \"#{hpxml}\" #{debug} \"#{timeseries_output_freq}\" \"#{timeseries_outputs.join('|')}\" \"#{add_comp_loads}\"")
 
   return output_hpxml_path, designdir, pid
 end
 
-def hourly_outputs_for_run(run, hourly_outputs)
+def timeseries_output_for_run(run, timeseries_output_freq, timeseries_outputs)
   if [Constants.CalcTypeERIRatedHome, Constants.CalcTypeERIReferenceHome].include? run[0]
-    return hourly_outputs
+    return timeseries_output_freq, timeseries_outputs
   end
 
-  return []
+  return 'none', []
 end
 
 def retrieve_outputs(runs, options)
@@ -232,6 +268,7 @@ def _calculate_eri(rated_output, ref_output, results_iad: nil, opp_reduction_lim
            HPXML::FuelTypeWoodPellets].include? fuel
       return 1.0943, 0.4030
     end
+
     fail 'Could not identify EEC coefficients for heating system.'
   end
 
@@ -249,6 +286,7 @@ def _calculate_eri(rated_output, ref_output, results_iad: nil, opp_reduction_lim
            HPXML::FuelTypeWoodPellets].include? fuel
       return 1.1877, 1.0130
     end
+
     fail 'Could not identify EEC coefficients for water heating system.'
   end
 


### PR DESCRIPTION
## Pull Request Description

Allows monthly or daily outputs instead of hourly, if desired. Closes #555.

## Checklist

Not all may apply:

- [ ] OS-HPXML git subtree has been pulled
- [ ] 301/ES rulesets and unit tests have been updated
- [ ] 301validator.xml has been updated (reference EPvalidator.xml)
- [x] Workflow tests have been updated
- [x] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
