### PR TITLE
Optional `AirInfiltrationMeasurement/InfiltrationHeight` input

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 __New Features__
 - **Breaking change**: Deprecates duct leakage to outside exemptions; software tools must provide duct leakage to outside or DSE. `SoftwareInfo/extension/ERICalculation/Version` enumerations "2014ADEGL", "2014ADEG", "2014ADE" are replaced by "2014AEG" and "2014AE".
+- Allows `AirInfiltrationMeasurement/InfiltrationHeight` as an optional input; if not provided, it is inferred from other inputs as before. 
 
 ## OpenStudio-ERI v1.3.0
 

--- a/docs/source/workflow_inputs.rst
+++ b/docs/source/workflow_inputs.rst
@@ -193,19 +193,22 @@ HPXML Air Infiltration
 
 Building air leakage is entered in ``/HPXML/Building/BuildingDetails/Enclosure/AirInfiltration/AirInfiltrationMeasurement``.
 
-  ====================================  ======  =====  ===========  =========  =======  ===============================================
-  Element                               Type    Units  Constraints  Required   Default  Notes
-  ====================================  ======  =====  ===========  =========  =======  ===============================================
-  ``SystemIdentifier``                  id                          Yes                 Unique identifier
-  ``BuildingAirLeakage/UnitofMeasure``  string         See [#]_     Yes                 Units for air leakage
-  ``HousePressure``                     double  Pa     > 0          See [#]_            House pressure with respect to outside [#]_
-  ``BuildingAirLeakage/AirLeakage``     double         > 0          Yes                 Value for air leakage
-  ``InfiltrationVolume``                double  ft3    > 0          Yes                 Volume associated with infiltration measurement
-  ====================================  ======  =====  ===========  =========  =======  ===============================================
+  ====================================  ======  =====  ===========  =========  ========  ===============================================
+  Element                               Type    Units  Constraints  Required   Default   Notes
+  ====================================  ======  =====  ===========  =========  ========  ===============================================
+  ``SystemIdentifier``                  id                          Yes                  Unique identifier
+  ``BuildingAirLeakage/UnitofMeasure``  string         See [#]_     Yes                  Units for air leakage
+  ``HousePressure``                     double  Pa     > 0          See [#]_             House pressure with respect to outside [#]_
+  ``BuildingAirLeakage/AirLeakage``     double         > 0          Yes                  Value for air leakage
+  ``InfiltrationVolume``                double  ft3    > 0          Yes                  Volume associated with infiltration measurement
+  ``InfiltrationHeight``                double  ft     > 0          No         See [#]_  Height associated with infiltration measurement [#]_
+  ====================================  ======  =====  ===========  =========  ========  ===============================================
 
   .. [#] UnitofMeasure choices are "ACH" (air changes per hour at user-specified pressure), "CFM" (cubic feet per minute at user-specified pressure), or "ACHnatural" (natural air changes per hour).
   .. [#] HousePressure only required if BuildingAirLeakage/UnitofMeasure is not "ACHnatural".
   .. [#] HousePressure typical value is 50 Pa.
+  .. [#] If InfiltrationHeight not provided, it is inferred from other inputs (e.g., conditioned floor area, number of conditioned floors above-grade, above-grade foundation wall height, etc.).
+  .. [#] InfiltrationHeight is defined as the vertical distance between the lowest and highest above-grade points within the pressure boundary, per ASHRAE 62.2.
 
 HPXML Attics
 ************

--- a/rulesets/301EnergyRatingIndexRuleset/resources/301.rb
+++ b/rulesets/301EnergyRatingIndexRuleset/resources/301.rb
@@ -301,7 +301,10 @@ class EnergyRatingIndex301Ruleset
   end
 
   def self.set_enclosure_air_infiltration_reference(orig_hpxml, new_hpxml)
-    @infil_height = new_hpxml.inferred_infiltration_height(@infil_volume)
+    @infil_height = get_infiltration_height(orig_hpxml)
+    if @infil_height.nil?
+      @infil_height = new_hpxml.inferred_infiltration_height(@infil_volume)
+    end
     @infil_a_ext = calc_mech_vent_Aext_ratio(new_hpxml)
 
     sla = 0.00036
@@ -316,7 +319,10 @@ class EnergyRatingIndex301Ruleset
   end
 
   def self.set_enclosure_air_infiltration_rated(orig_hpxml, new_hpxml)
-    @infil_height = new_hpxml.inferred_infiltration_height(@infil_volume)
+    @infil_height = get_infiltration_height(orig_hpxml)
+    if @infil_height.nil?
+      @infil_height = new_hpxml.inferred_infiltration_height(@infil_volume)
+    end
     @infil_a_ext = calc_mech_vent_Aext_ratio(new_hpxml)
 
     ach50 = calc_rated_home_infiltration_ach50(orig_hpxml)
@@ -2629,6 +2635,15 @@ class EnergyRatingIndex301Ruleset
 
       return air_infiltration_measurement.infiltration_volume
     end
+  end
+
+  def self.get_infiltration_height(hpxml)
+    hpxml.air_infiltration_measurements.each do |air_infiltration_measurement|
+      next if air_infiltration_measurement.infiltration_height.nil?
+
+      return air_infiltration_measurement.infiltration_height
+    end
+    return
   end
 
   def self.get_reference_water_heater_ef_and_re(wh_fuel_type, wh_tank_vol)

--- a/rulesets/301EnergyRatingIndexRuleset/resources/301validator.xml
+++ b/rulesets/301EnergyRatingIndexRuleset/resources/301validator.xml
@@ -167,6 +167,8 @@
       <sch:assert role='ERROR' test='count(h:HousePressure[number(text())=50]) = 1'>Expected 1 element(s) for xpath: HousePressure[number(text())=50]</sch:assert>
       <sch:assert role='ERROR' test='count(h:BuildingAirLeakage/h:AirLeakage) = 1'>Expected 1 element(s) for xpath: BuildingAirLeakage/AirLeakage</sch:assert>
       <sch:assert role='ERROR' test='count(h:InfiltrationVolume) = 1'>Expected 1 element(s) for xpath: InfiltrationVolume</sch:assert>
+      <sch:assert role='ERROR' test='count(h:InfiltrationHeight) &lt;= 1'>Expected 0 or 1 element(s) for xpath: InfiltrationHeight</sch:assert>
+      <sch:assert role='ERROR' test='number(h:InfiltrationHeight) &gt; 0 or not(h:InfiltrationHeight)'>Expected InfiltrationHeight to be greater than 0</sch:assert>
     </sch:rule>
   </sch:pattern>
 
@@ -177,6 +179,8 @@
       <sch:assert role='ERROR' test='count(h:HousePressure) = 0'>Expected 0 element(s) for xpath: HousePressure</sch:assert>
       <sch:assert role='ERROR' test='count(h:BuildingAirLeakage/h:AirLeakage) = 1'>Expected 1 element(s) for xpath: BuildingAirLeakage/AirLeakage</sch:assert>
       <sch:assert role='ERROR' test='count(h:InfiltrationVolume) = 1'>Expected 1 element(s) for xpath: InfiltrationVolume</sch:assert>
+      <sch:assert role='ERROR' test='count(h:InfiltrationHeight) &lt;= 1'>Expected 0 or 1 element(s) for xpath: InfiltrationHeight</sch:assert>
+      <sch:assert role='ERROR' test='number(h:InfiltrationHeight) &gt; 0 or not(h:InfiltrationHeight)'>Expected InfiltrationHeight to be greater than 0</sch:assert>
     </sch:rule>
   </sch:pattern>
 

--- a/rulesets/301EnergyRatingIndexRuleset/tests/test_enclosure.rb
+++ b/rulesets/301EnergyRatingIndexRuleset/tests/test_enclosure.rb
@@ -22,25 +22,43 @@ class ERIEnclosureTest < MiniTest::Test
     hpxml_name = 'base.xml'
 
     hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIRatedHome)
-    _check_infiltration(hpxml, ach50: 9.3)
+    _check_infiltration(hpxml, ach50: 9.3, height: 9.75, volume: 21600.0)
     hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIReferenceHome)
-    _check_infiltration(hpxml, ach50: 7.09)
+    _check_infiltration(hpxml, ach50: 7.09, height: 9.75, volume: 21600.0)
     hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentDesign)
-    _check_infiltration(hpxml, ach50: 3.0)
+    _check_infiltration(hpxml, ach50: 3.0, height: 17.0, volume: 20400.0)
     hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentReferenceHome)
-    _check_infiltration(hpxml, ach50: 6.67)
+    _check_infiltration(hpxml, ach50: 6.67, height: 17.0, volume: 20400.0)
 
     # Test w/ mech vent
     hpxml_name = 'base-mechvent-exhaust.xml'
 
     hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIRatedHome)
-    _check_infiltration(hpxml, ach50: 3.0)
+    _check_infiltration(hpxml, ach50: 3.0, height: 9.75, volume: 21600.0)
     hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIReferenceHome)
-    _check_infiltration(hpxml, ach50: 7.09)
+    _check_infiltration(hpxml, ach50: 7.09, height: 9.75, volume: 21600.0)
     hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentDesign)
-    _check_infiltration(hpxml, ach50: 3.0)
+    _check_infiltration(hpxml, ach50: 3.0, height: 17.0, volume: 20400.0)
     hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentReferenceHome)
-    _check_infiltration(hpxml, ach50: 6.67)
+    _check_infiltration(hpxml, ach50: 6.67, height: 17.0, volume: 20400.0)
+
+    # Test w/ InfiltrationHeight input provided
+    hpxml_name = 'base-mechvent-exhaust.xml'
+    hpxml = HPXML.new(hpxml_path: File.join(@root_path, 'workflow', 'sample_files', hpxml_name))
+    hpxml.air_infiltration_measurements.each do |m|
+      m.infiltration_height = 10.5
+    end
+    hpxml_name = File.basename(@tmp_hpxml_path)
+    XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
+
+    hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIRatedHome)
+    _check_infiltration(hpxml, ach50: 3.0, height: 10.5, volume: 21600.0)
+    hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIReferenceHome)
+    _check_infiltration(hpxml, ach50: 7.09, height: 10.5, volume: 21600.0)
+    hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentDesign)
+    _check_infiltration(hpxml, ach50: 3.0, height: 17.0, volume: 20400.0)
+    hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentReferenceHome)
+    _check_infiltration(hpxml, ach50: 6.67, height: 17.0, volume: 20400.0)
 
     # Test w/ unmeasured mech vent
     # Create derivative file for testing
@@ -55,13 +73,13 @@ class ERIEnclosureTest < MiniTest::Test
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
 
     hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIRatedHome)
-    _check_infiltration(hpxml, ach50: 9.3) # 0.3 nACH
+    _check_infiltration(hpxml, ach50: 9.3, height: 9.75, volume: 21600.0) # 0.3 nACH
     hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIReferenceHome)
-    _check_infiltration(hpxml, ach50: 7.09)
+    _check_infiltration(hpxml, ach50: 7.09, height: 9.75, volume: 21600.0)
     hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentDesign)
-    _check_infiltration(hpxml, ach50: 3.0)
+    _check_infiltration(hpxml, ach50: 3.0, height: 17.0, volume: 20400.0)
     hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentReferenceHome)
-    _check_infiltration(hpxml, ach50: 6.67)
+    _check_infiltration(hpxml, ach50: 6.67, height: 17.0, volume: 20400.0)
 
     # Test attached dwelling where airtightness test results <= 0.30 cfm50 per ft2 of Compartmentalization Boundary
     # Create derivative file for testing
@@ -78,13 +96,13 @@ class ERIEnclosureTest < MiniTest::Test
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
 
     hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIRatedHome)
-    _check_infiltration(hpxml, ach50: 0.74)
+    _check_infiltration(hpxml, ach50: 0.74, height: 8.0, volume: 7200.0)
     hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIReferenceHome)
-    _check_infiltration(hpxml, ach50: 7.09)
+    _check_infiltration(hpxml, ach50: 7.09, height: 8.0, volume: 7200.0)
     hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentDesign)
-    _check_infiltration(hpxml, ach50: 3.0)
+    _check_infiltration(hpxml, ach50: 3.0, height: 17.0, volume: 20400.0)
     hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentReferenceHome)
-    _check_infiltration(hpxml, ach50: 6.67)
+    _check_infiltration(hpxml, ach50: 6.67, height: 17.0, volume: 20400.0)
 
     # Test attached dwelling where Aext < 0.5 and exhaust mech vent
     # Create derivative file for testing
@@ -101,16 +119,13 @@ class ERIEnclosureTest < MiniTest::Test
     XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
 
     hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIRatedHome)
-    _check_infiltration(hpxml, ach50: 10.1)
+    _check_infiltration(hpxml, ach50: 10.1, height: 8.0, volume: 7200.0)
     hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIReferenceHome)
-    _check_infiltration(hpxml, ach50: 7.09)
+    _check_infiltration(hpxml, ach50: 7.09, height: 8.0, volume: 7200.0)
     hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentDesign)
-    _check_infiltration(hpxml, ach50: 3.0)
+    _check_infiltration(hpxml, ach50: 3.0, height: 17.0, volume: 20400.0)
     hpxml = _test_measure(hpxml_name, Constants.CalcTypeERIIndexAdjustmentReferenceHome)
-    _check_infiltration(hpxml, ach50: 6.67)
-
-    # TODO: Add 301-2014 tests
-    # TODO: Add tests for new 301-2019 space types HPXML file
+    _check_infiltration(hpxml, ach50: 6.67, height: 17.0, volume: 20400.0)
   end
 
   def test_enclosure_roofs
@@ -894,12 +909,14 @@ class ERIEnclosureTest < MiniTest::Test
     return measure.new_hpxml
   end
 
-  def _check_infiltration(hpxml, ach50:)
+  def _check_infiltration(hpxml, ach50:, height:, volume:)
     assert_equal(1, hpxml.air_infiltration_measurements.size)
     air_infiltration_measurement = hpxml.air_infiltration_measurements[0]
     assert_equal(HPXML::UnitsACH, air_infiltration_measurement.unit_of_measure)
     assert_equal(50.0, air_infiltration_measurement.house_pressure)
     assert_in_epsilon(ach50, air_infiltration_measurement.air_leakage, 0.01)
+    assert_in_epsilon(height, air_infiltration_measurement.infiltration_height, 0.01)
+    assert_in_epsilon(volume, air_infiltration_measurement.infiltration_volume, 0.01)
   end
 
   def _check_roofs(hpxml, area: nil, rvalue: nil, sabs: nil, emit: nil, rb_grade: nil)

--- a/rulesets/EnergyStarRuleset/measure.xml
+++ b/rulesets/EnergyStarRuleset/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>energy_star_measure</name>
   <uid>cd245684-9633-49dd-9eae-d5ccfa972bab</uid>
-  <version_id>67445f69-16cd-46e8-8121-d5cd93bca090</version_id>
-  <version_modified>20211215T180021Z</version_modified>
+  <version_id>fcad66ce-e8b2-4d0d-8d0e-ad32725f1ed5</version_id>
+  <version_modified>20211216T171729Z</version_modified>
   <xml_checksum>48718AE9</xml_checksum>
   <class_name>EnergyStarMeasure</class_name>
   <display_name>Apply ENERGY STAR Ruleset</display_name>
@@ -168,12 +168,6 @@
       <checksum>99A24B00</checksum>
     </file>
     <file>
-      <filename>EnergyStarRuleset.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>AECBB019</checksum>
-    </file>
-    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.1.1</identifier>
@@ -183,6 +177,12 @@
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
       <checksum>D729FDF6</checksum>
+    </file>
+    <file>
+      <filename>EnergyStarRuleset.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>A32548A5</checksum>
     </file>
   </files>
 </measure>

--- a/rulesets/EnergyStarRuleset/resources/EnergyStarRuleset.rb
+++ b/rulesets/EnergyStarRuleset/resources/EnergyStarRuleset.rb
@@ -110,6 +110,7 @@ class EnergyStarRuleset
     @ncfl_ag = orig_hpxml.building_construction.number_of_conditioned_floors_above_grade
     @cvolume = orig_hpxml.building_construction.conditioned_building_volume
     @infilvolume = get_infiltration_volume(orig_hpxml)
+    @infilheight = get_infiltration_height(orig_hpxml)
     @has_cond_bsmnt = orig_hpxml.has_location(HPXML::LocationBasementConditioned)
     @has_uncond_bsmnt = orig_hpxml.has_location(HPXML::LocationBasementUnconditioned)
     @has_crawlspace = (orig_hpxml.has_location(HPXML::LocationCrawlspaceVented) || orig_hpxml.has_location(HPXML::LocationCrawlspaceUnvented))
@@ -145,7 +146,8 @@ class EnergyStarRuleset
                                                 house_pressure: 50,
                                                 unit_of_measure: infil_unit_of_measure,
                                                 air_leakage: infil_air_leakage.round(1),
-                                                infiltration_volume: @infilvolume)
+                                                infiltration_volume: @infilvolume,
+                                                infiltration_height: @infilheight)
   end
 
   def self.set_enclosure_attics_reference(orig_hpxml, new_hpxml)
@@ -1099,6 +1101,15 @@ class EnergyStarRuleset
 
       return air_infiltration_measurement.infiltration_volume
     end
+  end
+
+  def self.get_infiltration_height(hpxml)
+    hpxml.air_infiltration_measurements.each do |air_infiltration_measurement|
+      next if air_infiltration_measurement.infiltration_height.nil?
+
+      return air_infiltration_measurement.infiltration_height
+    end
+    return
   end
 
   def self.get_hvac_configurations(orig_hpxml)


### PR DESCRIPTION
## Pull Request Description

Allows optional `AirInfiltrationMeasurement/InfiltrationHeight` input. InfiltrationHeight is defined as the vertical distance between the lowest and highest above-grade points within the pressure boundary, per ASHRAE 62.2. If InfiltrationHeight is not provided, it is inferred from other inputs (e.g., conditioned floor area, number of conditioned floors above-grade, above-grade foundation wall height, etc.) as before.

## Checklist

Not all may apply:

- [x] ~OS-HPXML git subtree has been pulled~
- [x] 301/ES rulesets and unit tests have been updated
- [x] 301validator.xml has been updated (reference EPvalidator.xml)
- [x] ~Workflow tests have been updated~
- [x] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
