### PR TITLE
Adds `--skip-simulation` flag

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ __New Features__
 - Allows modeling an electric storage battery.
 - Allows `AirInfiltrationMeasurement/InfiltrationHeight` as an optional input; if not provided, it is inferred from other inputs as before. 
 - Allows duct leakage to be entered in units of CFM50 as an alternative to CFM25.
+- Adds a `--skip-simulation` flag that can be used to just generate the ERI Rated/Reference Home HPXMLs and then stop.
 
 __Bugfixes__
 - Adds more stringent limits for `AirflowDefectRatio` (now allows values from 1/10th to 10x the design value).

--- a/docs/source/usage_instructions.rst
+++ b/docs/source/usage_instructions.rst
@@ -36,6 +36,9 @@ For example, to request all possible hourly outputs:
 Or for example, one or more specific monthly output types can be requested, e.g.:
 ``openstudio workflow/energy_rating_index.rb -x workflow/sample_files/base.xml --monthly fuels --monthly temperatures``
 
+You can also skip simulations (i.e., just generate the ERI Reference/Rated Home HPXMLs) by using, e.g.:
+``openstudio workflow/energy_rating_index.rb -x workflow/sample_files/base.xml --skip-simulation``
+
 Run ``openstudio workflow/energy_rating_index.rb -h`` to see all available commands/arguments.
 
 Running ENERGY STAR

--- a/workflow/design.rb
+++ b/workflow/design.rb
@@ -12,7 +12,7 @@ def get_output_filename(run, file_suffix = '.xml')
   return File.join(run[3], run[0].gsub(' ', '') + file_suffix)
 end
 
-def run_design(basedir, run, hpxml, debug, timeseries_output_freq, timeseries_outputs, add_comp_loads)
+def run_design(basedir, run, hpxml, debug, timeseries_output_freq, timeseries_outputs, add_comp_loads, skip_simulation)
   measures_dir = File.join(File.dirname(__FILE__), '..')
   designdir = get_design_dir(run)
   output_hpxml = get_output_filename(run)
@@ -27,39 +27,42 @@ def run_design(basedir, run, hpxml, debug, timeseries_output_freq, timeseries_ou
   args['hpxml_output_path'] = output_hpxml
   update_args_hash(measures, measure_subdir, args)
 
-  # Add HPXML translator measure to workflow
-  measure_subdir = 'hpxml-measures/HPXMLtoOpenStudio'
-  args = {}
-  args['hpxml_path'] = output_hpxml
-  args['output_dir'] = File.absolute_path(designdir)
-  args['debug'] = debug
-  args['add_component_loads'] = (add_comp_loads || timeseries_outputs.include?('componentloads'))
-  args['skip_validation'] = !debug
-  update_args_hash(measures, measure_subdir, args)
+  if not skip_simulation
+    # Add OS-HPXML translator measure to workflow
+    measure_subdir = 'hpxml-measures/HPXMLtoOpenStudio'
+    args = {}
+    args['hpxml_path'] = output_hpxml
+    args['output_dir'] = File.absolute_path(designdir)
+    args['debug'] = debug
+    args['add_component_loads'] = (add_comp_loads || timeseries_outputs.include?('componentloads'))
+    args['skip_validation'] = !debug
+    update_args_hash(measures, measure_subdir, args)
 
-  # Add reporting measure to workflow
-  measure_subdir = 'hpxml-measures/ReportSimulationOutput'
-  args = {}
-  args['timeseries_frequency'] = timeseries_output_freq
-  args['include_timeseries_fuel_consumptions'] = timeseries_outputs.include? 'fuels'
-  args['include_timeseries_end_use_consumptions'] = timeseries_outputs.include? 'enduses'
-  args['include_timeseries_emissions'] = timeseries_outputs.include? 'emissions'
-  args['include_timeseries_hot_water_uses'] = timeseries_outputs.include? 'hotwater'
-  args['include_timeseries_total_loads'] = timeseries_outputs.include? 'loads'
-  args['include_timeseries_component_loads'] = timeseries_outputs.include? 'componentloads'
-  args['include_timeseries_zone_temperatures'] = timeseries_outputs.include? 'temperatures'
-  args['include_timeseries_airflows'] = timeseries_outputs.include? 'airflows'
-  args['include_timeseries_weather'] = timeseries_outputs.include? 'weather'
-  update_args_hash(measures, measure_subdir, args)
+    # Add OS-HPXML reporting measure to workflow
+    measure_subdir = 'hpxml-measures/ReportSimulationOutput'
+    args = {}
+    args['timeseries_frequency'] = timeseries_output_freq
+    args['include_timeseries_fuel_consumptions'] = timeseries_outputs.include? 'fuels'
+    args['include_timeseries_end_use_consumptions'] = timeseries_outputs.include? 'enduses'
+    args['include_timeseries_emissions'] = timeseries_outputs.include? 'emissions'
+    args['include_timeseries_hot_water_uses'] = timeseries_outputs.include? 'hotwater'
+    args['include_timeseries_total_loads'] = timeseries_outputs.include? 'loads'
+    args['include_timeseries_component_loads'] = timeseries_outputs.include? 'componentloads'
+    args['include_timeseries_zone_temperatures'] = timeseries_outputs.include? 'temperatures'
+    args['include_timeseries_airflows'] = timeseries_outputs.include? 'airflows'
+    args['include_timeseries_weather'] = timeseries_outputs.include? 'weather'
+    update_args_hash(measures, measure_subdir, args)
+  end
 
   print_prefix = "[#{run[0]}] "
 
-  results = run_hpxml_workflow(designdir, measures, measures_dir, debug: debug, print_prefix: print_prefix)
+  results = run_hpxml_workflow(designdir, measures, measures_dir, debug: debug, print_prefix: print_prefix,
+                                                                  run_measures_only: skip_simulation)
 
   return output_hpxml
 end
 
-if ARGV.size == 7
+if ARGV.size == 8
   basedir = ARGV[0]
   run = ARGV[1].split('|').map { |x| (x.length == 0 ? nil : x) }
   hpxml = ARGV[2]
@@ -67,5 +70,6 @@ if ARGV.size == 7
   timeseries_output_freq = ARGV[4]
   timeseries_outputs = ARGV[5].split('|')
   add_comp_loads = (ARGV[6].downcase.to_s == 'true')
-  run_design(basedir, run, hpxml, debug, timeseries_output_freq, timeseries_outputs, add_comp_loads)
+  skip_simulation = (ARGV[7].downcase.to_s == 'true')
+  run_design(basedir, run, hpxml, debug, timeseries_output_freq, timeseries_outputs, add_comp_loads, skip_simulation)
 end

--- a/workflow/energy_rating_index.rb
+++ b/workflow/energy_rating_index.rb
@@ -61,25 +61,27 @@ end
 
 run_simulations(runs, options, basedir)
 
-design_outputs = retrieve_outputs(runs, options)
-if calc_co2e_index
-  # CO2e Rated Home is same as ERI Rated Home
-  design_outputs[Constants.CalcTypeCO2eRatedHome] = design_outputs[Constants.CalcTypeERIRatedHome].dup
-end
+if not options[:skip_simulation]
+  design_outputs = retrieve_outputs(runs, options)
+  if calc_co2e_index
+    # CO2e Rated Home is same as ERI Rated Home
+    design_outputs[Constants.CalcTypeCO2eRatedHome] = design_outputs[Constants.CalcTypeERIRatedHome].dup
+  end
 
-# Calculate and write results
-if calc_co2e_index
-  puts 'Calculating ERI & CO2e Index...'
-else
-  puts 'Calculating ERI...'
-end
-results = calculate_eri(design_outputs, resultsdir, eri_version: eri_version)
-puts "ERI: #{results[:eri].round(2)}"
-if calc_co2e_index
-  if not results[:co2eindex].nil?
-    puts "CO2e Index: #{results[:co2eindex].round(2)}"
+  # Calculate and write results
+  if calc_co2e_index
+    puts 'Calculating ERI & CO2e Index...'
   else
-    puts 'CO2e Index: N/A'
+    puts 'Calculating ERI...'
+  end
+  results = calculate_eri(design_outputs, resultsdir, eri_version: eri_version)
+  puts "ERI: #{results[:eri].round(2)}"
+  if calc_co2e_index
+    if not results[:co2eindex].nil?
+      puts "CO2e Index: #{results[:co2eindex].round(2)}"
+    else
+      puts 'CO2e Index: N/A'
+    end
   end
 end
 

--- a/workflow/energy_star.rb
+++ b/workflow/energy_star.rb
@@ -137,36 +137,38 @@ runs << [Constants.CalcTypeERIIndexAdjustmentReferenceHome, rated_hpxml, esrated
 # Run simulations
 run_simulations(runs, options, basedir)
 
-puts 'Calculating ENERGY STAR...'
+if not options[:skip_simulation]
+  puts 'Calculating ENERGY STAR...'
 
-# Calculate ES Reference ERI
-esrd_outputs = retrieve_outputs(runs[0..3], options)
-esrd_results = calculate_eri(esrd_outputs, esrd_resultsdir)
+  # Calculate ES Reference ERI
+  esrd_outputs = retrieve_outputs(runs[0..3], options)
+  esrd_results = calculate_eri(esrd_outputs, esrd_resultsdir)
 
-# Calculate Size-Adjusted ERI for Energy Star Reference Homes
-saf = calc_energystar_saf(esrd_results, es_version, esrd_hpxml)
-target_eri = esrd_results[:eri] * saf
+  # Calculate Size-Adjusted ERI for Energy Star Reference Homes
+  saf = calc_energystar_saf(esrd_results, es_version, esrd_hpxml)
+  target_eri = esrd_results[:eri] * saf
 
-# Calculate ES Rated ERI, w/ On-site Power Production (OPP) restriction as appropriate
-opp_reduction_limit = calc_opp_eri_limit(esrd_results[:eri], saf, es_version)
-rated_outputs = retrieve_outputs(runs[4..7], options)
-rated_results = calculate_eri(rated_outputs, esrated_resultsdir, opp_reduction_limit: opp_reduction_limit)
+  # Calculate ES Rated ERI, w/ On-site Power Production (OPP) restriction as appropriate
+  opp_reduction_limit = calc_opp_eri_limit(esrd_results[:eri], saf, es_version)
+  rated_outputs = retrieve_outputs(runs[4..7], options)
+  rated_results = calculate_eri(rated_outputs, esrated_resultsdir, opp_reduction_limit: opp_reduction_limit)
 
-if rated_results[:eri].round(0) <= target_eri.round(0)
-  passes = true
-else
-  passes = false
-end
+  if rated_results[:eri].round(0) <= target_eri.round(0)
+    passes = true
+  else
+    passes = false
+  end
 
-# Calculate ES Rated ERI w/o OPP for extra information
-rated_results_wo_opp = calculate_eri(rated_outputs, esrated_resultsdir, opp_reduction_limit: 0.0)
+  # Calculate ES Rated ERI w/o OPP for extra information
+  rated_results_wo_opp = calculate_eri(rated_outputs, esrated_resultsdir, opp_reduction_limit: 0.0)
 
-write_es_results(resultsdir, esrd_results, rated_results, rated_results_wo_opp, target_eri, saf, passes)
+  write_es_results(resultsdir, esrd_results, rated_results, rated_results_wo_opp, target_eri, saf, passes)
 
-if passes
-  puts 'ENERGY STAR Certification: PASS'
-else
-  puts 'ENERGY STAR Certification: FAIL'
+  if passes
+    puts 'ENERGY STAR Certification: PASS'
+  else
+    puts 'ENERGY STAR Certification: FAIL'
+  end
 end
 
 puts "Output files written to #{resultsdir}"

--- a/workflow/tests/energy_rating_index_test.rb
+++ b/workflow/tests/energy_rating_index_test.rb
@@ -115,6 +115,14 @@ class EnergyRatingIndexTest < Minitest::Test
     end
   end
 
+  def test_skip_simulation
+    test_name = 'skip_simulation'
+
+    # Run ERI workflow
+    xml = "#{File.dirname(__FILE__)}/../sample_files/base.xml"
+    rundir, hpxmls, csvs = _run_workflow(xml, test_name, skip_simulation: true)
+  end
+
   def test_resnet_ashrae_140
     test_name = 'RESNET_Test_4.1_Standard_140'
     test_results_csv = File.absolute_path(File.join(@test_results_dir, "#{test_name}.csv"))

--- a/workflow/tests/energy_star_test.rb
+++ b/workflow/tests/energy_star_test.rb
@@ -150,6 +150,14 @@ class EnergyStarTest < Minitest::Test
     end
   end
 
+  def test_skip_simulation
+    test_name = 'skip_simulation'
+
+    # Run ENERGY STAR workflow
+    xml = "#{File.dirname(__FILE__)}/../sample_files/base.xml"
+    rundir, hpxmls, csvs = _run_workflow(xml, test_name, run_energystar: true, skip_simulation: true)
+  end
+
   def test_epa
     test_name = 'EPA_Tests'
     test_results_csv = File.absolute_path(File.join(@test_results_dir, "#{test_name}.csv"))


### PR DESCRIPTION
## Pull Request Description

Adds a `--skip-simulation` flag that can be used to just generate the ERI Rated/Reference Home HPXMLs and then stop.

E.g.:
`openstudio workflow/energy_rating_index.rb -x workflow/sample_files/base.xml --skip-simulation`

## Checklist

Not all may apply:

- [x] ~OS-HPXML git subtree has been pulled~
- [x] ~301/ES rulesets and unit tests have been updated~
- [x] ~301validator.xml has been updated (reference EPvalidator.xml)~
- [x] Workflow tests have been updated
- [x] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
