### PR TITLE
Fixes possible NaN result

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@ __Bugfixes__
 - Adds more stringent limits for `AirflowDefectRatio` (now allows values from 1/10th to 10x the design value).
 - Fixes opaque door R-value in the Reference Home in IECC climate zone 1.
 - Hourly output fixes: some outputs off by 1 hour; possible negative combi boiler values.
+- Fixes possible NaN result for ERI if, in a very cold climate, the Reference Home has no cooling load.
 
 ## OpenStudio-ERI v1.3.0
 

--- a/workflow/util.rb
+++ b/workflow/util.rb
@@ -437,9 +437,9 @@ def _calculate_eri(rated_output, ref_output, results_iad: nil, opp_reduction_lim
     nec_x_cool = 0
     if eec_x_cool * reul_cool > 0
       nec_x_cool = (coeff_cool_a * eec_x_cool - coeff_cool_b) * (ec_x_cool * ec_r_cool * dse_r_cool) / (eec_x_cool * reul_cool)
+      # Add whole-house fan energy to nec_x_cool per 301 (apportioned by load) and excluded from eul_la
+      nec_x_cool += (rated_output['End Use: Electricity: Whole House Fan (MBtu)'] * reul_cool / tot_reul_cool)
     end
-    # Add whole-house fan energy to nec_x_cool per 301 (apportioned by load) and excluded from eul_la
-    nec_x_cool += (rated_output['End Use: Electricity: Whole House Fan (MBtu)'] * reul_cool / tot_reul_cool)
     nmeul_cool = 0
     if ec_r_cool > 0
       nmeul_cool = reul_cool * (nec_x_cool / ec_r_cool)


### PR DESCRIPTION
## Pull Request Description

Fixes possible NaN result for ERI if, in a very cold climate, the Reference Home has no cooling load.

## Checklist

Not all may apply:

- [ ] OS-HPXML git subtree has been pulled
- [ ] 301/ES rulesets and unit tests have been updated
- [ ] 301validator.xml has been updated (reference EPvalidator.xml)
- [ ] Workflow tests have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
