### PR TITLE
Allow running only the ERI Rated Home

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@ __New Features__
 - Allows `AirInfiltrationMeasurement/InfiltrationHeight` as an optional input; if not provided, it is inferred from other inputs as before. 
 - Allows duct leakage to be entered in units of CFM50 as an alternative to CFM25.
 - Adds a `--skip-simulation` flag that can be used to just generate the ERI Rated/Reference Home HPXMLs and then stop.
+- Adds a `--rated-home-only` flag to run only the ERI Rated Home simulation (ERI will not be calculated).
 - Simplifies ERI Reference Home configuration with respect to HVAC types and number of DSE distribution systems.
 
 __Bugfixes__

--- a/workflow/energy_rating_index.rb
+++ b/workflow/energy_rating_index.rb
@@ -67,7 +67,7 @@ end
 # Check for correct versions of OS
 Version.check_openstudio_version()
 
-options = process_arguments(File.basename(__FILE__), args, basedir)
+options = process_arguments(File.basename(__FILE__), args, basedir, 'eri')
 
 resultsdir = setup_resultsdir(options)
 
@@ -77,22 +77,24 @@ eri_version = get_eri_version(hpxml_doc)
 # Create list of designs to run: [calc_type, HPXML, output_dir, results_dir]
 runs = []
 runs << [Constants.CalcTypeERIRatedHome, options[:hpxml], options[:output_dir], resultsdir]
-runs << [Constants.CalcTypeERIReferenceHome, options[:hpxml], options[:output_dir], resultsdir]
-if (eri_version == 'latest') || (Constants.ERIVersions.index(eri_version) >= Constants.ERIVersions.index('2014AE'))
-  runs << [Constants.CalcTypeERIIndexAdjustmentDesign, options[:hpxml], options[:output_dir], resultsdir]
-  runs << [Constants.CalcTypeERIIndexAdjustmentReferenceHome, options[:hpxml], options[:output_dir], resultsdir]
-end
-calc_co2e_index = false
-if (eri_version == 'latest') || (Constants.ERIVersions.index(eri_version) >= Constants.ERIVersions.index('2019ABCD'))
-  calc_co2e_index = true
-end
-if calc_co2e_index
-  # All-electric ERI Reference Home
-  eri_ref_home_is_electric = is_eri_ref_all_electric(hpxml_doc)
-  co2_ref_home_run = [Constants.CalcTypeCO2eReferenceHome, options[:hpxml], options[:output_dir], resultsdir]
-  if not eri_ref_home_is_electric
-    # Additional CO2e Reference Home run only needed if different than ERI Reference Home
-    runs << co2_ref_home_run
+if not options[:rated_home_only]
+  runs << [Constants.CalcTypeERIReferenceHome, options[:hpxml], options[:output_dir], resultsdir]
+  if (eri_version == 'latest') || (Constants.ERIVersions.index(eri_version) >= Constants.ERIVersions.index('2014AE'))
+    runs << [Constants.CalcTypeERIIndexAdjustmentDesign, options[:hpxml], options[:output_dir], resultsdir]
+    runs << [Constants.CalcTypeERIIndexAdjustmentReferenceHome, options[:hpxml], options[:output_dir], resultsdir]
+  end
+  calc_co2e_index = false
+  if (eri_version == 'latest') || (Constants.ERIVersions.index(eri_version) >= Constants.ERIVersions.index('2019ABCD'))
+    calc_co2e_index = true
+  end
+  if calc_co2e_index
+    # All-electric ERI Reference Home
+    eri_ref_home_is_electric = is_eri_ref_all_electric(hpxml_doc)
+    co2_ref_home_run = [Constants.CalcTypeCO2eReferenceHome, options[:hpxml], options[:output_dir], resultsdir]
+    if not eri_ref_home_is_electric
+      # Additional CO2e Reference Home run only needed if different than ERI Reference Home
+      runs << co2_ref_home_run
+    end
   end
 end
 
@@ -100,31 +102,34 @@ run_simulations(runs, options, basedir)
 
 if not options[:skip_simulation]
   design_outputs = retrieve_outputs(runs, options)
-  if calc_co2e_index
-    # CO2e Rated Home is same as ERI Rated Home
-    design_outputs[Constants.CalcTypeCO2eRatedHome] = design_outputs[Constants.CalcTypeERIRatedHome].dup
-    if eri_ref_home_is_electric
-      design_outputs[Constants.CalcTypeCO2eReferenceHome] = design_outputs[Constants.CalcTypeERIReferenceHome].dup
 
-      # Duplicate output files too
-      eri_ref_home_run = runs.select { |r| r[0] == Constants.CalcTypeERIReferenceHome }[0]
-      duplicate_output_files(eri_ref_home_run, co2_ref_home_run, resultsdir)
+  if not options[:rated_home_only]
+    if calc_co2e_index
+      # CO2e Rated Home is same as ERI Rated Home
+      design_outputs[Constants.CalcTypeCO2eRatedHome] = design_outputs[Constants.CalcTypeERIRatedHome].dup
+      if eri_ref_home_is_electric
+        design_outputs[Constants.CalcTypeCO2eReferenceHome] = design_outputs[Constants.CalcTypeERIReferenceHome].dup
+
+        # Duplicate output files too
+        eri_ref_home_run = runs.select { |r| r[0] == Constants.CalcTypeERIReferenceHome }[0]
+        duplicate_output_files(eri_ref_home_run, co2_ref_home_run, resultsdir)
+      end
     end
-  end
 
-  # Calculate and write results
-  if calc_co2e_index
-    puts 'Calculating ERI & CO2e Index...'
-  else
-    puts 'Calculating ERI...'
-  end
-  results = calculate_eri(design_outputs, resultsdir, eri_version: eri_version)
-  puts "ERI: #{results[:eri].round(2)}"
-  if calc_co2e_index
-    if not results[:co2eindex].nil?
-      puts "CO2e Index: #{results[:co2eindex].round(2)}"
+    # Calculate and write results
+    if calc_co2e_index
+      puts 'Calculating ERI & CO2e Index...'
     else
-      puts 'CO2e Index: N/A'
+      puts 'Calculating ERI...'
+    end
+    results = calculate_eri(design_outputs, resultsdir, eri_version: eri_version)
+    puts "ERI: #{results[:eri].round(2)}"
+    if calc_co2e_index
+      if not results[:co2eindex].nil?
+        puts "CO2e Index: #{results[:co2eindex].round(2)}"
+      else
+        puts 'CO2e Index: N/A'
+      end
     end
   end
 end

--- a/workflow/energy_star.rb
+++ b/workflow/energy_star.rb
@@ -103,7 +103,7 @@ end
 # Check for correct versions of OS
 Version.check_openstudio_version()
 
-options = process_arguments(File.basename(__FILE__), args, basedir)
+options = process_arguments(File.basename(__FILE__), args, basedir, 'energystar')
 
 resultsdir = setup_resultsdir(options)
 

--- a/workflow/tests/energy_rating_index_test.rb
+++ b/workflow/tests/energy_rating_index_test.rb
@@ -161,6 +161,14 @@ class EnergyRatingIndexTest < Minitest::Test
     rundir, hpxmls, csvs = _run_workflow(xml, test_name, skip_simulation: true)
   end
 
+  def test_rated_home_only
+    test_name = 'rated_home_only'
+
+    # Run ERI workflow
+    xml = "#{File.dirname(__FILE__)}/../sample_files/base.xml"
+    rundir, hpxmls, csvs = _run_workflow(xml, test_name, rated_home_only: true)
+  end
+
   def test_co2index_without_extra_simulation
     # Check that if we run an all-electric home, it reuses the ERI Reference Home
     # simulation results for the CO2e Reference Home, rather than running an additional

--- a/workflow/util.rb
+++ b/workflow/util.rb
@@ -13,7 +13,7 @@ def setup_resultsdir(options)
   return resultsdir
 end
 
-def process_arguments(calling_rb, args, basedir)
+def process_arguments(calling_rb, args, basedir, caller)
   timeseries_types = ['ALL', 'total', 'fuels', 'enduses', 'emissions', 'hotwater', 'loads', 'componentloads', 'temperatures', 'airflows', 'weather']
 
   options = {}
@@ -59,6 +59,13 @@ def process_arguments(calling_rb, args, basedir)
     options[:skip_simulation] = false
     opts.on('--skip-simulation', 'Skip the EnergyPlus simulations') do |t|
       options[:skip_simulation] = true
+    end
+
+    if caller == 'eri'
+      options[:rated_home_only] = false
+      opts.on('--rated-home-only', 'Only run the Rated Home') do |t|
+        options[:rated_home_only] = true
+      end
     end
 
     options[:debug] = false


### PR DESCRIPTION
## Pull Request Description

Adds a `--rated-home-only` flag to run only the ERI Rated Home simulation (ERI will not be calculated).

E.g., `openstudio workflow/energy_rating_index.rb -x workflow/sample_files/base.xml -o test --rated-home-only`

## Checklist

Not all may apply:

- [ ] OS-HPXML git subtree has been pulled
- [ ] 301/ES rulesets and unit tests have been updated
- [ ] 301validator.xml has been updated (reference EPvalidator.xml)
- [ ] Workflow tests have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
