### PR TITLE
Auto-Gen bugfix

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,4 @@
-## OpenStudio-ERI v1.5.0
-
-__New Features__
+## OpenStudio-ERI v1.4.1
 
 __Bugfixes__
 - Fixes possible error when running HERS Auto-Generation tests.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+## OpenStudio-ERI v1.5.0
+
+__New Features__
+
+__Bugfixes__
+- Fixes possible error when running HERS Auto-Generation tests.
+
 ## OpenStudio-ERI v1.4.0
 
 __New Features__

--- a/rulesets/301EnergyRatingIndexRuleset/resources/301.rb
+++ b/rulesets/301EnergyRatingIndexRuleset/resources/301.rb
@@ -1126,7 +1126,8 @@ class EnergyRatingIndex301Ruleset
         end
       end
       if not cooling_system.nil?
-        if new_hpxml.heat_pumps.select { |hp| hp.clg_seed_id == cooling_system.id }.size > 0
+        clg_seed_id = cooling_system.clg_seed_id.nil? ? cooling_system.id : cooling_system.clg_seed_id
+        if new_hpxml.heat_pumps.select { |hp| hp.clg_seed_id == clg_seed_id }.size > 0
           # Already created HP above
         else
           add_reference_air_conditioner(orig_hpxml, new_hpxml, cooling_system.fraction_cool_load_served, orig_system: cooling_system)

--- a/workflow/util.rb
+++ b/workflow/util.rb
@@ -111,7 +111,7 @@ def process_arguments(calling_rb, args, basedir, caller)
     options[:timeseries_outputs] = timeseries_types[1..-1]
   end
   if options[:version]
-    workflow_version = '1.4.0'
+    workflow_version = '1.4.1'
     puts "OpenStudio-ERI v#{workflow_version}"
     puts "OpenStudio v#{OpenStudio.openStudioLongVersion}"
     puts "EnergyPlus v#{OpenStudio.energyPlusVersion}.#{OpenStudio.energyPlusBuildSHA}"


### PR DESCRIPTION
## Pull Request Description

Fixes possible error when running HERS Auto-Generation tests.

## Checklist

Not all may apply:

- [ ] OS-HPXML git subtree has been pulled
- [ ] 301/ES rulesets and unit tests have been updated
- [ ] 301validator.xml has been updated (reference EPvalidator.xml)
- [ ] Workflow tests have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
