### PR TITLE
Remove redundant HPXML validations

### DIFF
--- a/rulesets/301EnergyRatingIndexRuleset/measure.rb
+++ b/rulesets/301EnergyRatingIndexRuleset/measure.rb
@@ -28,8 +28,6 @@ require_relative 'resources/301'
 
 # start the measure
 class EnergyRatingIndex301Measure < OpenStudio::Measure::ModelMeasure
-  attr_accessor(:orig_hpxml, :new_hpxml)
-
   # human readable name
   def name
     return 'Apply Energy Rating Index Ruleset'
@@ -97,19 +95,22 @@ class EnergyRatingIndex301Measure < OpenStudio::Measure::ModelMeasure
     end
 
     begin
-      stron_paths = [File.join(File.dirname(__FILE__), '..', '..', 'hpxml-measures', 'HPXMLtoOpenStudio', 'resources', 'hpxml_schematron', 'HPXMLvalidator.xml'),
-                     File.join(File.dirname(__FILE__), 'resources', '301validator.xml')]
-      @orig_hpxml = HPXML.new(hpxml_path: hpxml_input_path, schematron_validators: stron_paths)
-      @orig_hpxml.errors.each do |error|
+      stron_paths = []
+      if calc_type == Constants.CalcTypeERIRatedHome # Only need to validate once
+        stron_paths << File.join(File.dirname(__FILE__), '..', '..', 'hpxml-measures', 'HPXMLtoOpenStudio', 'resources', 'hpxml_schematron', 'HPXMLvalidator.xml')
+        stron_paths << File.join(File.dirname(__FILE__), 'resources', '301validator.xml')
+      end
+      orig_hpxml = HPXML.new(hpxml_path: hpxml_input_path, schematron_validators: stron_paths)
+      orig_hpxml.errors.each do |error|
         runner.registerError(error)
       end
-      @orig_hpxml.warnings.each do |warning|
+      orig_hpxml.warnings.each do |warning|
         runner.registerWarning(warning)
       end
-      return false unless @orig_hpxml.errors.empty?
+      return false unless orig_hpxml.errors.empty?
 
       # Weather file
-      epw_path = @orig_hpxml.climate_and_risk_zones.weather_station_epw_filepath
+      epw_path = orig_hpxml.climate_and_risk_zones.weather_station_epw_filepath
       if not File.exist? epw_path
         test_epw_path = File.join(File.dirname(hpxml_input_path), epw_path)
         epw_path = test_epw_path if File.exist? test_epw_path
@@ -132,11 +133,11 @@ class EnergyRatingIndex301Measure < OpenStudio::Measure::ModelMeasure
       weather = WeatherProcess.new(nil, nil, cache_path)
 
       # Apply 301 ruleset on HPXML object
-      @new_hpxml = EnergyRatingIndex301Ruleset.apply_ruleset(runner, @orig_hpxml, calc_type, weather)
+      new_hpxml = EnergyRatingIndex301Ruleset.apply_ruleset(runner, orig_hpxml, calc_type, weather)
 
       # Write new HPXML file
       if hpxml_output_path.is_initialized
-        XMLHelper.write_file(@new_hpxml.to_oga, hpxml_output_path.get)
+        XMLHelper.write_file(new_hpxml.to_oga, hpxml_output_path.get)
         runner.registerInfo("Wrote file: #{hpxml_output_path.get}")
       end
     rescue Exception => e

--- a/rulesets/EnergyStarRuleset/measure.rb
+++ b/rulesets/EnergyStarRuleset/measure.rb
@@ -16,6 +16,8 @@ require_relative 'resources/constants'
 
 # start the measure
 class EnergyStarMeasure < OpenStudio::Measure::ModelMeasure
+  attr_accessor(:orig_hpxml, :new_hpxml)
+
   # human readable name
   def name
     return 'Apply ENERGY STAR Ruleset'
@@ -85,21 +87,21 @@ class EnergyStarMeasure < OpenStudio::Measure::ModelMeasure
         stron_paths << File.join(File.dirname(__FILE__), '..', '..', 'hpxml-measures', 'HPXMLtoOpenStudio', 'resources', 'hpxml_schematron', 'HPXMLvalidator.xml')
         stron_paths << File.join(File.dirname(__FILE__), '..', '301EnergyRatingIndexRuleset', 'resources', '301validator.xml')
       end
-      orig_hpxml = HPXML.new(hpxml_path: hpxml_input_path, schematron_validators: stron_paths)
-      orig_hpxml.errors.each do |error|
+      @orig_hpxml = HPXML.new(hpxml_path: hpxml_input_path, schematron_validators: stron_paths)
+      @orig_hpxml.errors.each do |error|
         runner.registerError(error)
       end
-      orig_hpxml.warnings.each do |warning|
+      @orig_hpxml.warnings.each do |warning|
         runner.registerWarning(warning)
       end
-      return false unless orig_hpxml.errors.empty?
+      return false unless @orig_hpxml.errors.empty?
 
       # Apply ENERGY STAR ruleset on HPXML object
-      new_hpxml = EnergyStarRuleset.apply_ruleset(orig_hpxml, calc_type)
+      @new_hpxml = EnergyStarRuleset.apply_ruleset(@orig_hpxml, calc_type)
 
       # Write new HPXML file
       if hpxml_output_path.is_initialized
-        XMLHelper.write_file(new_hpxml.to_oga, hpxml_output_path.get)
+        XMLHelper.write_file(@new_hpxml.to_oga, hpxml_output_path.get)
         runner.registerInfo("Wrote file: #{hpxml_output_path.get}")
       end
     rescue Exception => e

--- a/rulesets/EnergyStarRuleset/measure.rb
+++ b/rulesets/EnergyStarRuleset/measure.rb
@@ -16,8 +16,6 @@ require_relative 'resources/constants'
 
 # start the measure
 class EnergyStarMeasure < OpenStudio::Measure::ModelMeasure
-  attr_accessor(:orig_hpxml, :new_hpxml)
-
   # human readable name
   def name
     return 'Apply ENERGY STAR Ruleset'
@@ -81,24 +79,32 @@ class EnergyStarMeasure < OpenStudio::Measure::ModelMeasure
       return false
     end
 
-    stron_paths = [File.join(File.dirname(__FILE__), '..', '..', 'hpxml-measures', 'HPXMLtoOpenStudio', 'resources', 'hpxml_schematron', 'HPXMLvalidator.xml'),
-                   File.join(File.dirname(__FILE__), '..', '301EnergyRatingIndexRuleset', 'resources', '301validator.xml')]
-    @orig_hpxml = HPXML.new(hpxml_path: hpxml_input_path, schematron_validators: stron_paths)
-    @orig_hpxml.errors.each do |error|
-      runner.registerError(error)
-    end
-    @orig_hpxml.warnings.each do |warning|
-      runner.registerWarning(warning)
-    end
-    return false unless @orig_hpxml.errors.empty?
+    begin
+      stron_paths = []
+      if calc_type == ESConstants.CalcTypeEnergyStarRated # Only need to validate once
+        stron_paths << File.join(File.dirname(__FILE__), '..', '..', 'hpxml-measures', 'HPXMLtoOpenStudio', 'resources', 'hpxml_schematron', 'HPXMLvalidator.xml')
+        stron_paths << File.join(File.dirname(__FILE__), '..', '301EnergyRatingIndexRuleset', 'resources', '301validator.xml')
+      end
+      orig_hpxml = HPXML.new(hpxml_path: hpxml_input_path, schematron_validators: stron_paths)
+      orig_hpxml.errors.each do |error|
+        runner.registerError(error)
+      end
+      orig_hpxml.warnings.each do |warning|
+        runner.registerWarning(warning)
+      end
+      return false unless orig_hpxml.errors.empty?
 
-    # Apply ENERGY STAR ruleset on HPXML object
-    @new_hpxml = EnergyStarRuleset.apply_ruleset(@orig_hpxml, calc_type)
+      # Apply ENERGY STAR ruleset on HPXML object
+      new_hpxml = EnergyStarRuleset.apply_ruleset(orig_hpxml, calc_type)
 
-    # Write new HPXML file
-    if hpxml_output_path.is_initialized
-      XMLHelper.write_file(@new_hpxml.to_oga, hpxml_output_path.get)
-      runner.registerInfo("Wrote file: #{hpxml_output_path.get}")
+      # Write new HPXML file
+      if hpxml_output_path.is_initialized
+        XMLHelper.write_file(new_hpxml.to_oga, hpxml_output_path.get)
+        runner.registerInfo("Wrote file: #{hpxml_output_path.get}")
+      end
+    rescue Exception => e
+      runner.registerError("#{e.message}\n#{e.backtrace.join("\n")}")
+      return false
     end
 
     return true

--- a/rulesets/EnergyStarRuleset/measure.xml
+++ b/rulesets/EnergyStarRuleset/measure.xml
@@ -4,8 +4,8 @@
   <error>Unable to extract OpenStudio::Measure::OSMeasure object from /mnt/c/git/openstudio-eri/rulesets/EnergyStarRuleset/measure.rb. The script should contain a class that derives from OpenStudio::Measure::OSMeasure and should close with a line stating the class name followed by .new.registerWithApplication.</error>
   <name>energy_star_measure</name>
   <uid>cd245684-9633-49dd-9eae-d5ccfa972bab</uid>
-  <version_id>7b09d4f6-be98-4d1e-8a61-845f85aa01f0</version_id>
-  <version_modified>20220609T035730Z</version_modified>
+  <version_id>8c5c4ae5-0e62-44b9-b73e-dde84958a7e0</version_id>
+  <version_modified>20220624T194305Z</version_modified>
   <xml_checksum>48718AE9</xml_checksum>
   <class_name>EnergyStarMeasure</class_name>
   <display_name>Apply ENERGY STAR Ruleset</display_name>
@@ -157,17 +157,6 @@
       <checksum>C829AD5C</checksum>
     </file>
     <file>
-      <version>
-        <software_program>OpenStudio</software_program>
-        <identifier>2.1.1</identifier>
-        <min_compatible>2.1.1</min_compatible>
-      </version>
-      <filename>measure.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>script</usage_type>
-      <checksum>7B22697D</checksum>
-    </file>
-    <file>
       <filename>test_es_lighting.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
@@ -196,6 +185,17 @@
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
       <checksum>AD7446A1</checksum>
+    </file>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>2.1.1</identifier>
+        <min_compatible>2.1.1</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>AF80FEE1</checksum>
     </file>
   </files>
 </measure>

--- a/rulesets/EnergyStarRuleset/measure.xml
+++ b/rulesets/EnergyStarRuleset/measure.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
 <measure>
   <schema_version>3.0</schema_version>
-  <error>Unable to extract OpenStudio::Measure::OSMeasure object from /mnt/c/git/openstudio-eri/rulesets/EnergyStarRuleset/measure.rb. The script should contain a class that derives from OpenStudio::Measure::OSMeasure and should close with a line stating the class name followed by .new.registerWithApplication.</error>
   <name>energy_star_measure</name>
   <uid>cd245684-9633-49dd-9eae-d5ccfa972bab</uid>
-  <version_id>8c5c4ae5-0e62-44b9-b73e-dde84958a7e0</version_id>
-  <version_modified>20220624T194305Z</version_modified>
+  <version_id>af22b799-1fa4-41b5-a78c-c56d195b1ce8</version_id>
+  <version_modified>20220624T211215Z</version_modified>
   <xml_checksum>48718AE9</xml_checksum>
   <class_name>EnergyStarMeasure</class_name>
   <display_name>Apply ENERGY STAR Ruleset</display_name>
@@ -15,9 +14,7 @@
     <argument>
       <name>calc_type</name>
       <display_name>Calculation Type</display_name>
-      <description></description>
       <type>Choice</type>
-      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>ES Reference</default_value>
@@ -31,32 +28,22 @@
           <display_name>ES Reference</display_name>
         </choice>
       </choices>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
     <argument>
       <name>hpxml_input_path</name>
       <display_name>HPXML Input File Path</display_name>
       <description>Absolute (or relative) path of the input HPXML file.</description>
       <type>String</type>
-      <units></units>
       <required>true</required>
       <model_dependent>false</model_dependent>
-      <default_value></default_value>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
     <argument>
       <name>hpxml_output_path</name>
       <display_name>HPXML Output File Path</display_name>
       <description>Absolute (or relative) path of the output HPXML file.</description>
       <type>String</type>
-      <units></units>
       <required>false</required>
       <model_dependent>false</model_dependent>
-      <default_value></default_value>
-      <min_value></min_value>
-      <max_value></max_value>
     </argument>
   </arguments>
   <outputs />
@@ -195,7 +182,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>AF80FEE1</checksum>
+      <checksum>58B9432F</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
## Pull Request Description

Should have some runtime improvement w/o any downside.

## Checklist

Not all may apply:

- [ ] OS-HPXML git subtree has been pulled
- [ ] 301/ES rulesets and unit tests have been updated
- [ ] 301validator.xml has been updated (reference EPvalidator.xml)
- [ ] Workflow tests have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
