### PR TITLE
Fix ERI warnings

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+## OpenStudio-ERI v1.5.1
+
+__Bugfixes__
+- Fixes incorrect warning about zip code not found in eGRID/Cambium lookup table.
+
 ## OpenStudio-ERI v1.5.0
 
 __New Features__

--- a/rulesets/main.rb
+++ b/rulesets/main.rb
@@ -65,12 +65,12 @@ def run_rulesets(hpxml_input_path, designs)
     if not eri_version.nil?
       # Obtain egrid subregion & cambium gea region
       egrid_subregion = get_epa_egrid_subregion(zip_code)
-      if not egrid_subregion.nil?
+      if egrid_subregion.nil?
         warnings << "Could not look up eGRID subregion for zip code: '#{zip_code}'. Emissions will not be calculated."
       end
       if Constants.ERIVersions.index(eri_version) >= Constants.ERIVersions.index('2019ABCD')
         cambium_gea = get_cambium_gea_region(zip_code)
-        if not cambium_gea.nil?
+        if cambium_gea.nil?
           warnings << "Could not look up Cambium GEA for zip code: '#{zip_code}'. CO2e emissions will not be calculated."
         end
       end


### PR DESCRIPTION
## Pull Request Description

Fix ERI warnings in main.rb

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [x] ~OS-HPXML git subtree has been pulled~
- [x] ~301/ES rulesets and unit tests have been updated~
- [x] ~301validator.xml has been updated (reference EPvalidator.xml)~
- [x] ~Workflow tests have been updated~
- [x] ~Documentation has been updated~
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
