### PR TITLE
ENERGY STAR MFNC: Use the same floor construction in Reference Designs as Rated Homes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@ __New Features__
 - `WaterHeatingSystem/RecoveryEfficiency` is now an optional input.
 - Weather cache file (\*-cache.csv) is now optional; if not provided, it will be generated on the fly. Provide the cache file for fastest runtime.
 - Provide two decimal places in ENERGY STARS/ZERH CSV output files to better prevent user confusion.
-- Preserves `Floor/FloorType`
+- Preserves `Floor/FloorType` in the Rated Home as per EPA's request.
 
 __Bugfixes__
 - Bugfixes for ENERGY STAR and ZERH programs.

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ __New Features__
 - `WaterHeatingSystem/RecoveryEfficiency` is now an optional input.
 - Weather cache file (\*-cache.csv) is now optional; if not provided, it will be generated on the fly. Provide the cache file for fastest runtime.
 - Provide two decimal places in ENERGY STARS/ZERH CSV output files to better prevent user confusion.
+- Preserves `Floor/FloorType`
 
 __Bugfixes__
 - Bugfixes for ENERGY STAR and ZERH programs.

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@ __New Features__
 - `WaterHeatingSystem/RecoveryEfficiency` is now an optional input.
 - Weather cache file (\*-cache.csv) is now optional; if not provided, it will be generated on the fly. Provide the cache file for fastest runtime.
 - Provide two decimal places in ENERGY STARS/ZERH CSV output files to better prevent user confusion.
-- Preserves `Floor/FloorType` in the Rated Home as per EPA's request.
+- Uses the same `Floor/FloorType` in the Reference Design as the Rated Home for ENERGY STAR MFNC, as per EPA's request.
 
 __Bugfixes__
 - Bugfixes for ENERGY STAR and ZERH programs.

--- a/rulesets/resources/ES_ZERHruleset.rb
+++ b/rulesets/resources/ES_ZERHruleset.rb
@@ -462,7 +462,7 @@ class EnergyStarZeroEnergyReadyHomeRuleset
                            exterior_adjacent_to: ceiling_exterior_adjacent_to,
                            interior_adjacent_to: orig_floor.interior_adjacent_to.gsub('unvented', 'vented'),
                            floor_or_ceiling: orig_floor.floor_or_ceiling,
-                           floor_type: HPXML::FloorTypeWoodFrame,
+                           floor_type: orig_floor.floor_type,
                            area: orig_floor.area,
                            insulation_id: orig_floor.insulation_id,
                            insulation_assembly_r_value: insulation_assembly_r_value)

--- a/rulesets/resources/ES_ZERHruleset.rb
+++ b/rulesets/resources/ES_ZERHruleset.rb
@@ -507,7 +507,7 @@ class EnergyStarZeroEnergyReadyHomeRuleset
                            exterior_adjacent_to: orig_floor.exterior_adjacent_to.gsub('unvented', 'vented'),
                            interior_adjacent_to: orig_floor.interior_adjacent_to.gsub('unvented', 'vented'),
                            floor_or_ceiling: orig_floor.floor_or_ceiling,
-                           floor_type: HPXML::FloorTypeWoodFrame,
+                           floor_type: orig_floor.floor_type,
                            area: orig_floor.area,
                            insulation_id: orig_floor.insulation_id,
                            insulation_assembly_r_value: insulation_assembly_r_value)

--- a/rulesets/tests/test_es_zerh_enclosure.rb
+++ b/rulesets/tests/test_es_zerh_enclosure.rb
@@ -387,7 +387,7 @@ class EnergyStarZeroEnergyReadyHomeEnclosureTest < MiniTest::Test
       end
       XMLHelper.write_file(hpxml.to_oga, @tmp_hpxml_path)
       hpxml = _test_ruleset(program_version)
-      _check_ceilings(hpxml, area: 900, rvalue: 2.1, floor_type: HPXML::FloorTypeWoodFrame)
+      _check_ceilings(hpxml, area: 900, rvalue: 2.1, floor_type: HPXML::FloorTypeConcrete)
     end
   end
 
@@ -440,7 +440,7 @@ class EnergyStarZeroEnergyReadyHomeEnclosureTest < MiniTest::Test
       elsif [ESConstants.MFNationalVer1_2].include? program_version
         rvalue = 1.0 / 0.051
       end
-      _check_floors(hpxml, area: 900, rvalue: (2.1 * 150 + 3.1 * 200 + rvalue * 550) / 900, floor_type: HPXML::FloorTypeWoodFrame)
+      _check_floors(hpxml, area: 900, rvalue: (2.1 * 150 + 3.1 * 200 + rvalue * 550) / 900, floor_type: HPXML::FloorTypeConcrete)
     end
 
     [*ESConstants.NationalVersions, *ZERHConstants.AllVersions].each do |program_version|


### PR DESCRIPTION
## Pull Request Description

EPA's intention has been that the floor type would be the same construction in the Reference Design as the Rated Home, but the Target Procedure currently says floor construction is wood-framed in the Reference Design. EPA will be updating the Target Procedures to note that the floor construction in the Reference Design should match the Rated Home. 

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [ ] ~~OS-HPXML git subtree has been pulled~~
- [x] 301/ES rulesets and unit tests have been updated
- [ ] ~~301validator.xml has been updated (reference EPvalidator.xml)~~
- [ ] ~~Workflow tests have been updated~~
- [ ] ~~Documentation has been updated~~
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
