### PR TITLE
Fixes possible "Sum of energy consumptions do not match total" error

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,7 @@ __New Features__
 
 __Bugfixes__
 - Fixes possible "Electricity category end uses do not sum to total" error for a heat pump w/o backup.
+- Fixes possible "Sum of energy consumptions do not match total" error for shared water heater w/ FractionDHWLoadServed=0.
 - Fixes error if conditioned basement has `InsulationSpansEntireSlab=true`.
 - Fixes error if heat pump `CompressorLockoutTemperature` == `BackupHeatingLockoutTemperature`.
 - Fixes ground source heat pump fan/pump adjustment to rated efficiency.

--- a/Changelog.md
+++ b/Changelog.md
@@ -22,7 +22,6 @@ __New Features__
 
 __Bugfixes__
 - Fixes possible "Electricity category end uses do not sum to total" error for a heat pump w/o backup.
-- Fixes possible "Sum of energy consumptions do not match total" error for shared water heater w/ FractionDHWLoadServed=0.
 - Fixes error if conditioned basement has `InsulationSpansEntireSlab=true`.
 - Fixes error if heat pump `CompressorLockoutTemperature` == `BackupHeatingLockoutTemperature`.
 - Fixes ground source heat pump fan/pump adjustment to rated efficiency.
@@ -30,6 +29,11 @@ __Bugfixes__
 - Minor HVAC design load calculation bugfixes for foundation walls.
 - Fixes `nEC_x` calculation for a fossil fuel water heater w/ UEF entered.
 - Various HVAC sizing bugfixes and improvements.
+
+## OpenStudio-ERI v1.6.3
+
+__Bugfixes__
+- Fixes possible "Sum of energy consumptions do not match total" error for shared water heater w/ FractionDHWLoadServed=0.
 
 ## OpenStudio-ERI v1.6.2
 

--- a/workflow/energy_rating_index.rb
+++ b/workflow/energy_rating_index.rb
@@ -413,7 +413,7 @@ def _calculate_eri(rated_output, ref_output, results_iad: nil,
     elsif rated_sys.respond_to? :integrated_heating_system_fraction_heat_load_served
       fraction_heat_load_served = rated_sys.integrated_heating_system_fraction_heat_load_served
     end
-    next if fraction_heat_load_served.to_f <= 0
+    next if fraction_heat_load_served.nil?
 
     # Get corresponding Reference Home system
     ref_sys = reg_bldg.hvac_systems.select { |h| h.respond_to?(:htg_seed_id) && (h.htg_seed_id == rated_sys.htg_seed_id) }[0]
@@ -437,7 +437,7 @@ def _calculate_eri(rated_output, ref_output, results_iad: nil,
     if rated_sys.respond_to? :fraction_cool_load_served
       fraction_cool_load_served = rated_sys.fraction_cool_load_served
     end
-    next if fraction_cool_load_served.to_f <= 0
+    next if fraction_cool_load_served.nil?
 
     # Get corresponding Reference Home system
     ref_sys = reg_bldg.hvac_systems.select { |h| h.respond_to?(:clg_seed_id) && (h.clg_seed_id == rated_sys.clg_seed_id) }[0]
@@ -456,7 +456,7 @@ def _calculate_eri(rated_output, ref_output, results_iad: nil,
   end
 
   rated_bldg.water_heating_systems.each do |rated_sys|
-    next if rated_sys.fraction_dhw_load_served <= 0
+    next if rated_sys.fraction_dhw_load_served.nil?
 
     # Get corresponding Reference Home system
     ref_sys = reg_bldg.water_heating_systems[0]

--- a/workflow/energy_rating_index.rb
+++ b/workflow/energy_rating_index.rb
@@ -413,7 +413,7 @@ def _calculate_eri(rated_output, ref_output, results_iad: nil,
     elsif rated_sys.respond_to? :integrated_heating_system_fraction_heat_load_served
       fraction_heat_load_served = rated_sys.integrated_heating_system_fraction_heat_load_served
     end
-    next if fraction_heat_load_served.nil?
+    next if fraction_heat_load_served.to_f <= 0
 
     # Get corresponding Reference Home system
     ref_sys = reg_bldg.hvac_systems.select { |h| h.respond_to?(:htg_seed_id) && (h.htg_seed_id == rated_sys.htg_seed_id) }[0]
@@ -437,7 +437,7 @@ def _calculate_eri(rated_output, ref_output, results_iad: nil,
     if rated_sys.respond_to? :fraction_cool_load_served
       fraction_cool_load_served = rated_sys.fraction_cool_load_served
     end
-    next if fraction_cool_load_served.nil?
+    next if fraction_cool_load_served.to_f <= 0
 
     # Get corresponding Reference Home system
     ref_sys = reg_bldg.hvac_systems.select { |h| h.respond_to?(:clg_seed_id) && (h.clg_seed_id == rated_sys.clg_seed_id) }[0]


### PR DESCRIPTION
## Pull Request Description

Fixes possible "Sum of energy consumptions do not match total" error for a shared water heater w/ FractionDHWLoadServed=0 (i.e., it only serves shared hot water appliances).

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [ ] OS-HPXML git subtree has been pulled
- [ ] 301/ES rulesets and unit tests have been updated
- [ ] 301validator.xml has been updated (reference EPvalidator.xml)
- [ ] Workflow tests have been updated
- [ ] Documentation has been updated
- [x] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI
