### PR TITLE
Docs footnote check

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -48,6 +48,11 @@ jobs:
           cd docs
           make html SPHINXOPTS="-W --keep-going -n"
 
+      - name: Check documentation
+        run: |
+          echo "Checking for misaligned documentation footnotes..."
+          for RST_FILE in docs/source/*.rst; do NUM_REFS=$(grep -F -o "[#]_" $RST_FILE | wc -l); NUM_FOOTNOTES=$(grep -F -o ".. [#]" $RST_FILE | wc -l); if [ $NUM_REFS != $NUM_FOOTNOTES ]; then echo "ERROR: Number of footnote references doesn't match number of footnotes in $RST_FILE." && exit 1; fi done
+
       - name: Save Docs
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
## Pull Request Description

Since sphinx isn't automatically flagging this, manually check for number of footnote references not equal to number of footnotes on the CI.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [ ] OS-HPXML git subtree has been pulled
- [ ] 301/ES rulesets and unit tests have been updated
- [ ] 301validator.xml has been updated (reference EPvalidator.xml)
- [ ] Workflow tests have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
