### PR TITLE
Fix emissions lookup when zip code starts with a zero

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ __New Features__
 __Bugfixes__
 - Fixes incorrect Reference Home mechanical ventilation flowrate for attached units (when Aext is not 1).
 - Fixes possible 301ruleset.rb error due to floating point arithmetic.
+- Fixes emissions lookup when zip code starts with a zero.
 
 ## OpenStudio-ERI v1.7.0
 

--- a/rulesets/main.rb
+++ b/rulesets/main.rb
@@ -165,16 +165,9 @@ def lookup_region_from_zip(zip_code, zip_filepath, zip_column_index, output_colu
   end
   zip_code = zip_code.rjust(5, '0')
 
-  return if zip_code.size != 5
-
-  begin
-    Integer(zip_code)
-  rescue
-    return
-  end
+  fail "Zip code in #{zip_filepath} needs to be 5 digits." if zip_code.size != 5
 
   CSV.foreach(zip_filepath) do |row|
-    fail "Zip code in #{zip_filepath} needs to be 5 digits." if zip_code.size != 5
     next unless row[zip_column_index] == zip_code
 
     return row[output_column_index]


### PR DESCRIPTION
## Pull Request Description

[description here]

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [ ] OS-HPXML git subtree has been pulled
- [ ] 301/ES rulesets and unit tests have been updated
- [ ] 301validator.xml has been updated (reference EPvalidator.xml)
- [ ] Workflow tests have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI
