### PR TITLE
Removes extra annual output file

### DIFF
--- a/workflow/design.rb
+++ b/workflow/design.rb
@@ -45,6 +45,7 @@ def run_design(design, debug, timeseries_output_freq, timeseries_outputs, add_co
   args['output_dir'] = File.absolute_path(design.design_dir)
   args['debug'] = debug
   args['add_component_loads'] = (add_comp_loads || timeseries_outputs.include?('componentloads'))
+  args['annual_output_file_name'] = File.join('..', 'results', File.basename(design.annual_output_path))
   args['skip_validation'] = !debug
   measures[measure_subdir] = [args]
 


### PR DESCRIPTION
## Pull Request Description

[description here]

## Checklist

Not all may apply:

- [ ] OS-HPXML git subtree has been pulled
- [ ] 301validator.sch has been updated (reference EPvalidator.sch)
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `rulesets\tests` and/or `workflow/tests/*_test.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results on CI
