### PR TITLE
Support `OS_ERI_TEST_BASE_DIR` environment variable for test isolation

### DIFF
--- a/workflow/tests/es_denh_test.rb
+++ b/workflow/tests/es_denh_test.rb
@@ -10,11 +10,12 @@ require_relative '../util.rb'
 
 class ESDENHTest < Minitest::Test
   def setup
+    @test_base_dir = ENV['OS_ERI_TEST_BASE_DIR'] || File.dirname(__FILE__)
     @root_path = File.absolute_path(File.join(File.dirname(__FILE__), '..', '..'))
     @sample_files_path = File.join(@root_path, 'workflow', 'sample_files')
-    @test_results_dir = File.join(File.dirname(__FILE__), 'test_results')
+    @test_results_dir = File.join(@test_base_dir, 'test_results')
     FileUtils.mkdir_p @test_results_dir
-    @test_files_dir = File.join(File.dirname(__FILE__), 'test_files')
+    @test_files_dir = File.join(@test_base_dir, 'test_files')
     FileUtils.mkdir_p @test_files_dir
   end
 

--- a/workflow/tests/real_homes_test.rb
+++ b/workflow/tests/real_homes_test.rb
@@ -14,9 +14,10 @@ require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/xmlhelper'
 
 class RealHomesTest < Minitest::Test
   def setup
-    @test_results_dir = File.join(File.dirname(__FILE__), 'test_results')
+    @test_base_dir = ENV['OS_ERI_TEST_BASE_DIR'] || File.dirname(__FILE__)
+    @test_results_dir = File.join(@test_base_dir, 'test_results')
     FileUtils.mkdir_p @test_results_dir
-    @test_files_dir = File.join(File.dirname(__FILE__), 'test_files')
+    @test_files_dir = File.join(@test_base_dir, 'test_files')
     FileUtils.mkdir_p @test_files_dir
   end
 
@@ -27,7 +28,7 @@ class RealHomesTest < Minitest::Test
 
     # Run simulations
     all_results = {}
-    xmldir = "#{File.dirname(__FILE__)}/../real_homes"
+    xmldir = File.join(File.dirname(__FILE__), '..', 'real_homes')
     Dir["#{xmldir}/*.xml"].sort.each do |xml|
       rundir, _hpxmls, csvs = _run_workflow(xml, test_name, diagnostic_output: true)
       all_results[File.basename(xml)] = _get_csv_results([csvs[:eri_results],

--- a/workflow/tests/resnet_hers_test.rb
+++ b/workflow/tests/resnet_hers_test.rb
@@ -13,10 +13,12 @@ require_relative 'util.rb'
 
 class RESNETTest < Minitest::Test
   def setup
-    @test_results_dir = File.join(File.dirname(__FILE__), 'test_results')
+    @test_base_dir = ENV['RESNET_TEST_BASE_DIR'] || File.dirname(__FILE__)
+    @test_results_dir = File.join(@test_base_dir, 'test_results')
     FileUtils.mkdir_p @test_results_dir
-    @test_files_dir = File.join(File.dirname(__FILE__), 'test_files')
+    @test_files_dir = File.join(@test_base_dir, 'test_files')
     FileUtils.mkdir_p @test_files_dir
+    @resnet_tests_dir = File.join(@test_base_dir, 'RESNET_Tests')
   end
 
   def test_resnet_ashrae_140
@@ -25,7 +27,7 @@ class RESNETTest < Minitest::Test
     File.delete(test_results_csv) if File.exist? test_results_csv
 
     # Run simulations
-    xmldir = File.join(File.dirname(__FILE__), 'RESNET_Tests/4.1_Standard_140')
+    xmldir = File.join(@resnet_tests_dir, '4.1_Standard_140')
     all_results = {}
     Dir["#{xmldir}/*.xml"].sort.each do |xml|
       csv_path = _run_simulation(xml, test_name)
@@ -53,7 +55,7 @@ class RESNETTest < Minitest::Test
   def test_resnet_hers_reference_home_auto_generation
     version = '2022C' # Latest version that caused changes to results
     all_results = _test_resnet_hers_reference_home_auto_generation('RESNET_Test_4.2_HERS_AutoGen_Reference_Home',
-                                                                   'RESNET_Tests/4.2_HERS_AutoGen_Reference_Home',
+                                                                   '4.2_HERS_AutoGen_Reference_Home',
                                                                    version)
 
     # Check results
@@ -66,7 +68,7 @@ class RESNETTest < Minitest::Test
   def test_resnet_hers_method
     version = '2019A' # Latest version that caused changes to results
     all_results = _test_resnet_hers_method('RESNET_Test_4.3_HERS_Method',
-                                           'RESNET_Tests/4.3_HERS_Method')
+                                           '4.3_HERS_Method')
 
     # Check results
     all_results.each do |xml, results|
@@ -81,7 +83,7 @@ class RESNETTest < Minitest::Test
     File.delete(test_results_csv) if File.exist? test_results_csv
 
     # Run simulations
-    xmldir = File.join(File.dirname(__FILE__), 'RESNET_Tests/4.4_HVAC')
+    xmldir = File.join(@resnet_tests_dir, '4.4_HVAC')
     all_results = {}
     Dir["#{xmldir}/*.xml"].sort.each do |xml|
       csv_path = _run_simulation(xml, test_name)
@@ -113,7 +115,7 @@ class RESNETTest < Minitest::Test
     File.delete(test_results_csv) if File.exist? test_results_csv
 
     # Run simulations
-    xmldir = File.join(File.dirname(__FILE__), 'RESNET_Tests/4.5_DSE')
+    xmldir = File.join(@resnet_tests_dir, '4.5_DSE')
     all_results = {}
     Dir["#{xmldir}/*.xml"].sort.each do |xml|
       csv_path = _run_simulation(xml, test_name)
@@ -143,7 +145,7 @@ class RESNETTest < Minitest::Test
 
     # Run simulations
     all_results = {}
-    xmldir = File.join(File.dirname(__FILE__), 'RESNET_Tests/4.6_Hot_Water')
+    xmldir = File.join(@resnet_tests_dir, '4.6_Hot_Water')
     Dir["#{xmldir}/*.xml"].sort.each do |xml|
       csv_path = _run_simulation(xml, test_name)
 

--- a/workflow/tests/resnet_hers_test.rb
+++ b/workflow/tests/resnet_hers_test.rb
@@ -13,7 +13,7 @@ require_relative 'util.rb'
 
 class RESNETTest < Minitest::Test
   def setup
-    @test_base_dir = ENV['RESNET_TEST_BASE_DIR'] || File.dirname(__FILE__)
+    @test_base_dir = ENV['OS_ERI_TEST_BASE_DIR'] || File.dirname(__FILE__)
     @test_results_dir = File.join(@test_base_dir, 'test_results')
     FileUtils.mkdir_p @test_results_dir
     @test_files_dir = File.join(@test_base_dir, 'test_files')

--- a/workflow/tests/resnet_other_test.rb
+++ b/workflow/tests/resnet_other_test.rb
@@ -13,7 +13,7 @@ require_relative 'util.rb'
 
 class RESNETOtherTest < Minitest::Test
   def setup
-    @test_base_dir = ENV['RESNET_TEST_BASE_DIR'] || File.dirname(__FILE__)
+    @test_base_dir = ENV['OS_ERI_TEST_BASE_DIR'] || File.dirname(__FILE__)
     @test_results_dir = File.join(@test_base_dir, 'test_results')
     FileUtils.mkdir_p @test_results_dir
     @test_files_dir = File.join(@test_base_dir, 'test_files')

--- a/workflow/tests/resnet_other_test.rb
+++ b/workflow/tests/resnet_other_test.rb
@@ -13,16 +13,18 @@ require_relative 'util.rb'
 
 class RESNETOtherTest < Minitest::Test
   def setup
-    @test_results_dir = File.join(File.dirname(__FILE__), 'test_results')
+    @test_base_dir = ENV['RESNET_TEST_BASE_DIR'] || File.dirname(__FILE__)
+    @test_results_dir = File.join(@test_base_dir, 'test_results')
     FileUtils.mkdir_p @test_results_dir
-    @test_files_dir = File.join(File.dirname(__FILE__), 'test_files')
+    @test_files_dir = File.join(@test_base_dir, 'test_files')
     FileUtils.mkdir_p @test_files_dir
+    @resnet_tests_dir = File.join(@test_base_dir, 'RESNET_Tests')
   end
 
   def test_resnet_hers_reference_home_auto_generation_301_2019_pre_addendum_a
     version = '2019'
     all_results = _test_resnet_hers_reference_home_auto_generation('RESNET_Test_Other_HERS_AutoGen_Reference_Home_301_2019_PreAddendumA',
-                                                                   'RESNET_Tests/Other_HERS_AutoGen_Reference_Home_301_2019_PreAddendumA',
+                                                                   'Other_HERS_AutoGen_Reference_Home_301_2019_PreAddendumA',
                                                                    version)
 
     # Check results
@@ -36,7 +38,7 @@ class RESNETOtherTest < Minitest::Test
     # Older test w/ 301-2014 mechanical ventilation acceptance criteria
     version = '2014'
     all_results = _test_resnet_hers_reference_home_auto_generation('RESNET_Test_Other_HERS_AutoGen_Reference_Home_301_2014',
-                                                                   'RESNET_Tests/Other_HERS_AutoGen_Reference_Home_301_2014',
+                                                                   'Other_HERS_AutoGen_Reference_Home_301_2014',
                                                                    version)
 
     # Check results
@@ -53,7 +55,7 @@ class RESNETOtherTest < Minitest::Test
 
     # Run simulations
     all_results = {}
-    xmldir = File.join(File.dirname(__FILE__), 'RESNET_Tests/Other_HERS_AutoGen_IAD_Home')
+    xmldir = File.join(@resnet_tests_dir, 'Other_HERS_AutoGen_IAD_Home')
     Dir["#{xmldir}/*.xml"].sort.each do |xml|
       _rundir, hpxmls, _csvs = _run_workflow(xml, test_name, skip_simulation: true)
       test_num = File.basename(xml)[0, 2].to_i
@@ -88,7 +90,7 @@ class RESNETOtherTest < Minitest::Test
 
   def test_resnet_hers_method_301_2019_pre_addendum_a
     all_results = _test_resnet_hers_method('RESNET_Test_Other_HERS_Method_301_2019_PreAddendumA',
-                                           'RESNET_Tests/Other_HERS_Method_301_2019_PreAddendumA')
+                                           'Other_HERS_Method_301_2019_PreAddendumA')
 
     # Check results
     all_results.each do |xml, results|
@@ -100,7 +102,7 @@ class RESNETOtherTest < Minitest::Test
   def test_resnet_hers_method_301_2014_pre_addendum_e
     # Tests before 301-2019 Addendum E (IAF) was in place
     all_results = _test_resnet_hers_method('RESNET_Test_Other_HERS_Method_301_2014_PreAddendumE',
-                                           'RESNET_Tests/Other_HERS_Method_301_2014_PreAddendumE')
+                                           'Other_HERS_Method_301_2014_PreAddendumE')
 
     # Check results
     all_results.each do |xml, results|
@@ -117,7 +119,7 @@ class RESNETOtherTest < Minitest::Test
 
     # Run simulations
     all_results = {}
-    xmldir = File.join(File.dirname(__FILE__), 'RESNET_Tests/Other_Hot_Water_301_2019_PreAddendumA')
+    xmldir = File.join(@resnet_tests_dir, 'Other_Hot_Water_301_2019_PreAddendumA')
     Dir["#{xmldir}/*.xml"].sort.each do |xml|
       csv_path = _run_simulation(xml, test_name)
 
@@ -141,7 +143,7 @@ class RESNETOtherTest < Minitest::Test
 
     # Run simulations
     all_results = {}
-    xmldir = File.join(File.dirname(__FILE__), 'RESNET_Tests/Other_Hot_Water_301_2014_PreAddendumA')
+    xmldir = File.join(@resnet_tests_dir, 'Other_Hot_Water_301_2014_PreAddendumA')
     Dir["#{xmldir}/*.xml"].sort.each do |xml|
       csv_path = _run_simulation(xml, test_name)
 

--- a/workflow/tests/sample_files1_test.rb
+++ b/workflow/tests/sample_files1_test.rb
@@ -14,9 +14,10 @@ require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/xmlhelper'
 
 class SampleFilesTest1 < Minitest::Test
   def setup
-    @test_results_dir = File.join(File.dirname(__FILE__), 'test_results')
+    @test_base_dir = ENV['OS_ERI_TEST_BASE_DIR'] || File.dirname(__FILE__)
+    @test_results_dir = File.join(@test_base_dir, 'test_results')
     FileUtils.mkdir_p @test_results_dir
-    @test_files_dir = File.join(File.dirname(__FILE__), 'test_files')
+    @test_files_dir = File.join(@test_base_dir, 'test_files')
     FileUtils.mkdir_p @test_files_dir
   end
 
@@ -28,7 +29,7 @@ class SampleFilesTest1 < Minitest::Test
     # Run simulations
     files = 'base*.xml'
     all_results = {}
-    xmldir = "#{File.dirname(__FILE__)}/../sample_files"
+    xmldir = File.join(File.dirname(__FILE__), '..', 'sample_files')
     Dir["#{xmldir}/#{files}"].sort.each do |xml|
       break if xml.include? 'base-hvac-air-to-air-heat-pump-1-speed.xml' # Run first half of the sample files
 

--- a/workflow/tests/sample_files2_test.rb
+++ b/workflow/tests/sample_files2_test.rb
@@ -14,9 +14,10 @@ require_relative '../../hpxml-measures/HPXMLtoOpenStudio/resources/xmlhelper'
 
 class SampleFilesTest1 < Minitest::Test
   def setup
-    @test_results_dir = File.join(File.dirname(__FILE__), 'test_results')
+    @test_base_dir = ENV['OS_ERI_TEST_BASE_DIR'] || File.dirname(__FILE__)
+    @test_results_dir = File.join(@test_base_dir, 'test_results')
     FileUtils.mkdir_p @test_results_dir
-    @test_files_dir = File.join(File.dirname(__FILE__), 'test_files')
+    @test_files_dir = File.join(@test_base_dir, 'test_files')
     FileUtils.mkdir_p @test_files_dir
   end
 
@@ -28,7 +29,7 @@ class SampleFilesTest1 < Minitest::Test
     # Run simulations
     files = 'base*.xml'
     all_results = {}
-    xmldir = "#{File.dirname(__FILE__)}/../sample_files"
+    xmldir = File.join(File.dirname(__FILE__), '..', 'sample_files')
     start = false
     Dir["#{xmldir}/#{files}"].sort.each do |xml|
       start = true if xml.include? 'base-hvac-air-to-air-heat-pump-1-speed.xml'

--- a/workflow/tests/util.rb
+++ b/workflow/tests/util.rb
@@ -315,7 +315,7 @@ def _test_resnet_hers_reference_home_auto_generation(test_name, dir_name, versio
 
   # Run simulations
   all_results = {}
-  xmldir = File.join(File.dirname(__FILE__), dir_name)
+  xmldir = File.join(@resnet_tests_dir, dir_name)
   Dir["#{xmldir}/*.xml"].sort.each do |xml|
     _rundir, hpxmls, _csvs = _run_workflow(xml, test_name, skip_simulation: true)
 
@@ -385,7 +385,7 @@ def _test_resnet_hers_method(test_name, dir_name)
 
   # Run simulations
   all_results = {}
-  xmldir = File.join(File.dirname(__FILE__), dir_name)
+  xmldir = File.join(@resnet_tests_dir, dir_name)
   Dir["#{xmldir}/*.xml"].sort.each do |xml|
     _rundir, _hpxmls, csvs = _run_workflow(xml, test_name)
     results = _get_csv_results([csvs[:eri_results]])

--- a/workflow/tests/workflow_test.rb
+++ b/workflow/tests/workflow_test.rb
@@ -9,9 +9,10 @@ require_relative 'util.rb'
 
 class WorkflowTest < Minitest::Test
   def setup
-    @test_results_dir = File.join(File.dirname(__FILE__), 'test_results')
+    @test_base_dir = ENV['OS_ERI_TEST_BASE_DIR'] || File.dirname(__FILE__)
+    @test_results_dir = File.join(@test_base_dir, 'test_results')
     FileUtils.mkdir_p @test_results_dir
-    @test_files_dir = File.join(File.dirname(__FILE__), 'test_files')
+    @test_files_dir = File.join(@test_base_dir, 'test_files')
     FileUtils.mkdir_p @test_files_dir
   end
 


### PR DESCRIPTION
## Summary
Add support for a single `OS_ERI_TEST_BASE_DIR` environment variable that allows running tests with isolated directories. When set, all test directories (`test_results`, `test_files`, `RESNET_Tests`) are derived from this base directory.

## Motivation
This enables QA orchestration systems to run individual tests in isolated environments without interference from:
- Pre-existing test files in the default directories
- Other concurrent test runs
- Stale results from previous runs

## Changes
- `*_test.rb`: Check ENV var in setup, derive all paths from base
- `util.rb`: Use `@resnet_tests_dir` in helper methods

## Usage
```bash
# Run with isolated directories
export OS_ERI_TEST_BASE_DIR=/path/to/isolated/test/dir
ruby -Ilib:test workflow/tests/resnet_hers_test.rb

# Or inline
OS_ERI_TEST_BASE_DIR=/tmp/my_test ruby -Ilib:test workflow/tests/resnet_hers_test.rb
```

## Backwards Compatibility
Fully backwards compatible - defaults to `File.dirname(__FILE__)` when the environment variable is not set, preserving existing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)