### PR TITLE
Add mechanical ventilation warnings

### DIFF
--- a/rulesets/resources/301validator.sch
+++ b/rulesets/resources/301validator.sch
@@ -1085,6 +1085,10 @@
     <sch:title>[MechanicalVentilation]</sch:title>
     <sch:rule context='/h:HPXML/h:Building/h:BuildingDetails/h:Systems/h:MechanicalVentilation/h:VentilationFans/h:VentilationFan[h:UsedForWholeBuildingVentilation="true"]'>
       <sch:assert role='ERROR' test='count(h:FanType) = 1'>Expected FanType</sch:assert>
+      <!-- Warnings -->
+      <sch:report role='WARN' test='count(h:RatedFlowRate) + count(h:extension/h:FlowRateNotTested[text()="true"]) = 2'>Both RatedFlowRate and extension/FlowRateNotTested="true" are provided; the ventilation system is assumed to have unmeasured airflow and RatedFlowRate will not be used.</sch:report>
+      <sch:report role='WARN' test='count(h:CalculatedFlowRate) + count(h:extension/h:FlowRateNotTested[text()="true"]) = 2'>Both CalculatedFlowRate and extension/FlowRateNotTested="true" are provided; the ventilation system is assumed to have unmeasured airflow and CalculatedFlowRate will not be used.</sch:report>
+      <sch:report role='WARN' test='count(h:DeliveredVentilation) + count(h:extension/h:FlowRateNotTested[text()="true"]) = 2'>Both DeliveredVentilation and extension/FlowRateNotTested="true" are provided; the ventilation system is assumed to have unmeasured airflow and DeliveredVentilation will not be used.</sch:report>
     </sch:rule>
   </sch:pattern>
 


### PR DESCRIPTION
## Pull Request Description

Adds some warnings related to mechanical ventilation systems with unmeasured airflow.

For example, if this is in the HPXML:
```
            <VentilationFan>
              <SystemIdentifier id='VentilationFan1'/>
              <FanType>energy recovery ventilator</FanType>
              <RatedFlowRate dataSource>75.8</RatedFlowRate>
              <HoursInOperation>24.0</HoursInOperation>
              <UsedForWholeBuildingVentilation>true</UsedForWholeBuildingVentilation>
              <IsSharedSystem>false</IsSharedSystem>
              <TotalRecoveryEfficiency>0.6</TotalRecoveryEfficiency>
              <SensibleRecoveryEfficiency>0.7</SensibleRecoveryEfficiency>
              <FanPower>66.1</FanPower>
              <extension>
                <FlowRateNotTested>true</FlowRateNotTested>
              </extension>
            </VentilationFan>
```

you will now get:

`Warning: Both RatedFlowRate and extension/FlowRateNotTested="true" are provided; the ventilation system is assumed to have unmeasured airflow and RatedFlowRate will not be used.`

## Checklist

Not all may apply:

- [ ] OS-HPXML git subtree has been pulled
- [ ] 301validator.sch has been updated (reference EPvalidator.sch)
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [ ] Tests have been added/updated (e.g., `rulesets\tests` and/or `workflow/tests/*_test.rb`)
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected changes to simulation results on CI
